### PR TITLE
Build the provider statically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY go.* $DIR/
 WORKDIR $DIR
 RUN go mod download
 COPY . $DIR/
-RUN go build -o /terraform-provider-spacelift
+RUN CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /terraform-provider-spacelift
 
 FROM alpine:3.10
 


### PR DESCRIPTION
This will allow copying the provider binary to an arbitrary Docker image used by customers.