### PR TITLE
Remove access management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,9 @@ RUN go mod download
 COPY . $DIR/
 RUN CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /terraform-provider-spacelift
 
-FROM ruby:alpine
+FROM alpine:3.10
 
-RUN apk add --no-cache ca-certificates curl git openssh \
-  && gem install spacelift-policy
+RUN apk add --no-cache ca-certificates curl git openssh
 
 COPY --from=builder /terraform-provider-spacelift /bin/terraform-provider-spacelift
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,8 @@ resource "spacelift_stack" "core-infra-production" {
   administrative    = true
   branch            = "master"
   description       = "Shared production infrastructure (networking, k8s)"
-  readers_team      = "engineering"
   repository        = "core-infra"
   terraform_version = "0.12.6"
-  writers_team      = "devops"
 }
 ```
 
@@ -373,10 +371,8 @@ resource "spacelift_stack" "k8s-core" {
   branch            = "master"
   description       = "Shared cluster services (Datadog, Istio etc.)"
   name              = "Kubernetes core services"
-  readers_team      = "engineering"
   repository        = "core-infra"
   terraform_version = "0.12.6"
-  writers_team      = "devops"
 }
 ```
 
@@ -420,9 +416,7 @@ The following arguments are supported:
 - `description` - (Optional) - Free-form stack description for GUI users;
 - `import_state` - (Optional) - Content of the state file to import if Spacelift should manage the stack but the state has already been created externally. This only applies during creation and the field can be deleted afterwards without triggering a resource change;
 - `manage_state` - (Optional) - Boolean that determines if Spacelift should manage state for this stack. Default: `true`;
-- `readers_team` - (Optional) - Slug of the GitHub team whose members get read-only access;
 - `terraform_version` - (Optional) - Terraform version to use;
-- `writers_team` - (Optional) - Slug of the GitHub team whose members get read-write access;
 
 #### Attributes reference
 

--- a/spacelift/data_stack.go
+++ b/spacelift/data_stack.go
@@ -42,11 +42,6 @@ func dataStack() *schema.Resource {
 				Description: "Name of the stack - should be unique in one account",
 				Computed:    true,
 			},
-			"readers_team": &schema.Schema{
-				Type:        schema.TypeString,
-				Description: "Slug of the GitHub team whose members get read-only access",
-				Computed:    true,
-			},
 			"repository": &schema.Schema{
 				Type:        schema.TypeString,
 				Description: "Name of the GitHub repository, without the owner part",
@@ -60,11 +55,6 @@ func dataStack() *schema.Resource {
 			"terraform_version": &schema.Schema{
 				Type:        schema.TypeString,
 				Description: "Terraform version to use",
-				Computed:    true,
-			},
-			"writers_team": &schema.Schema{
-				Type:        schema.TypeString,
-				Description: "Slug of the GitHub team whose members get read-write access",
 				Computed:    true,
 			},
 		},
@@ -101,22 +91,10 @@ func dataStackRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("description", nil)
 	}
 
-	if stack.Readers != nil {
-		d.Set("readers_team", stack.Readers.Slug)
-	} else {
-		d.Set("readers_team", nil)
-	}
-
 	if stack.TerraformVersion != nil {
 		d.Set("terraform_version", *stack.TerraformVersion)
 	} else {
 		d.Set("terraform_version", nil)
-	}
-
-	if stack.Writers != nil {
-		d.Set("writers_team", stack.Writers.Slug)
-	} else {
-		d.Set("writers_team", nil)
 	}
 
 	return nil

--- a/spacelift/e2e/stack_aws_role_test.go
+++ b/spacelift/e2e/stack_aws_role_test.go
@@ -16,19 +16,19 @@ func (e *StackAWSRoleTest) TestLifecycle_OK() {
 	defer gock.Off()
 
 	e.posts(
-		`{"query":"mutation($id:ID!$roleArn:String){stackSetAwsRoleDelegation(id: $id, roleArn: $roleArn){id,administrative,awsAssumedRoleARN,awsAssumeRolePolicyStatement,branch,description,managesStateFile,name,readers{slug},repository,terraformVersion,writers{slug}}}","variables":{"id":"babys-first-stack","roleArn":"arn:aws:iam::075108987694:role/terraform"}}`,
+		`{"query":"mutation($id:ID!$roleArn:String){stackSetAwsRoleDelegation(id: $id, roleArn: $roleArn){id,administrative,awsAssumedRoleARN,awsAssumeRolePolicyStatement,branch,description,managesStateFile,name,repository,terraformVersion}}","variables":{"id":"babys-first-stack","roleArn":"arn:aws:iam::075108987694:role/terraform"}}`,
 		`{"data":{"stackSetAwsRoleDelegation":{}}}`,
 		1,
 	)
 
 	e.posts(
-		`{"query":"query($id:ID!){stack(id: $id){id,administrative,awsAssumedRoleARN,awsAssumeRolePolicyStatement,branch,description,managesStateFile,name,readers{slug},repository,terraformVersion,writers{slug}}}","variables":{"id":"babys-first-stack"}}`,
+		`{"query":"query($id:ID!){stack(id: $id){id,administrative,awsAssumedRoleARN,awsAssumeRolePolicyStatement,branch,description,managesStateFile,name,repository,terraformVersion}}","variables":{"id":"babys-first-stack"}}`,
 		`{"data":{"stack":{"awsAssumedRoleARN":"arn:aws:iam::075108987694:role/terraform"}}}`,
 		7,
 	)
 
 	e.posts(
-		`{"query":"mutation($id:ID!$roleArn:String){stackSetAwsRoleDelegation(id: $id, roleArn: $roleArn){id,administrative,awsAssumedRoleARN,awsAssumeRolePolicyStatement,branch,description,managesStateFile,name,readers{slug},repository,terraformVersion,writers{slug}}}","variables":{"id":"babys-first-stack","roleArn":null}}`,
+		`{"query":"mutation($id:ID!$roleArn:String){stackSetAwsRoleDelegation(id: $id, roleArn: $roleArn){id,administrative,awsAssumedRoleARN,awsAssumeRolePolicyStatement,branch,description,managesStateFile,name,repository,terraformVersion}}","variables":{"id":"babys-first-stack","roleArn":null}}`,
 		`{"data":{"stackSetAwsRoleDelegation":{}}}`,
 		1,
 	)

--- a/spacelift/e2e/stack_test.go
+++ b/spacelift/e2e/stack_test.go
@@ -30,19 +30,19 @@ func (e *StackTest) TestLifecycle_OK() {
 		Reply(http.StatusOK)
 
 	e.posts(
-		`{"query":"mutation($input:StackInput!$manageState:Boolean!$stackObjectID:String){stackCreate(input: $input, manageState: $manageState, stackObjectID: $stackObjectID){id,administrative,awsAssumedRoleARN,awsAssumeRolePolicyStatement,branch,description,managesStateFile,name,readers{slug},repository,terraformVersion,writers{slug}}}","variables":{"input":{"administrative":true,"branch":"master","description":"My description","name":"Baby's first stack","readersSlug":"engineering","repository":"core-infra","terraformVersion":"0.12.6","writersSlug":"devops"},"manageState":true,"stackObjectID":"objectID"}}`,
+		`{"query":"mutation($input:StackInput!$manageState:Boolean!$stackObjectID:String){stackCreate(input: $input, manageState: $manageState, stackObjectID: $stackObjectID){id,administrative,awsAssumedRoleARN,awsAssumeRolePolicyStatement,branch,description,managesStateFile,name,repository,terraformVersion}}","variables":{"input":{"administrative":true,"branch":"master","description":"My description","name":"Baby's first stack","repository":"core-infra","terraformVersion":"0.12.6"},"manageState":true,"stackObjectID":"objectID"}}`,
 		`{"data":{"stackCreate":{"id":"babys-first-stack"}}}`,
 		1,
 	)
 
 	e.posts(
-		`{"query":"query($id:ID!){stack(id: $id){id,administrative,awsAssumedRoleARN,awsAssumeRolePolicyStatement,branch,description,managesStateFile,name,readers{slug},repository,terraformVersion,writers{slug}}}","variables":{"id":"babys-first-stack"}}`,
-		`{"data":{"stack":{"id":"babys-first-stack","administrative":true,"awsAssumeRolePolicyStatement":"bacon","branch":"master","description":"My description","managesStateFile":true,"name":"Baby's first stack","readers":{"slug":"engineering"},"repository":"core-infra","terraformVersion":"0.12.6","writers":{"slug":"devops"}}}}`,
+		`{"query":"query($id:ID!){stack(id: $id){id,administrative,awsAssumedRoleARN,awsAssumeRolePolicyStatement,branch,description,managesStateFile,name,repository,terraformVersion}}","variables":{"id":"babys-first-stack"}}`,
+		`{"data":{"stack":{"id":"babys-first-stack","administrative":true,"awsAssumeRolePolicyStatement":"bacon","branch":"master","description":"My description","managesStateFile":true,"name":"Baby's first stack","repository":"core-infra","terraformVersion":"0.12.6"}}}`,
 		7,
 	)
 
 	e.posts(
-		`{"query":"mutation($id:ID!){stackDelete(id: $id){id,administrative,awsAssumedRoleARN,awsAssumeRolePolicyStatement,branch,description,managesStateFile,name,readers{slug},repository,terraformVersion,writers{slug}}}","variables":{"id":"babys-first-stack"}}`,
+		`{"query":"mutation($id:ID!){stackDelete(id: $id){id,administrative,awsAssumedRoleARN,awsAssumeRolePolicyStatement,branch,description,managesStateFile,name,repository,terraformVersion}}","variables":{"id":"babys-first-stack"}}`,
 		`{"data":{"stackDelete":{}}}`,
 		1,
 	)
@@ -56,10 +56,8 @@ resource "spacelift_stack" "stack" {
 	description       = "My description"
 	import_state      = "bacon"
 	name              = "Baby's first stack"
-	readers_team      = "engineering"
 	repository        = "core-infra"
 	terraform_version = "0.12.6"
-	writers_team      = "devops"
 }
 
 data "spacelift_stack" "stack" {
@@ -74,10 +72,8 @@ data "spacelift_stack" "stack" {
 				resource.TestCheckResourceAttr("spacelift_stack.stack", "branch", "master"),
 				resource.TestCheckResourceAttr("spacelift_stack.stack", "description", "My description"),
 				resource.TestCheckResourceAttr("spacelift_stack.stack", "manage_state", "true"),
-				resource.TestCheckResourceAttr("spacelift_stack.stack", "readers_team", "engineering"),
 				resource.TestCheckResourceAttr("spacelift_stack.stack", "repository", "core-infra"),
 				resource.TestCheckResourceAttr("spacelift_stack.stack", "terraform_version", "0.12.6"),
-				resource.TestCheckResourceAttr("spacelift_stack.stack", "writers_team", "devops"),
 
 				// Test data.
 				resource.TestCheckResourceAttr("data.spacelift_stack.stack", "id", "babys-first-stack"),
@@ -86,10 +82,8 @@ data "spacelift_stack" "stack" {
 				resource.TestCheckResourceAttr("data.spacelift_stack.stack", "branch", "master"),
 				resource.TestCheckResourceAttr("data.spacelift_stack.stack", "description", "My description"),
 				resource.TestCheckResourceAttr("data.spacelift_stack.stack", "manage_state", "true"),
-				resource.TestCheckResourceAttr("data.spacelift_stack.stack", "readers_team", "engineering"),
 				resource.TestCheckResourceAttr("data.spacelift_stack.stack", "repository", "core-infra"),
 				resource.TestCheckResourceAttr("data.spacelift_stack.stack", "terraform_version", "0.12.6"),
-				resource.TestCheckResourceAttr("data.spacelift_stack.stack", "writers_team", "devops"),
 			),
 		},
 	})

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -65,11 +65,6 @@ func resourceStack() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
-			"readers_team": &schema.Schema{
-				Type:        schema.TypeString,
-				Description: "Slug of the GitHub team whose members get read-only access",
-				Optional:    true,
-			},
 			"repository": &schema.Schema{
 				Type:        schema.TypeString,
 				Description: "Name of the GitHub repository, without the owner part",
@@ -78,11 +73,6 @@ func resourceStack() *schema.Resource {
 			"terraform_version": &schema.Schema{
 				Type:        schema.TypeString,
 				Description: "Terraform version to use",
-				Optional:    true,
-			},
-			"writers_team": &schema.Schema{
-				Type:        schema.TypeString,
-				Description: "Slug of the GitHub team whose members get read-write access",
 				Optional:    true,
 			},
 		},
@@ -150,16 +140,8 @@ func resourceStackRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("description", *description)
 	}
 
-	if readers := stack.Readers; readers != nil {
-		d.Set("readers_team", readers.Slug)
-	}
-
 	if terraformVersion := stack.TerraformVersion; terraformVersion != nil {
 		d.Set("terraform_version", *terraformVersion)
-	}
-
-	if writers := stack.Writers; writers != nil {
-		d.Set("writers_team", writers.Slug)
 	}
 
 	return nil
@@ -211,19 +193,9 @@ func stackInput(d *schema.ResourceData) structs.StackInput {
 		ret.Description = toOptionalString(description)
 	}
 
-	readersSlug, ok := d.GetOk("readers_team")
-	if ok {
-		ret.ReadersSlug = toOptionalString(readersSlug)
-	}
-
 	terraformVersion, ok := d.GetOk("terraform_version")
 	if ok {
 		ret.TerraformVersion = toOptionalString(terraformVersion)
-	}
-
-	writersSlug, ok := d.GetOk("writers_team")
-	if ok {
-		ret.WritersSlug = toOptionalString(writersSlug)
 	}
 
 	return ret

--- a/spacelift/structs/stack.go
+++ b/spacelift/structs/stack.go
@@ -1,11 +1,5 @@
 package structs
 
-// Team represents a readers or writers team, though the only thing we really
-// care about here is the slug.
-type Team struct {
-	Slug string `graphql:"slug"`
-}
-
 // Stack represents the Stack data relevant to the provider.
 type Stack struct {
 	ID                           string  `graphql:"id"`
@@ -16,8 +10,6 @@ type Stack struct {
 	Description                  *string `graphql:"description"`
 	ManagesStateFile             bool    `graphql:"managesStateFile"`
 	Name                         string  `graphql:"name"`
-	Readers                      *Team   `graphql:"readers"`
 	Repository                   string  `graphql:"repository"`
 	TerraformVersion             *string `graphql:"terraformVersion"`
-	Writers                      *Team   `graphql:"writers"`
 }

--- a/spacelift/structs/stack_input.go
+++ b/spacelift/structs/stack_input.go
@@ -8,8 +8,6 @@ type StackInput struct {
 	Branch           graphql.String  `json:"branch"`
 	Description      *graphql.String `json:"description"`
 	Name             graphql.String  `json:"name"`
-	ReadersSlug      *graphql.String `json:"readersSlug"`
 	Repository       graphql.String  `json:"repository"`
 	TerraformVersion *graphql.String `json:"terraformVersion"`
-	WritersSlug      *graphql.String `json:"writersSlug"`
 }


### PR DESCRIPTION
Given that access is now more flexibly managed by stack access policies, there's no longer any need to handle it using GitHub teams.