### PR TITLE
Always send before_init's, even when empty

### DIFF
--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -336,13 +336,13 @@ func stackInput(d *schema.ResourceData) structs.StackInput {
 		Repository:     toString(d.Get("repository")),
 	}
 
-	if beforeInits, ok := d.GetOk("before_init"); ok {
-		var cmds []graphql.String
-		for _, cmd := range beforeInits.([]interface{}) {
-			cmds = append(cmds, graphql.String(cmd.(string)))
+	var beforeInits []graphql.String
+	if commands, ok := d.GetOk("before_init"); ok {
+		for _, cmd := range commands.([]interface{}) {
+			beforeInits = append(beforeInits, graphql.String(cmd.(string)))
 		}
-		ret.BeforeInit = &cmds
 	}
+	ret.BeforeInit = &beforeInits
 
 	description, ok := d.GetOk("description")
 	if ok {


### PR DESCRIPTION
## Description of the change

We don't update the before_inits array if the requested value is an empty list. So if someone sets something there through the GUI, we will notice the difference, but will not fix it.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
