### PR TITLE
Fix documentation for file mount path

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ data "spacelift_mounted_file" "core-kubeconfig" {
 
 The following arguments are supported:
 
-- `relative_path` - (Required) - Relative path to the mounted file. The full (absolute) path to the file will be prefixed with `/spacelift/project/`;
+- `relative_path` - (Required) - Relative path to the mounted file. The full (absolute) path to the file will be prefixed with `/mnt/workspace/`;
 - `context_id` - (Optional) - ID of the context on which the environment variable is defined;
 - `module_id` - (Optional) - ID of the module on which the environment variable is defined;
 - `stack_id` - (Optional) - ID of the stack on which the environment variable is defined;
@@ -622,7 +622,7 @@ resource "spacelift_mounted_file" "core-kubeconfig" {
 The following arguments are supported:
 
 - `content` - (Required) - Content of the mounted file encoded using Base-64;
-- `relative_path` - (Required) - Relative path to the mounted file, without the `/spacelift/project/` prefix;
+- `relative_path` - (Required) - Relative path to the mounted file, without the `/mnt/workspace/` prefix;
 - `context_id` - (Optional) - ID of the context on which the mounted file is defined;
 - `module_id` - (Optional) - ID of the module on which the mounted file is defined;
 - `stack_id` - (Optional) - ID of the stack on which the mounted file is defined;

--- a/spacelift/resource_mounted_file.go
+++ b/spacelift/resource_mounted_file.go
@@ -52,7 +52,7 @@ func resourceMountedFile() *schema.Resource {
 			},
 			"relative_path": {
 				Type:        schema.TypeString,
-				Description: "Relative path to the mounted file, without the /spacelift/project/ prefix",
+				Description: "Relative path to the mounted file, without the /mnt/workspace/ prefix",
 				Required:    true,
 				ForceNew:    true,
 			},


### PR DESCRIPTION
## Description of the change

Just a documentation fix, we've long been using the new mount path and missed some docs

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
