### PR TITLE
Once the version is set, do not unset

### DIFF
--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -180,10 +180,10 @@ func resourceStack() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"version": {
-							Type:        schema.TypeString,
-							Description: "Terraform version to be used by the Stack",
-							Optional:    true,
-							Computed:    true,
+							Type:             schema.TypeString,
+							Description:      "Terraform version to be used by the Stack",
+							Optional:         true,
+							DiffSuppressFunc: onceTheVersionIsSetDoNotUnset,
 						},
 						"workspace": {
 							Type:        schema.TypeString,
@@ -194,12 +194,12 @@ func resourceStack() *schema.Resource {
 				},
 			},
 			"terraform_version": {
-				Type:          schema.TypeString,
-				ConflictsWith: []string{"terraform"},
-				Deprecated:    `Please use the "terraform" block instead`,
-				Description:   "Terraform version to use",
-				Optional:      true,
-				Computed:      true,
+				Type:             schema.TypeString,
+				ConflictsWith:    []string{"terraform"},
+				Deprecated:       `Please use the "terraform" block instead`,
+				Description:      "Terraform version to use",
+				Optional:         true,
+				DiffSuppressFunc: onceTheVersionIsSetDoNotUnset,
 			},
 			"worker_pool_id": {
 				Type:        schema.TypeString,
@@ -488,4 +488,8 @@ func uploadStateFile(content string, meta interface{}) (string, error) {
 	}
 
 	return mutation.StateUploadURL.ObjectID, nil
+}
+
+func onceTheVersionIsSetDoNotUnset(_, _, new string, _ *schema.ResourceData) bool {
+	return new == ""
 }


### PR DESCRIPTION
## Description of the change

Once the Terraform version is set on the Stack, the lack of this setting should not cause the provider to explicitly nullify it.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
