### PR TITLE
Forget the `terraform` block, just make it work with the new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,13 @@ provider "spacelift" {}
 resource "spacelift_stack" "core-infra-production" {
   name = "Core Infrastructure (production)"
 
-  administrative    = true
-  autodeploy        = true
-  branch            = "master"
-  description       = "Shared production infrastructure (networking, k8s)"
-  repository        = "core-infra"
-
-  terraform {
-    version = "0.12.6"
-  }
+  administrative      = true
+  autodeploy          = true
+  branch              = "master"
+  description         = "Shared production infrastructure (networking, k8s)"
+  repository          = "core-infra"
+  terraform_version   = "0.12.6"
+  terraform_workspace = "workspace"
 }
 ```
 ## Terraform 0.13.x
@@ -894,10 +892,8 @@ The following arguments are supported:
   - `login_url` - (Required) - State backend to log in to.
   - `stack_name` - (Required) - Pulumi stack name to use in the backend (multiple stacks can use one state backend, provided they have different stack_name's).
 - `runner_image` - (Optional) - Name of the Docker image used to process Runs;
-- `terraform` - (Optional) - Terraform-specific configuration block. Sets the Stack vendor to Terraform if present:
-  - `version` - (Optional) - Terraform version to use;
-  - `workspace` - (Optional) - Workspace to select before performing Terraform operations;
 - `terraform_version` - (Optional) - Terraform version to use;
+- `terraform_workspace` - (Optional) - Workspace to select before performing Terraform operations;
 - `worker_pool_id` - (Optional) - ID of the worker pool to use;
 
 #### Attributes reference

--- a/spacelift/data_stack.go
+++ b/spacelift/data_stack.go
@@ -146,28 +146,14 @@ func dataStack() *schema.Resource {
 				Description: "ID (slug) of the stack",
 				Required:    true,
 			},
-			"terraform": {
-				Type:        schema.TypeList,
-				Description: "Terraform-specific configuration. Presence means this Stack is a Terraform Stack.",
-				Computed:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"version": {
-							Type:        schema.TypeString,
-							Description: "Terraform version to be used by the Stack",
-							Computed:    true,
-						},
-						"workspace": {
-							Type:        schema.TypeString,
-							Description: "Workspace to select before performing Terraform operations",
-							Computed:    true,
-						},
-					},
-				},
-			},
 			"terraform_version": {
 				Type:        schema.TypeString,
 				Description: "Terraform version to use",
+				Computed:    true,
+			},
+			"terraform_workspace": {
+				Type:        schema.TypeString,
+				Description: "Terraform workspace to select",
 				Computed:    true,
 			},
 			"worker_pool_id": {
@@ -244,12 +230,8 @@ func dataStackRead(d *schema.ResourceData, meta interface{}) error {
 
 		d.Set("pulumi", []interface{}{m})
 	default:
-		m := map[string]interface{}{
-			"version":   stack.VendorConfig.Terraform.Version,
-			"workspace": stack.VendorConfig.Terraform.Workspace,
-		}
-
-		d.Set("terraform", []interface{}{m})
+		d.Set("terraform_version", stack.VendorConfig.Terraform.Version)
+		d.Set("terraform_workspace", stack.VendorConfig.Terraform.Workspace)
 	}
 
 	if workerPool := stack.WorkerPool; workerPool != nil {

--- a/spacelift/data_stack_test.go
+++ b/spacelift/data_stack_test.go
@@ -18,21 +18,18 @@ func TestStackData(t *testing.T) {
 	testSteps(t, []resource.TestStep{{
 		Config: fmt.Sprintf(`
 			resource "spacelift_stack" "test" {
-				administrative = true
-				autodeploy     = true
-				autoretry      = false
-				before_init    = ["terraform fmt -check", "tflint"]
-				branch         = "master"
-				description    = "description"
-				labels         = ["one", "two"]
-				name           = "Test stack %s"
-				project_root   = "root"
-				repository     = "demo"
-				runner_image   = "custom_image:runner"
-				
-				terraform {
-					workspace = "bacon"
-				}
+				administrative      = true
+				autodeploy          = true
+				autoretry           = false
+				before_init         = ["terraform fmt -check", "tflint"]
+				branch              = "master"
+				description         = "description"
+				labels              = ["one", "two"]
+				name                = "Test stack %s"
+				project_root        = "root"
+				repository          = "demo"
+				runner_image        = "custom_image:runner"
+				terraform_workspace = "bacon"
 			}
 
 			data "spacelift_stack" "test" {
@@ -55,9 +52,7 @@ func TestStackData(t *testing.T) {
 			Attribute("project_root", Equals("root")),
 			Attribute("repository", Equals("demo")),
 			Attribute("runner_image", Equals("custom_image:runner")),
-			Attribute("terraform.#", Equals("1")),
-			Attribute("terraform.0.version", IsEmpty()),
-			Attribute("terraform.0.workspace", Equals("bacon")),
+			Attribute("terraform_workspace", Equals("bacon")),
 		),
 	}})
 }

--- a/spacelift/internal/structs/stack_input.go
+++ b/spacelift/internal/structs/stack_input.go
@@ -4,22 +4,21 @@ import "github.com/shurcooL/graphql"
 
 // StackInput represents the input required to create or update a Stack.
 type StackInput struct {
-	Administrative   graphql.Boolean    `json:"administrative"`
-	Autodeploy       graphql.Boolean    `json:"autodeploy"`
-	Autoretry        graphql.Boolean    `json:"autoretry"`
-	BeforeInit       *[]graphql.String  `json:"beforeInit"`
-	Branch           graphql.String     `json:"branch"`
-	Description      *graphql.String    `json:"description"`
-	Labels           *[]graphql.String  `json:"labels"`
-	Name             graphql.String     `json:"name"`
-	Namespace        *graphql.String    `json:"namespace"`
-	ProjectRoot      *graphql.String    `json:"projectRoot"`
-	Provider         *graphql.String    `json:"provider"`
-	Repository       graphql.String     `json:"repository"`
-	RunnerImage      *graphql.String    `json:"runnerImage"`
-	TerraformVersion *graphql.String    `json:"terraformVersion"`
-	VendorConfig     *VendorConfigInput `json:"vendorConfig"`
-	WorkerPool       *graphql.ID        `json:"workerPool"`
+	Administrative graphql.Boolean    `json:"administrative"`
+	Autodeploy     graphql.Boolean    `json:"autodeploy"`
+	Autoretry      graphql.Boolean    `json:"autoretry"`
+	BeforeInit     *[]graphql.String  `json:"beforeInit"`
+	Branch         graphql.String     `json:"branch"`
+	Description    *graphql.String    `json:"description"`
+	Labels         *[]graphql.String  `json:"labels"`
+	Name           graphql.String     `json:"name"`
+	Namespace      *graphql.String    `json:"namespace"`
+	ProjectRoot    *graphql.String    `json:"projectRoot"`
+	Provider       *graphql.String    `json:"provider"`
+	Repository     graphql.String     `json:"repository"`
+	RunnerImage    *graphql.String    `json:"runnerImage"`
+	VendorConfig   *VendorConfigInput `json:"vendorConfig"`
+	WorkerPool     *graphql.ID        `json:"workerPool"`
 }
 
 // VendorConfigInput represents vendor-specific configuration.

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -176,6 +176,7 @@ func resourceStack() *schema.Resource {
 				ConflictsWith: []string{"cloudformation", "pulumi", "terraform_version"},
 				Description:   "Terraform-specific configuration. Presence means this Stack is a Terraform Stack.",
 				Optional:      true,
+				Computed:      true,
 				MaxItems:      1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -253,6 +253,7 @@ func TestStackResource(t *testing.T) {
 				runner_image   = "custom_image:runner"
 
 				terraform {
+					version   = "0.12.5"
 					workspace = "bacon"
 				}
 			}
@@ -279,6 +280,7 @@ func TestStackResource(t *testing.T) {
 					Attribute("project_root", Equals("root")),
 					Attribute("runner_image", Equals("custom_image:runner")),
 					Attribute("terraform.#", Equals("1")),
+					Attribute("terraform.0.version", Equals("0.12.5")),
 					Attribute("terraform.0.workspace", Equals("bacon")),
 				),
 			},
@@ -293,7 +295,9 @@ func TestStackResource(t *testing.T) {
 					Attribute("labels.#", Equals("0")),
 					Attribute("project_root", IsEmpty()),
 					Attribute("runner_image", IsEmpty()),
-					Attribute("terraform.#", Equals("0")),
+					Attribute("terraform.#", Equals("1")),
+					Attribute("terraform.0.version", Equals("0.12.5")),
+					Attribute("terraform.0.workspace", IsEmpty()),
 				),
 			},
 		})

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -241,21 +241,18 @@ func TestStackResource(t *testing.T) {
 
 		before := fmt.Sprintf(`
 			resource "spacelift_stack" "test" {
-				administrative = true
-				autodeploy     = true
-				before_init    = ["terraform fmt -check", "tflint"]
-				branch         = "master"
-				description    = "bacon"
-				labels         = ["one", "two"]
-				name           = "Provider test stack %s"
-				project_root   = "root"
-				repository     = "demo"
-				runner_image   = "custom_image:runner"
-
-				terraform {
-					version   = "0.12.5"
-					workspace = "bacon"
-				}
+				administrative      = true
+				autodeploy          = true
+				before_init         = ["terraform fmt -check", "tflint"]
+				branch              = "master"
+				description         = "bacon"
+				labels              = ["one", "two"]
+				name                = "Provider test stack %s"
+				project_root        = "root"
+				repository          = "demo"
+				runner_image        = "custom_image:runner"
+				terraform_version   = "0.12.5"
+				terraform_workspace = "bacon"
 			}
 		`, randomID)
 
@@ -279,9 +276,8 @@ func TestStackResource(t *testing.T) {
 					SetEquals("labels", "one", "two"),
 					Attribute("project_root", Equals("root")),
 					Attribute("runner_image", Equals("custom_image:runner")),
-					Attribute("terraform.#", Equals("1")),
-					Attribute("terraform.0.version", Equals("0.12.5")),
-					Attribute("terraform.0.workspace", Equals("bacon")),
+					Attribute("terraform_version", Equals("0.12.5")),
+					Attribute("terraform_workspace", Equals("bacon")),
 				),
 			},
 			{
@@ -295,9 +291,8 @@ func TestStackResource(t *testing.T) {
 					Attribute("labels.#", Equals("0")),
 					Attribute("project_root", IsEmpty()),
 					Attribute("runner_image", IsEmpty()),
-					Attribute("terraform.#", Equals("1")),
-					Attribute("terraform.0.version", Equals("0.12.5")),
-					Attribute("terraform.0.workspace", IsEmpty()),
+					Attribute("terraform_version", Equals("0.12.5")),
+					Attribute("terraform_workspace", IsEmpty()),
 				),
 			},
 		})


### PR DESCRIPTION
## Description of the change

When the version is supplied externally, the entire block gets removed.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
