### PR TITLE
Remove policy custom input

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,7 +787,6 @@ The following arguments are supported:
 - `module_id` - (Optional) - ID of the module to attach the policy to;
 - `policy_id` - (Required) - ID of the policy to attach;
 - `stack_id` - (Optional) - ID of the stack to attach the policy to;
-- `custom_input` - (Optional) - JSON-encoded custom input to be passed to the evaluated document at the "attachment" key;
 
 Note that `module_id` and `stack_id` are mutually exclusive, and exactly one of them _must_ be specified.
 

--- a/spacelift/resource_policy_attachment_test.go
+++ b/spacelift/resource_policy_attachment_test.go
@@ -16,37 +16,33 @@ func TestPolicyAttachmentResource(t *testing.T) {
 	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
 	t.Run("with a stack", func(t *testing.T) {
-		config := func(message string) string {
-			return fmt.Sprintf(`
-				resource "spacelift_policy" "test" {
-					name = "My first policy %s"
-					body = "package spacelift"
-					type = "PLAN"
-				}
+		config := fmt.Sprintf(`
+			resource "spacelift_policy" "test" {
+				name = "My first policy %s"
+				body = "package spacelift"
+				type = "PLAN"
+			}
 
-				resource "spacelift_stack" "test" {
-					branch     = "master"
-					repository = "demo"
-					name       = "Test stack %s"
-				}
+			resource "spacelift_stack" "test" {
+				branch     = "master"
+				repository = "demo"
+				name       = "Test stack %s"
+			}
 
-				resource "spacelift_policy_attachment" "test" {
-					policy_id    = spacelift_policy.test.id
-					stack_id     = spacelift_stack.test.id
-					custom_input = jsonencode({ message = "%s" })
-				}
-			`, randomID, randomID, message)
-		}
+			resource "spacelift_policy_attachment" "test" {
+				policy_id    = spacelift_policy.test.id
+				stack_id     = spacelift_stack.test.id
+			}
+		`, randomID, randomID)
 
 		testSteps(t, []resource.TestStep{
 			{
-				Config: config("boom"),
+				Config: config,
 				Check: Resource(
 					resourceName,
 					Attribute("id", IsNotEmpty()),
 					Attribute("policy_id", Contains(randomID)),
 					Attribute("stack_id", Contains(randomID)),
-					Attribute("custom_input", Contains("boom")),
 				),
 			},
 			{
@@ -54,10 +50,6 @@ func TestPolicyAttachmentResource(t *testing.T) {
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("my-first-policy-%s/test-stack-%s", randomID, randomID),
 				ImportStateVerify: true,
-			},
-			{
-				Config: config("bang"),
-				Check:  Resource(resourceName, Attribute("custom_input", Contains("bang"))),
 			},
 		})
 	})
@@ -87,7 +79,6 @@ func TestPolicyAttachmentResource(t *testing.T) {
 					Attribute("id", IsNotEmpty()),
 					Attribute("policy_id", Contains(randomID)),
 					Attribute("module_id", Equals("terraform-bacon-tasty")),
-					AttributeNotPresent("custom_input"),
 				),
 			},
 			{


### PR DESCRIPTION
This feature is confusing, and unused. Folks prefer to use stack labels.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
