### PR TITLE
Update the secret attribute of the webhook resource to be marked as sensitive

### DIFF
--- a/spacelift/resource_webhook.go
+++ b/spacelift/resource_webhook.go
@@ -69,6 +69,7 @@ func resourceWebhook() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "secret used to sign each POST request so you're able to verify that the request comes from us",
 				Optional:    true,
+				Sensitive:   true,
 				Default:     "",
 			},
 			"stack_id": {


### PR DESCRIPTION
## Description of the change

This change updates the secret attribute of the webhook resource to be marked as Sensitive, which will prevent the secret value from being visible during a plan/apply.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
