### PR TITLE
Name policy in creation failure message

### DIFF
--- a/spacelift/resource_policy.go
+++ b/spacelift/resource_policy.go
@@ -90,7 +90,7 @@ func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if err := meta.(*internal.Client).Mutate(ctx, &mutation, variables); err != nil {
-		return diag.Errorf("could not create policy: %v", err)
+		return diag.Errorf("could not create policy %v: %v", toString(d.Get("name")), err)
 	}
 
 	d.SetId(mutation.CreatePolicy.ID)


### PR DESCRIPTION
## Description of the change

Current error can be confusing if one resource block is responsible for
generating many policies (eg for_each, or module).

```
│ Error: could not create policy: policy name must be unique within one account
│ 
│   on file.tf line 25, in resource "spacelift_policy" "default":
│   25: resource "spacelift_policy" "default" {
```

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
