### PR TITLE
Add aws-cli and bump Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ RUN go mod download
 COPY . $DIR/
 RUN CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /terraform-provider-spacelift
 
-FROM alpine:3.13.5
+FROM alpine:3.14.0
 
 RUN apk -U upgrade
-RUN apk add --no-cache ca-certificates curl git openssh jq
+RUN apk add --no-cache ca-certificates curl git openssh jq aws-cli
 
 COPY --from=builder /bin/infracost /bin/infracost
 COPY --from=builder /bin/terragrunt /bin/terragrunt


### PR DESCRIPTION
## Description of the change

It adds the latest aws-cli version 1. Unfortunately, version 2 is still not supported on Alpine images.

```
/ $ aws --version
aws-cli/1.19.93 Python/3.9.5 Linux/5.12.9-200.fc33.x86_64 botocore/1.20.93
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [x] Changes have been reviewed by at least one other engineer
