### PR TITLE
Update Infracost to 0.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.16-alpine as builder
 
 # 3rd party soft dependency versions
-ARG INFRACOST_VERSION=0.9.1
+ARG INFRACOST_VERSION=0.9.2
 ARG TERRAGRUNT_VERSION=0.28.15
 
 RUN apk add --no-cache curl git


### PR DESCRIPTION
## Description

This includes a fix to remove a warning about not being able to sync the usage file when the `--sync-usage-file` flag hasn't been specified:

![image](https://user-images.githubusercontent.com/1884632/124244399-cec96280-db16-11eb-9101-aa63a838442d.png)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
