### PR TITLE
Add info about target branch to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 > Description here
 
 ## Type of change
+
 - [ ] Bug fix (non-breaking change that fixes an issue)
 - [ ] New feature (non-breaking change that adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
@@ -26,3 +27,4 @@
 - [ ] Pull Request is no longer marked as "draft"
 - [ ] Reviewers have been assigned
 - [ ] Changes have been reviewed by at least one other engineer
+- [ ] The target branch is `future` unless the change is going directly into production


### PR DESCRIPTION
## Description of the change

I keep on forgetting to set the target branch of this repo to `future` when creating PRs that I want to go into preprod first, so adding to the template.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
