### PR TITLE
Update GitHub Enterprise integration details 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Lint the code using "golint"
         run: go get -u golang.org/x/lint/golint && golint -set_exit_status ./...
-      
+
       - name: Run staticcheck
         run: go get -u honnef.co/go/tools/cmd/staticcheck && staticcheck ./...
 
@@ -33,9 +33,9 @@ jobs:
           SPACELIFT_PROVIDER_TEST_IPS: ${{ secrets.SPACELIFT_PROVIDER_TEST_IPS }}
           SPACELIFT_PROVIDER_TEST_GITLAB_API_HOST: https://gitlab.com
           SPACELIFT_PROVIDER_TEST_GITLAB_WEBHOOK_SECRET: ${{ secrets.SPACELIFT_PROVIDER_TEST_GITLAB_WEBHOOK_SECRET }}
-          SPACELIFT_PROVIDER_TEST_GITHUB_ENTERPRISE_API_HOST: https://github.liftspace.net
+          SPACELIFT_PROVIDER_TEST_GITHUB_ENTERPRISE_API_HOST: https://api.github.com
           SPACELIFT_PROVIDER_TEST_GITHUB_ENTERPRISE_WEBHOOK_SECRET: ${{ secrets.SPACELIFT_PROVIDER_TEST_GITHUB_ENTERPRISE_WEBHOOK_SECRET }}
-          SPACELIFT_PROVIDER_TEST_GITHUB_ENTERPRISE_APP_ID: 6
+          SPACELIFT_PROVIDER_TEST_GITHUB_ENTERPRISE_APP_ID: 135337
           SPACELIFT_PROVIDER_TEST_BITBUCKET_DATACENTER_API_HOST: private://bitbucket-datacenter-agent-pool
           SPACELIFT_PROVIDER_TEST_BITBUCKET_DATACENTER_WEBHOOK_SECRET: ${{ secrets.SPACELIFT_PROVIDER_TEST_BITBUCKET_DATACENTER_WEBHOOK_SECRET }}
           SPACELIFT_PROVIDER_TEST_BITBUCKET_DATACENTER_USER_FACING_HOST: http://localhost:7990


### PR DESCRIPTION
## Description

We're currently pointing the integration in preprod at api.github.com to run DataDog synthetics that ensure that the GitHub Enterprise integration works with github.com. I'm updating these credentials, and I've updated the SPACELIFT_PROVIDER_TEST_GITHUB_ENTERPRISE_WEBHOOK_SECRET secret to match the current setup.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The target branch is `future` unless the change is going directly into production
