### PR TITLE
Simplify retry handling

### DIFF
--- a/spacelift/internal/client.go
+++ b/spacelift/internal/client.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/shurcooL/graphql"
@@ -39,7 +38,6 @@ func (c *Client) client(ctx context.Context) *graphql.Client {
 	retryableClient := retryablehttp.NewClient()
 	retryableClient.HTTPClient = oauthClient
 	retryableClient.Logger = nil
-	retryableClient.CheckRetry = retryPolicy
 
 	return graphql.NewClient(
 		c.url(),
@@ -52,12 +50,4 @@ func (c *Client) client(ctx context.Context) *graphql.Client {
 
 func (c *Client) url() string {
 	return fmt.Sprintf("%s/graphql", c.Endpoint)
-}
-
-func retryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
-	if _, ok := err.(*graphql.ResponseError); ok {
-		return true, nil
-	}
-
-	return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
 }


### PR DESCRIPTION
## Description of the change

I realised that I hadn't noticed the retry handling we already had in place when adding the retryable HTTP client. I've removed the retry code and replaced it with a retry policy. It wraps the default policy that already takes care of 5xx errors as well as 429s.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
