### PR TITLE
Disallow concurrent deploys

### DIFF
--- a/.github/workflows/registry-preprod.yml
+++ b/.github/workflows/registry-preprod.yml
@@ -2,6 +2,9 @@ name: Preprod registry
 
 on: [push]
 
+concurrency:
+  group: ${{ github.ref }}-registry-preprod
+
 jobs:
   registry:
     name: Publish the provider to the registry

--- a/.github/workflows/registry-prod.yml
+++ b/.github/workflows/registry-prod.yml
@@ -2,6 +2,9 @@ name: Production registry
 
 on: [push]
 
+concurrency:
+  group: ${{ github.ref }}-registry-prod
+
 jobs:
   registry:
     name: Publish the provider to the registry


### PR DESCRIPTION
## Description of the change

When using the deprecated S3 registry, two deployments can override one another so checksums and signatures won't match.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The target branch is `future` unless the change is going directly into production
