### PR TITLE
Set version on docker image and our own registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,3 +42,6 @@ jobs:
         with:
           push: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/future' }}
           tags: ${{ env.DOCKER_IMAGE }}
+          build-args:
+            - "VERSION=1.0.0"
+            - "COMMIT=${{ github.sha }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.16-alpine as builder
 
+ARG VERSION=dev
+ARG COMMIT=dev
+
 # 3rd party soft dependency versions
 ARG INFRACOST_VERSION=0.9.7
 ARG TERRAGRUNT_VERSION=0.28.15
@@ -20,7 +23,8 @@ COPY go.* $DIR/
 WORKDIR $DIR
 RUN go mod download
 COPY . $DIR/
-RUN CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /terraform-provider-spacelift
+
+RUN CGO_ENABLED=0 go build -a -tags netgo -ldflags "-w -extldflags '-static' -X main.version=${VERSION} -X main.commit=${COMMIT}" -o /terraform-provider-spacelift
 
 FROM alpine:3.14.0
 

--- a/registry/package.sh
+++ b/registry/package.sh
@@ -3,6 +3,7 @@
 set -e
 
 VERSION="1.0.0"
+COMMIT=$(git rev-parse HEAD)
 
 echo "Preparing the build directory..." 1>&2
 BUILD_PATH=build
@@ -36,7 +37,7 @@ build () {
     CGO_ENABLED=0 \
     GOOS=$OS \
     GOARCH=$ARCH \
-    go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o $BINARY_NAME
+    go build -a -tags netgo -ldflags "-w -extldflags '-static' -X main.version=${VERSION} -X main.commit=${COMMIT}" -o $BINARY_NAME
 
     # Step 2: zip and remove source binary
     zip $ZIP_NAME $BINARY_NAME


### PR DESCRIPTION
## Description of the change

We build the provider in three different ways:

- Using goreleaser to publish to the HashiCorp registry.
- As part of a docker build to embed on our worker image.
- Via the package.sh script, for upload to our own self-hosted registry on spacelift.io / spacelift.dev.

goreleaser passes the correct linker flags to set the version and commit, but the other two don't. This matters because we pass the version as an HTTP header so that we can track usage of different versions.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
