### PR TITLE
Verify stack and module existence on some creations

### DIFF
--- a/spacelift/resource_aws_role.go
+++ b/spacelift/resource_aws_role.go
@@ -83,8 +83,16 @@ func resourceAWSRoleCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	if stackID, ok := d.GetOk("stack_id"); ok {
 		ID = stackID.(string)
+
+		if err := verifyStack(ctx, ID, meta); err != nil {
+			return diag.FromErr(err)
+		}
 	} else {
 		ID = d.Get("module_id").(string)
+
+		if err := verifyModule(ctx, ID, meta); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	var err error

--- a/spacelift/resource_context_attachment.go
+++ b/spacelift/resource_context_attachment.go
@@ -73,8 +73,16 @@ func resourceContextAttachmentCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if stackID, ok := d.GetOk("stack_id"); ok {
+		if err := verifyStack(ctx, stackID.(string), meta); err != nil {
+			return diag.FromErr(err)
+		}
+
 		variables["stack"] = toID(stackID)
 	} else {
+		if err := verifyModule(ctx, d.Get("module_id").(string), meta); err != nil {
+			return diag.FromErr(err)
+		}
+
 		variables["stack"] = toID(d.Get("module_id"))
 	}
 

--- a/spacelift/resource_environment_variable.go
+++ b/spacelift/resource_environment_variable.go
@@ -99,11 +99,20 @@ func resourceEnvironmentVariableCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if stackID, ok := d.GetOk("stack_id"); ok {
+		if err := verifyStack(ctx, stackID.(string), meta); err != nil {
+			return diag.FromErr(err)
+		}
+
 		variables["stack"] = toID(stackID)
 		return resourceEnvironmentVariableCreateStack(ctx, d, meta.(*internal.Client), variables)
 	}
 
-	variables["stack"] = toID(d.Get("module_id"))
+	moduleID := d.Get("module_id").(string)
+	if err := verifyModule(ctx, moduleID, meta); err != nil {
+		return diag.FromErr(err)
+	}
+
+	variables["stack"] = toID(moduleID)
 
 	return resourceEnvironmentVariableCreateModule(ctx, d, meta.(*internal.Client), variables)
 }

--- a/spacelift/resource_gcp_service_account.go
+++ b/spacelift/resource_gcp_service_account.go
@@ -82,9 +82,18 @@ func resourceGCPServiceAccountCreate(ctx context.Context, d *schema.ResourceData
 
 	var ID string
 	if stackID, ok := d.GetOk("stack_id"); ok {
+		if err := verifyStack(ctx, stackID.(string), meta); err != nil {
+			return diag.FromErr(err)
+		}
+
 		ID = stackID.(string)
 	} else {
-		ID = d.Get("module_id").(string)
+		moduleID := d.Get("module_id").(string)
+		if err := verifyModule(ctx, moduleID, meta); err != nil {
+			return diag.FromErr(err)
+		}
+
+		ID = moduleID
 	}
 
 	variables := map[string]interface{}{

--- a/spacelift/resource_mounted_file.go
+++ b/spacelift/resource_mounted_file.go
@@ -98,11 +98,20 @@ func resourceMountedFileCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if stackID, ok := d.GetOk("stack_id"); ok {
+		if err := verifyStack(ctx, stackID.(string), meta); err != nil {
+			return diag.FromErr(err)
+		}
+
 		variables["stack"] = toID(stackID)
 		return resourceMountedFileCreateStack(ctx, d, meta.(*internal.Client), variables)
 	}
 
-	variables["stack"] = toID(d.Get("module_id"))
+	moduleID := d.Get("module_id").(string)
+	if err := verifyModule(ctx, moduleID, meta); err != nil {
+		return diag.FromErr(err)
+	}
+
+	variables["stack"] = toID(moduleID)
 	return resourceMountedFileCreateModule(ctx, d, meta.(*internal.Client), variables)
 }
 

--- a/spacelift/resource_policy_attachment.go
+++ b/spacelift/resource_policy_attachment.go
@@ -66,9 +66,18 @@ func resourcePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData,
 	variables := map[string]interface{}{"id": toID(policyID)}
 
 	if stackID, ok := d.GetOk("stack_id"); ok {
+		if err := verifyStack(ctx, stackID.(string), meta); err != nil {
+			return diag.FromErr(err)
+		}
+
 		variables["stack"] = toID(stackID)
 	} else {
-		variables["stack"] = toID(d.Get("module_id"))
+		moduleID := d.Get("module_id").(string)
+		if err := verifyModule(ctx, moduleID, meta); err != nil {
+			return diag.FromErr(err)
+		}
+
+		variables["stack"] = toID(moduleID)
 	}
 
 	if err := meta.(*internal.Client).Mutate(ctx, "PolicyAttachmentCreate", &mutation, variables); err != nil {

--- a/spacelift/resource_webhook.go
+++ b/spacelift/resource_webhook.go
@@ -102,9 +102,18 @@ func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if stackID, ok := d.GetOk("stack_id"); ok {
+		if err := verifyStack(ctx, stackID.(string), meta); err != nil {
+			return diag.FromErr(err)
+		}
+
 		variables["stack"] = toID(stackID)
 	} else {
-		variables["stack"] = toID(d.Get("module_id"))
+		moduleID := d.Get("module_id").(string)
+		if err := verifyModule(ctx, moduleID, meta); err != nil {
+			return diag.FromErr(err)
+		}
+
+		variables["stack"] = toID(moduleID)
 	}
 
 	if err := meta.(*internal.Client).Mutate(ctx, "WebhookCreate", &mutation, variables); err != nil {

--- a/spacelift/verify_project.go
+++ b/spacelift/verify_project.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shurcooL/graphql"
+
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
 )
@@ -34,8 +35,8 @@ func verifyStack(ctx context.Context, stackID string, meta interface{}) error {
 
 	variables := map[string]interface{}{"id": graphql.ID(stackID)}
 
-	if err := meta.(*internal.Client).Query(ctx, "ModuleVerifyExistence", &query, variables); err != nil {
-		return errors.Wrap(err, "could not query for module")
+	if err := meta.(*internal.Client).Query(ctx, "StackVerifyExistence", &query, variables); err != nil {
+		return errors.Wrap(err, "could not query for stack")
 	}
 
 	if query.Stack == nil {

--- a/spacelift/verify_project.go
+++ b/spacelift/verify_project.go
@@ -1,0 +1,46 @@
+package spacelift
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/shurcooL/graphql"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+)
+
+func verifyModule(ctx context.Context, moduleID string, meta interface{}) error {
+	var query struct {
+		Module *structs.Module `graphql:"module(id: $id)"`
+	}
+
+	variables := map[string]interface{}{"id": graphql.ID(moduleID)}
+
+	if err := meta.(*internal.Client).Query(ctx, "ModuleVerifyExistence", &query, variables); err != nil {
+		return errors.Wrap(err, "could not query for module")
+	}
+
+	if query.Module == nil {
+		return errors.New("module not found")
+	}
+
+	return nil
+}
+
+func verifyStack(ctx context.Context, stackID string, meta interface{}) error {
+	var query struct {
+		Stack *structs.Stack `graphql:"stack(id: $id)"`
+	}
+
+	variables := map[string]interface{}{"id": graphql.ID(stackID)}
+
+	if err := meta.(*internal.Client).Query(ctx, "ModuleVerifyExistence", &query, variables); err != nil {
+		return errors.Wrap(err, "could not query for module")
+	}
+
+	if query.Stack == nil {
+		return errors.New("stack not found")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description of the change

When a resource can be attached to either a stack or a module, validate the existence to prevent creating a resource for the wrong entity.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The target branch is `future` unless the change is going directly into production
