### PR TITLE
Allow importing state files by path

### DIFF
--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -140,7 +140,8 @@ resource "spacelift_stack" "k8s-core-pulumi" {
 - **github_enterprise** (Block List, Max: 1) GitHub Enterprise (self-hosted) VCS settings (see [below for nested schema](#nestedblock--github_enterprise))
 - **gitlab** (Block List, Max: 1) GitLab VCS settings (see [below for nested schema](#nestedblock--gitlab))
 - **id** (String) The ID of this resource.
-- **import_state** (String) State file to upload when creating a new stack
+- **import_state** (String, Sensitive) State file to upload when creating a new stack
+- **import_state_file** (String) Path to the state file to upload when creating a new stack
 - **labels** (Set of String)
 - **manage_state** (Boolean) Determines if Spacelift should manage state for this stack
 - **project_root** (String) Project root is the optional directory relative to the workspace root containing the entrypoint to the Stack.

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -255,6 +255,7 @@ func resourceStack() *schema.Resource {
 				ConflictsWith:    []string{"import_state_file"},
 				Optional:         true,
 				DiffSuppressFunc: ignoreOnceCreated,
+				Sensitive:        true,
 			},
 			"import_state_file": {
 				Type:             schema.TypeString,

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -3,6 +3,7 @@ package spacelift
 import (
 	"context"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -249,12 +250,18 @@ func resourceStack() *schema.Resource {
 				},
 			},
 			"import_state": {
-				Type:        schema.TypeString,
-				Description: "State file to upload when creating a new stack",
-				Optional:    true,
-				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
-					return d.Id() != ""
-				},
+				Type:             schema.TypeString,
+				Description:      "State file to upload when creating a new stack",
+				ConflictsWith:    []string{"import_state_file"},
+				Optional:         true,
+				DiffSuppressFunc: ignoreOnceCreated,
+			},
+			"import_state_file": {
+				Type:             schema.TypeString,
+				Description:      "Path to the state file to upload when creating a new stack",
+				ConflictsWith:    []string{"import_state"},
+				Optional:         true,
+				DiffSuppressFunc: ignoreOnceCreated,
 			},
 			"labels": {
 				Type:     schema.TypeSet,
@@ -361,11 +368,28 @@ func resourceStackCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		"stackObjectID": (*graphql.String)(nil),
 	}
 
+	var stateContent string
+
 	content, ok := d.GetOk("import_state")
 	if ok && !manageState {
 		return diag.Errorf(`"import_state" requires "manage_state" to be true`)
 	} else if ok {
-		objectID, err := uploadStateFile(ctx, content.(string), meta)
+		stateContent = content.(string)
+	}
+
+	path, ok := d.GetOk("import_state_file")
+	if ok && !manageState {
+		return diag.Errorf(`"import_state_file" requires "manage_state" to be true`)
+	} else if ok {
+		data, err := os.ReadFile(path.(string))
+		if err != nil {
+			return diag.Errorf("failed to read imported state file: %s", err)
+		}
+		stateContent = string(data)
+	}
+
+	if stateContent != "" {
+		objectID, err := uploadStateFile(ctx, stateContent, meta)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -714,4 +738,8 @@ func uploadStateFile(ctx context.Context, content string, meta interface{}) (str
 
 func onceTheVersionIsSetDoNotUnset(_, _, new string, _ *schema.ResourceData) bool {
 	return new == ""
+}
+
+func ignoreOnceCreated(_, _, _ string, d *schema.ResourceData) bool {
+	return d.Id() != ""
 }


### PR DESCRIPTION
## Description of the change

Sometimes the state file is too large, and importing by path is way more convenient.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
