### PR TITLE
Documentation: add warning regarding resource destruction in `spacelift_stack_destructor` docs

### DIFF
--- a/docs/resources/stack_destructor.md
+++ b/docs/resources/stack_destructor.md
@@ -8,6 +8,8 @@ description: |-
 
 # spacelift_stack_destructor (Resource)
 
+~> **Note:** Destroying this resource will delete the resources in the stack. If this resource needs to be deleted and the resources in the stacks are to be preserved, ensure that the `deactivated` attribute is set to `true`.
+
 `spacelift_stack_destructor` is used to destroy the resources of a Stack before deleting it. `depends_on` should be used to make sure that all necessery resources (environment variables, roles, integrations, etc.) are still in place when the destruction run is executed.
 
 ## Example Usage


### PR DESCRIPTION
## Description of the change

This PR adds a warning in the TF registry docs explaining that deleting the `spacelift_stack_destructor` resource will delete the resources in the stack. This is important to note because this resource may be deleted with the intention of disabling the stack destructor functionality. However, doing that when the `deactivated` attribute is not set to `true` will result in all of the resources in the stack being deleted.

See: https://github.com/spacelift-io/terraform-provider-spacelift/blob/6b9411707f6243ffa956e06bdaa1659820250c35/spacelift/resource_stack_destructor.go#L78-L104

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
