### PR TITLE
Support setting custom slug for a stack

### DIFF
--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -149,6 +149,7 @@ resource "spacelift_stack" "k8s-core-pulumi" {
 - **pulumi** (Block List, Max: 1) Pulumi-specific configuration. Presence means this Stack is a Pulumi Stack. (see [below for nested schema](#nestedblock--pulumi))
 - **runner_image** (String) Name of the Docker image used to process Runs
 - **showcase** (Block List, Max: 1) (see [below for nested schema](#nestedblock--showcase))
+- **slug** (String) Allows setting the custom ID (slug) for the stack
 - **terraform_version** (String) Terraform version to use
 - **terraform_workspace** (String) Terraform workspace to select
 - **worker_pool_id** (String) ID of the worker pool to use

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -313,6 +313,12 @@ func resourceStack() *schema.Resource {
 					},
 				},
 			},
+			"slug": {
+				Type:        schema.TypeString,
+				Description: "Allows setting the custom ID (slug) for the stack",
+				Optional:    true,
+				ForceNew:    true,
+			},
 			"repository": {
 				Type:        schema.TypeString,
 				Description: "Name of the repository, without the owner part",
@@ -358,7 +364,7 @@ func resourceStack() *schema.Resource {
 
 func resourceStackCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var mutation struct {
-		CreateStack structs.Stack `graphql:"stackCreate(input: $input, manageState: $manageState, stackObjectID: $stackObjectID)"`
+		CreateStack structs.Stack `graphql:"stackCreate(input: $input, manageState: $manageState, stackObjectID: $stackObjectID, slug: $slug)"`
 	}
 
 	manageState := d.Get("manage_state").(bool)
@@ -367,6 +373,11 @@ func resourceStackCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		"input":         stackInput(d),
 		"manageState":   graphql.Boolean(manageState),
 		"stackObjectID": (*graphql.String)(nil),
+		"slug":          (*graphql.String)(nil),
+	}
+
+	if slug, ok := d.GetOk("slug"); ok {
+		variables["slug"] = toOptionalString(slug)
 	}
 
 	var stateContent string

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -108,7 +108,7 @@ func TestStackResource(t *testing.T) {
 		})
 	})
 
-	t.Run("with private worker pool and autoretry", func(t *testing.T) {
+	t.Run("with private worker pool, custom slug and autoretry", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
 		config := func(description string) string {
@@ -136,6 +136,7 @@ func TestStackResource(t *testing.T) {
 					project_root         = "root"
 					repository           = "demo"
 					runner_image         = "custom_image:runner"
+					slug                 = "custom-slug-%s"
 					worker_pool_id       = spacelift_worker_pool.test.id
 				}
 
@@ -143,7 +144,7 @@ func TestStackResource(t *testing.T) {
 					name        = "Autoretryable worker pool."
 					description = "test worker pool"
 				}
-			`, description, randomID)
+			`, description, randomID, randomID)
 		}
 
 		testSteps(t, []resource.TestStep{
@@ -151,7 +152,7 @@ func TestStackResource(t *testing.T) {
 				Config: config("old description"),
 				Check: Resource(
 					resourceName,
-					Attribute("id", StartsWith("provider-test-stack-")),
+					Attribute("id", StartsWith("custom-slug-")),
 					Attribute("administrative", Equals("true")),
 					Attribute("after_apply.#", Equals("2")),
 					Attribute("after_apply.0", Equals("ls -la")),
@@ -191,9 +192,10 @@ func TestStackResource(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"slug"},
 			},
 			{
 				Config: config("new description"),


### PR DESCRIPTION
## Description of the change

With this change, we allow users to set the slug for the stack. This only works on creation, so there's no use in reading it back, and any attempt to change it after creation will trigger stack recreation.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
