### PR TITLE
Regenerate docs and include GCP docs fix

### DIFF
--- a/docs/data-sources/stack_aws_role.md
+++ b/docs/data-sources/stack_aws_role.md
@@ -3,14 +3,17 @@
 page_title: "spacelift_stack_aws_role Data Source - terraform-provider-spacelift"
 subcategory: ""
 description: |-
-  spacelift_aws_role represents cross-account IAM role delegation https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html between the Spacelift worker and an individual stack or module. If this is set, Spacelift will use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment.
+  ~> Note: spacelift_stack_aws_role is deprecated. Please use spacelift_aws_role instead. The functionality is identical.
+  spacelift_stack_aws_role represents cross-account IAM role delegation https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html between the Spacelift worker and an individual stack or module. If this is set, Spacelift will use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment.
   If you use private workers, you can also assume IAM role on the worker side using your own AWS credentials (e.g. from EC2 instance profile).
   Note: when assuming credentials for shared worker, Spacelift will use $accountName@$stackID or $accountName@$moduleID as external ID https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html and Run ID as session ID https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.
 ---
 
 # spacelift_stack_aws_role (Data Source)
 
-`spacelift_aws_role` represents [cross-account IAM role delegation](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) between the Spacelift worker and an individual stack or module. If this is set, Spacelift will use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment.
+~> **Note:** `spacelift_stack_aws_role` is deprecated. Please use `spacelift_aws_role` instead. The functionality is identical.
+
+`spacelift_stack_aws_role` represents [cross-account IAM role delegation](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) between the Spacelift worker and an individual stack or module. If this is set, Spacelift will use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment.
 
 If you use private workers, you can also assume IAM role on the worker side using your own AWS credentials (e.g. from EC2 instance profile).
 

--- a/docs/data-sources/stack_gcp_service_account.md
+++ b/docs/data-sources/stack_gcp_service_account.md
@@ -3,12 +3,15 @@
 page_title: "spacelift_stack_gcp_service_account Data Source - terraform-provider-spacelift"
 subcategory: ""
 description: |-
-  spacelift_gcp_service_account represents a Google Cloud Platform service account that's linked to a particular Stack or Module. These accounts are created by Spacelift on per-stack basis, and can be added as members to as many organizations and projects as needed. During a Run or a Task, temporary credentials for those service accounts are injected into the environment, which allows credential-less GCP Terraform provider setup.
+  ~> Note: spacelift_stack_gcp_service_account is deprecated. Please use spacelift_gcp_service_account instead. The functionality is identical.
+  spacelift_stack_gcp_service_account represents a Google Cloud Platform service account that's linked to a particular Stack or Module. These accounts are created by Spacelift on per-stack basis, and can be added as members to as many organizations and projects as needed. During a Run or a Task, temporary credentials for those service accounts are injected into the environment, which allows credential-less GCP Terraform provider setup.
 ---
 
 # spacelift_stack_gcp_service_account (Data Source)
 
-`spacelift_gcp_service_account` represents a Google Cloud Platform service account that's linked to a particular Stack or Module. These accounts are created by Spacelift on per-stack basis, and can be added as members to as many organizations and projects as needed. During a Run or a Task, temporary credentials for those service accounts are injected into the environment, which allows credential-less GCP Terraform provider setup.
+~> **Note:** `spacelift_stack_gcp_service_account` is deprecated. Please use `spacelift_gcp_service_account` instead. The functionality is identical.
+
+`spacelift_stack_gcp_service_account` represents a Google Cloud Platform service account that's linked to a particular Stack or Module. These accounts are created by Spacelift on per-stack basis, and can be added as members to as many organizations and projects as needed. During a Run or a Task, temporary credentials for those service accounts are injected into the environment, which allows credential-less GCP Terraform provider setup.
 
 ## Example Usage
 

--- a/docs/resources/aws_role.md
+++ b/docs/resources/aws_role.md
@@ -76,4 +76,12 @@ resource "spacelift_aws_role" "k8s-core" {
 - **module_id** (String) ID of the module which assumes the AWS IAM role
 - **stack_id** (String) ID of the stack which assumes the AWS IAM role
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_aws_role.k8s-core stack/$STACK_ID
+
+terraform import spacelift_aws_role.k8s-core module/$MODULE_ID
+```

--- a/docs/resources/azure_integration.md
+++ b/docs/resources/azure_integration.md
@@ -42,4 +42,10 @@ resource "spacelift_azure_integration" "example" {
 - **application_id** (String) The applicationId of the Azure AD application used by the integration.
 - **display_name** (String) The display name for the application in Azure. This is automatically generated when the integration is created, and cannot be changed without deleting and recreating the integration.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_azure_integration.example $INTEGRATION_ID
+```

--- a/docs/resources/azure_integration_attachment.md
+++ b/docs/resources/azure_integration_attachment.md
@@ -56,4 +56,6 @@ Import is supported using the following syntax:
 
 ```shell
 terraform import spacelift_azure_integration_attachment.readonly $INTEGRATION_ID/$STACK_ID
+
+terraform import spacelift_azure_integration_attachment.writeonly $INTEGRATION_ID/$MODULE_ID
 ```

--- a/docs/resources/context.md
+++ b/docs/resources/context.md
@@ -32,4 +32,10 @@ resource "spacelift_context" "prod-k8s-ie" {
 - **id** (String) The ID of this resource.
 - **labels** (Set of String)
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_context.prod-k8s-ie $CONTEXT_ID
+```

--- a/docs/resources/context_attachment.md
+++ b/docs/resources/context_attachment.md
@@ -42,4 +42,10 @@ resource "spacelift_context_attachment" "attachment" {
 - **priority** (Number) Priority of the context attachment, used in case of conflicts
 - **stack_id** (String) ID of the stack to attach the context to
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_context_attachment.test_stack $CONTEXT_ID/$STACK_ID
+```

--- a/docs/resources/drift_detection.md
+++ b/docs/resources/drift_detection.md
@@ -39,4 +39,12 @@ resource "spacelift_drift_detection" "core-infra-production-drift-detection" {
 - **id** (String) The ID of this resource.
 - **reconcile** (Boolean) Whether a tracked run should be triggered when drift is detected.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_drift_detection.core-infra-production-drift-detection stack/$STACK_ID
+
+terraform import spacelift_drift_detection.core-infra-production-drift-detection module/$MODULE_ID
+```

--- a/docs/resources/environment_variable.md
+++ b/docs/resources/environment_variable.md
@@ -58,4 +58,14 @@ resource "spacelift_environment_variable" "core-kubeconfig" {
 
 - **checksum** (String) SHA-256 checksum of the value
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_environment_variable.ireland-kubeconfig context/$CONTEXT_ID/$ENVIRONMENT_VARIABLE_NAME
+
+terraform import spacelift_environment_variable.module-kubeconfig module/$MODULE_ID/$ENVIRONMENT_VARIABLE_NAME
+
+terraform import spacelift_environment_variable.core-kubeconfig stack/$STACK_ID/$ENVIRONMENT_VARIABLE_NAME
+```

--- a/docs/resources/gcp_service_account.md
+++ b/docs/resources/gcp_service_account.md
@@ -38,7 +38,7 @@ resource "google_project" "k8s-core" {
 resource "google_project_iam_member" "k8s-core" {
   project = google_project.k8s-core.id
   role    = "roles/owner"
-  member  = "serviceAccount:${spacelift_stack_gcp_service_account.k8s-core.service_account_email}"
+  member  = "serviceAccount:${spacelift_gcp_service_account.k8s-core.service_account_email}"
 }
 ```
 
@@ -59,4 +59,12 @@ resource "google_project_iam_member" "k8s-core" {
 
 - **service_account_email** (String) Email address of the GCP service account dedicated for this stack
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_gcp_service_account.k8s-core stack/$STACK_ID
+
+terraform import spacelift_gcp_service_account.k8s-core module/$MODULE_ID
+```

--- a/docs/resources/module.md
+++ b/docs/resources/module.md
@@ -25,11 +25,11 @@ resource "spacelift_module" "k8s-module" {
 
 # Unspecified module name and provider (repository naming scheme terraform-${provider}-${name})
 resource "spacelift_module" "example-module" {
-  administrative     = true
-  branch             = "master"
-  description        = "Example terraform module"
-  repository         = "terraform-aws-example"
-  project_root       = "example"
+  administrative = true
+  branch         = "master"
+  description    = "Example terraform module"
+  repository     = "terraform-aws-example"
+  project_root   = "example"
 }
 ```
 
@@ -102,4 +102,10 @@ Required:
 
 - **namespace** (String) The GitLab namespace containing the repository
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_module.k8s-module $MODULE_ID
+```

--- a/docs/resources/mounted_file.md
+++ b/docs/resources/mounted_file.md
@@ -55,4 +55,14 @@ resource "spacelift_mounted_file" "core-kubeconfig" {
 
 - **checksum** (String) SHA-256 checksum of the value
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_mounted_file.ireland-kubeconfig context/$CONTEXT_ID/$MOUNTED_FILE_ID
+
+terraform import spacelift_mounted_file.module-kubeconfig module/$MODULE_ID/$MOUNTED_FILE_ID
+
+terraform import spacelift_mounted_file.core-kubeconfig stack/$STACK_ID/$MOUNTED_FILE_ID
+```

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -15,7 +15,7 @@ description: |-
 ```terraform
 resource "spacelift_policy" "no-weekend-deploys" {
   name = "Let's not deploy any changes over the weekend"
-  body = file("policies/no-weekend-deploys.rego")
+  body = file("${path.module}/policies/no-weekend-deploys.rego")
   type = "PLAN"
 }
 
@@ -38,11 +38,17 @@ resource "spacelift_policy_attachment" "no-weekend-deploys" {
 
 - **body** (String) Body of the policy
 - **name** (String) Name of the policy - should be unique in one account
-- **type** (String) Body of the policy
+- **type** (String) Type of the policy. Possible values are `ACCESS`, `APPROVAL`, `GIT_PUSH`, `INITIALIZATION`, `LOGIN`, `PLAN`, `TASK`, and `TRIGGER`. Deprecated values are `STACK_ACCESS` (use `ACCESS` instead), `TASK_RUN` (use `TASK` instead), and `TERRAFORM_PLAN` (use `PLAN` instead).
 
 ### Optional
 
 - **id** (String) The ID of this resource.
 - **labels** (Set of String)
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_policy.no-weekend-deploys $POLICY_ID
+```

--- a/docs/resources/policy_attachment.md
+++ b/docs/resources/policy_attachment.md
@@ -44,4 +44,10 @@ resource "spacelift_policy_attachment" "no-weekend-deploys" {
 - **module_id** (String) ID of the module to attach the policy to
 - **stack_id** (String) ID of the stack to attach the policy to
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_policy_attachment.no-weekend-deploys $POLICY_ID/$STACK_ID
+```

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -268,4 +268,10 @@ Required:
 
 - **namespace** (String)
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_stack.k8s_core $STACK_ID
+```

--- a/docs/resources/stack_aws_role.md
+++ b/docs/resources/stack_aws_role.md
@@ -3,14 +3,17 @@
 page_title: "spacelift_stack_aws_role Resource - terraform-provider-spacelift"
 subcategory: ""
 description: |-
-  spacelift_aws_role represents cross-account IAM role delegation https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html between the Spacelift worker and an individual stack or module. If this is set, Spacelift will use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment.
+  ~> Note: spacelift_stack_aws_role is deprecated. Please use spacelift_aws_role instead. The functionality is identical.
+  spacelift_stack_aws_role represents cross-account IAM role delegation https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html between the Spacelift worker and an individual stack or module. If this is set, Spacelift will use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment.
   If you use private workers, you can also assume IAM role on the worker side using your own AWS credentials (e.g. from EC2 instance profile).
   Note: when assuming credentials for shared worker, Spacelift will use $accountName@$stackID or $accountName@$moduleID as external ID https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html and Run ID as session ID https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.
 ---
 
 # spacelift_stack_aws_role (Resource)
 
-`spacelift_aws_role` represents [cross-account IAM role delegation](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) between the Spacelift worker and an individual stack or module. If this is set, Spacelift will use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment.
+~> **Note:** `spacelift_stack_aws_role` is deprecated. Please use `spacelift_aws_role` instead. The functionality is identical.
+
+`spacelift_stack_aws_role` represents [cross-account IAM role delegation](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) between the Spacelift worker and an individual stack or module. If this is set, Spacelift will use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment.
 
 If you use private workers, you can also assume IAM role on the worker side using your own AWS credentials (e.g. from EC2 instance profile).
 

--- a/docs/resources/stack_gcp_service_account.md
+++ b/docs/resources/stack_gcp_service_account.md
@@ -3,12 +3,15 @@
 page_title: "spacelift_stack_gcp_service_account Resource - terraform-provider-spacelift"
 subcategory: ""
 description: |-
-  spacelift_gcp_service_account represents a Google Cloud Platform service account that's linked to a particular Stack or Module. These accounts are created by Spacelift on per-stack basis, and can be added as members to as many organizations and projects as needed. During a Run or a Task, temporary credentials for those service accounts are injected into the environment, which allows credential-less GCP Terraform provider setup.
+  ~> Note: spacelift_stack_gcp_service_account is deprecated. Please use spacelift_gcp_service_account instead. The functionality is identical.
+  spacelift_stack_gcp_service_account represents a Google Cloud Platform service account that's linked to a particular Stack or Module. These accounts are created by Spacelift on per-stack basis, and can be added as members to as many organizations and projects as needed. During a Run or a Task, temporary credentials for those service accounts are injected into the environment, which allows credential-less GCP Terraform provider setup.
 ---
 
 # spacelift_stack_gcp_service_account (Resource)
 
-`spacelift_gcp_service_account` represents a Google Cloud Platform service account that's linked to a particular Stack or Module. These accounts are created by Spacelift on per-stack basis, and can be added as members to as many organizations and projects as needed. During a Run or a Task, temporary credentials for those service accounts are injected into the environment, which allows credential-less GCP Terraform provider setup.
+~> **Note:** `spacelift_stack_gcp_service_account` is deprecated. Please use `spacelift_gcp_service_account` instead. The functionality is identical.
+
+`spacelift_stack_gcp_service_account` represents a Google Cloud Platform service account that's linked to a particular Stack or Module. These accounts are created by Spacelift on per-stack basis, and can be added as members to as many organizations and projects as needed. During a Run or a Task, temporary credentials for those service accounts are injected into the environment, which allows credential-less GCP Terraform provider setup.
 
 ## Example Usage
 

--- a/docs/resources/vcs_agent_pool.md
+++ b/docs/resources/vcs_agent_pool.md
@@ -35,4 +35,10 @@ resource "spacelift_vcs_agent_pool" "ghe" {
 
 - **config** (String, Sensitive) VCS agent pool configuration, encoded using base64
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_vcs_agent_pool.ghe $VCS_AGENT_POOL_ID
+```

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -34,4 +34,10 @@ resource "spacelift_webhook" "webhook" {
 - **secret** (String, Sensitive) secret used to sign each POST request so you're able to verify that the request comes from us
 - **stack_id** (String) ID of the stack which triggers the webhooks
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_webhook.webhook stack/$STACK_ID/$WEBHOOK_ID
+```

--- a/docs/resources/worker_pool.md
+++ b/docs/resources/worker_pool.md
@@ -39,4 +39,10 @@ resource "spacelift_worker_pool" "k8s-core" {
 - **config** (String, Sensitive) credentials necessary to connect WorkerPool's workers to the control plane
 - **private_key** (String, Sensitive) private key in base64
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import spacelift_worker_pool.k8s-core $WORKER_POOL_ID
+```

--- a/examples/resources/spacelift_gcp_service_account/resource.tf
+++ b/examples/resources/spacelift_gcp_service_account/resource.tf
@@ -23,5 +23,5 @@ resource "google_project" "k8s-core" {
 resource "google_project_iam_member" "k8s-core" {
   project = google_project.k8s-core.id
   role    = "roles/owner"
-  member  = "serviceAccount:${spacelift_stack_gcp_service_account.k8s-core.service_account_email}"
+  member  = "serviceAccount:${spacelift_gcp_service_account.k8s-core.service_account_email}"
 }

--- a/examples/resources/spacelift_module/resource.tf
+++ b/examples/resources/spacelift_module/resource.tf
@@ -10,9 +10,9 @@ resource "spacelift_module" "k8s-module" {
 
 # Unspecified module name and provider (repository naming scheme terraform-${provider}-${name})
 resource "spacelift_module" "example-module" {
-  administrative     = true
-  branch             = "master"
-  description        = "Example terraform module"
-  repository         = "terraform-aws-example"
-  project_root       = "example"
+  administrative = true
+  branch         = "master"
+  description    = "Example terraform module"
+  repository     = "terraform-aws-example"
+  project_root   = "example"
 }


### PR DESCRIPTION
## Description of the change

- Regenerating the docs to get the latest updates on importing and deprecations from @jmfontaine.
- Fixing a typo reported by @kamsz in https://github.com/spacelift-io/terraform-provider-spacelift/pull/267 with the `gcp_service_account` resource docs.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
