### PR TITLE
Mark new AWS resources as experimental

### DIFF
--- a/docs/resources/aws_integration.md
+++ b/docs/resources/aws_integration.md
@@ -3,11 +3,14 @@
 page_title: "spacelift_aws_integration Resource - terraform-provider-spacelift"
 subcategory: ""
 description: |-
+  Note: This resource is experimental. Please continue to use spacelift_aws_role.
   spacelift_aws_integration represents an integration with an AWS account. This integration is account-level and needs to be explicitly attached to individual stacks in order to take effect.
   Note: when assuming credentials for shared workers, Spacelift will use $accountName-$integrationID@$stackID-$suffix or $accountName-$integrationID@$moduleID-$suffix as external ID https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html and $runID@$stackID@$accountName truncated to 64 characters as session ID https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole,$suffix will be read or write.
 ---
 
 # spacelift_aws_integration (Resource)
+
+**Note:** This resource is experimental. Please continue to use `spacelift_aws_role`.
 
 `spacelift_aws_integration` represents an integration with an AWS account. This integration is account-level and needs to be explicitly attached to individual stacks in order to take effect.
 

--- a/docs/resources/aws_integration_attachment.md
+++ b/docs/resources/aws_integration_attachment.md
@@ -3,10 +3,13 @@
 page_title: "spacelift_aws_integration_attachment Resource - terraform-provider-spacelift"
 subcategory: ""
 description: |-
+  Note: This resource is experimental. Please continue to use spacelift_aws_role.
   spacelift_aws_integration_attachment represents the attachment between a reusable AWS integration and a single stack or module.
 ---
 
 # spacelift_aws_integration_attachment (Resource)
+
+**Note:** This resource is experimental. Please continue to use `spacelift_aws_role`.
 
 `spacelift_aws_integration_attachment` represents the attachment between a reusable AWS integration and a single stack or module.
 

--- a/spacelift/resource_aws_integration.go
+++ b/spacelift/resource_aws_integration.go
@@ -14,6 +14,8 @@ import (
 func resourceAWSIntegration() *schema.Resource {
 	return &schema.Resource{
 		Description: "" +
+			"**Note:** This resource is experimental. Please continue to use `spacelift_aws_role`." +
+			"\n\n" +
 			"`spacelift_aws_integration` represents an integration with an AWS " +
 			"account. This integration is account-level and needs to be explicitly " +
 			"attached to individual stacks in order to take effect." +

--- a/spacelift/resource_aws_integration_attachment.go
+++ b/spacelift/resource_aws_integration_attachment.go
@@ -17,6 +17,8 @@ import (
 func resourceAWSIntegrationAttachment() *schema.Resource {
 	return &schema.Resource{
 		Description: "" +
+			"**Note:** This resource is experimental. Please continue to use `spacelift_aws_role`." +
+			"\n\n" +
 			"`spacelift_aws_integration_attachment` represents the attachment between " +
 			"a reusable AWS integration and a single stack or module.",
 


### PR DESCRIPTION
## Description of the change

Adding a note to the resources indicating that users should continue to use `spacelift_aws_role` until the new attachments support is rolled out to all users.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] `tfplugindocs` has been run to make sure the docs are up to date.

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
