### PR TITLE
Install Terraform before running tests

### DIFF
--- a/.github/workflows/test-prod.yml
+++ b/.github/workflows/test-prod.yml
@@ -8,11 +8,20 @@ jobs:
   deployment:
     name: Test the code
     runs-on: ubuntu-latest
-    container: golang:1.18
 
     steps:
       - name: Check out repository code
         uses: actions/checkout@master
+      
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.18"
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
 
       - name: Test with coverage
         run: go test -parallel 20 -coverprofile=coverage.txt -coverpkg=./... ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,15 @@ jobs:
   deployment:
     name: Test the code
     runs-on: ubuntu-latest
-    container: golang:1.18
 
     steps:
       - name: Check out repository code
         uses: actions/checkout@master
+      
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.18"
 
       - name: Check formatting using gofmt
         run: gofmt -s -l -d .
@@ -19,6 +23,11 @@ jobs:
         run: |
           wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.46.2
           ./bin/golangci-lint run -v
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
 
       - name: Test with coverage
         run: go test -parallel 20 -coverprofile=coverage.txt -coverpkg=./... ./...


### PR DESCRIPTION
## Description of the change

We're seeing occasional test failures caused by the `terraform` binary being modified while we're trying to execute it as part of the acceptance tests (see this related issue: https://github.com/hashicorp/terraform-plugin-sdk/issues/629).

The suggested solution in the Terraform plugin developer docs is to install a version of Terraform before running `go test`, which should stop the tests from trying to download Terraform themselves.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)
- [x] Other

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] `tfplugindocs` has been run to make sure the docs are up to date.

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
