### PR TITLE
Add default value for parent space ID

### DIFF
--- a/docs/resources/space.md
+++ b/docs/resources/space.md
@@ -23,7 +23,7 @@ description: |-
 
 - `description` (String) free-form space description for users
 - `inherit_entities` (Boolean) indication whether access to this space inherits read access to entities from the parent space
-- `parent_space_id` (String) immutable ID (slug) of parent space
+- `parent_space_id` (String) immutable ID (slug) of parent space. Defaults to `root`.
 
 ### Read-Only
 

--- a/spacelift/resource_space.go
+++ b/spacelift/resource_space.go
@@ -28,8 +28,9 @@ func resourceSpace() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"parent_space_id": {
 				Type:        schema.TypeString,
-				Description: "immutable ID (slug) of parent space",
+				Description: "immutable ID (slug) of parent space. Defaults to `root`.",
 				Optional:    true,
+				Default:     "root",
 			},
 			"description": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
## Description of the change

The `spacelift_space.parent_space_id` is marked as optional but a value is actually required:

<img width="845" alt="CleanShot 2022-07-20 at 11 37 04@2x" src="https://user-images.githubusercontent.com/174728/180024142-0e10b31e-7da0-48e6-965f-34f151522137.png">

Instead of marking it as required, I chose to default to adding spaces to the root by using `root` as default. I found in [the tests for the resource type](https://github.com/spacelift-io/terraform-provider-spacelift/blob/main/spacelift/resource_space_test.go#L23). It works fine and I think that this was the intended behavior.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (non-breaking change that adds documentation)

## Related issues

None

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development
- [X] `tfplugindocs` has been run to make sure the docs are up to date.

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [x] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
