### PR TITLE
Add smart sanitization field to stack resources

### DIFF
--- a/docs/data-sources/stack.md
+++ b/docs/data-sources/stack.md
@@ -66,7 +66,7 @@ data "spacelift_stack" "k8s-core" {
 - `runner_image` (String) Name of the Docker image used to process Runs
 - `showcase` (List of Object) Showcase-related attributes (see [below for nested schema](#nestedatt--showcase))
 - `space_id` (String) ID (slug) of the space the stack is in
-- `terraform_smart_sanitization` (Boolean) Indicates whether runs on this will use terraform's sensitive value system to sanitize the outputs of Terraform state and plans in spacelift.
+- `terraform_smart_sanitization` (Boolean) Indicates whether runs on this will use terraform's sensitive value system to sanitize the outputs of Terraform state and plans in spacelift instead of sanitizing all fields.
 - `terraform_version` (String) Terraform version to use
 - `terraform_workspace` (String) Terraform workspace to select
 - `worker_pool_id` (String) ID of the worker pool to use

--- a/docs/data-sources/stack.md
+++ b/docs/data-sources/stack.md
@@ -66,6 +66,7 @@ data "spacelift_stack" "k8s-core" {
 - `runner_image` (String) Name of the Docker image used to process Runs
 - `showcase` (List of Object) Showcase-related attributes (see [below for nested schema](#nestedatt--showcase))
 - `space_id` (String) ID (slug) of the space the stack is in
+- `terraform_smart_sanitization` (Boolean) Indicates whether runs on this will use terraform's sensitive value system to sanitize the outputs of Terraform state and plans in spacelift.
 - `terraform_version` (String) Terraform version to use
 - `terraform_workspace` (String) Terraform workspace to select
 - `worker_pool_id` (String) ID of the worker pool to use

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -38,7 +38,7 @@ resource "spacelift_stack" "k8s-cluster-bitbucket-cloud" {
   name              = "Kubernetes Cluster"
   project_root      = "cluster"
   repository        = "core-infra"
-  terraform_version = "0.12.6"
+  terraform_version = "1.2.6"
 }
 
 # Terraform stack using Bitbucket Data Center as VCS
@@ -87,6 +87,19 @@ resource "spacelift_stack" "k8s-cluster-gitlab" {
   project_root      = "cluster"
   repository        = "core-infra"
   terraform_version = "0.12.6"
+}
+
+# Terraform stack using github.com as VCS and enabling smart sanitization
+resource "spacelift_stack" "k8s-cluster" {
+  administrative               = true
+  autodeploy                   = true
+  branch                       = "master"
+  description                  = "Provisions a Kubernetes cluster"
+  name                         = "Kubernetes Cluster"
+  project_root                 = "cluster"
+  repository                   = "core-infra"
+  terraform_version            = "1.2.6"
+  terraform_smart_sanitization = true
 }
 
 # CloudFormation stack using github.com as VCS
@@ -200,6 +213,7 @@ resource "spacelift_stack" "ansible-stack" {
 - `showcase` (Block List, Max: 1) (see [below for nested schema](#nestedblock--showcase))
 - `slug` (String) Allows setting the custom ID (slug) for the stack
 - `space_id` (String) ID (slug) of the space the stack is in
+- `terraform_smart_sanitization` (Boolean) Indicates whether runs on this will use terraform's sensitive value system to sanitize the outputs of Terraform state and plans in spacelift. Note: Requires the terraform version to be v1.0.1 or above. Defaults to `false`.
 - `terraform_version` (String) Terraform version to use
 - `terraform_workspace` (String) Terraform workspace to select
 - `worker_pool_id` (String) ID of the worker pool to use

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -38,7 +38,7 @@ resource "spacelift_stack" "k8s-cluster-bitbucket-cloud" {
   name              = "Kubernetes Cluster"
   project_root      = "cluster"
   repository        = "core-infra"
-  terraform_version = "1.2.6"
+  terraform_version = "0.12.6"
 }
 
 # Terraform stack using Bitbucket Data Center as VCS
@@ -213,7 +213,7 @@ resource "spacelift_stack" "ansible-stack" {
 - `showcase` (Block List, Max: 1) (see [below for nested schema](#nestedblock--showcase))
 - `slug` (String) Allows setting the custom ID (slug) for the stack
 - `space_id` (String) ID (slug) of the space the stack is in
-- `terraform_smart_sanitization` (Boolean) Indicates whether runs on this will use terraform's sensitive value system to sanitize the outputs of Terraform state and plans in spacelift. Note: Requires the terraform version to be v1.0.1 or above. Defaults to `false`.
+- `terraform_smart_sanitization` (Boolean) Indicates whether runs on this will use terraform's sensitive value system to sanitize the outputs of Terraform state and plans in spacelift instead of sanitizing all fields. Note: Requires the terraform version to be v1.0.1 or above. Defaults to `false`.
 - `terraform_version` (String) Terraform version to use
 - `terraform_workspace` (String) Terraform workspace to select
 - `worker_pool_id` (String) ID of the worker pool to use

--- a/examples/resources/spacelift_stack/resource.tf
+++ b/examples/resources/spacelift_stack/resource.tf
@@ -23,7 +23,7 @@ resource "spacelift_stack" "k8s-cluster-bitbucket-cloud" {
   name              = "Kubernetes Cluster"
   project_root      = "cluster"
   repository        = "core-infra"
-  terraform_version = "0.12.6"
+  terraform_version = "1.2.6"
 }
 
 # Terraform stack using Bitbucket Data Center as VCS
@@ -72,6 +72,19 @@ resource "spacelift_stack" "k8s-cluster-gitlab" {
   project_root      = "cluster"
   repository        = "core-infra"
   terraform_version = "0.12.6"
+}
+
+# Terraform stack using github.com as VCS and enabling smart sanitization
+resource "spacelift_stack" "k8s-cluster" {
+  administrative               = true
+  autodeploy                   = true
+  branch                       = "master"
+  description                  = "Provisions a Kubernetes cluster"
+  name                         = "Kubernetes Cluster"
+  project_root                 = "cluster"
+  repository                   = "core-infra"
+  terraform_version            = "1.2.6"
+  terraform_smart_sanitization = true
 }
 
 # CloudFormation stack using github.com as VCS

--- a/examples/resources/spacelift_stack/resource.tf
+++ b/examples/resources/spacelift_stack/resource.tf
@@ -23,7 +23,7 @@ resource "spacelift_stack" "k8s-cluster-bitbucket-cloud" {
   name              = "Kubernetes Cluster"
   project_root      = "cluster"
   repository        = "core-infra"
-  terraform_version = "1.2.6"
+  terraform_version = "0.12.6"
 }
 
 # Terraform stack using Bitbucket Data Center as VCS

--- a/spacelift/data_stack.go
+++ b/spacelift/data_stack.go
@@ -323,7 +323,7 @@ func dataStack() *schema.Resource {
 			},
 			"terraform_smart_sanitization": {
 				Type:        schema.TypeBool,
-				Description: "Indicates whether runs on this will use terraform's sensitive value system to sanitize the outputs of Terraform state and plans in spacelift.",
+				Description: "Indicates whether runs on this will use terraform's sensitive value system to sanitize the outputs of Terraform state and plans in spacelift instead of sanitizing all fields.",
 				Computed:    true,
 			},
 			"terraform_version": {

--- a/spacelift/data_stack.go
+++ b/spacelift/data_stack.go
@@ -321,6 +321,11 @@ func dataStack() *schema.Resource {
 				Description: "ID (slug) of the stack",
 				Required:    true,
 			},
+			"terraform_smart_sanitization": {
+				Type:        schema.TypeBool,
+				Description: "Indicates whether runs on this will use terraform's sensitive value system to sanitize the outputs of Terraform state and plans in spacelift.",
+				Computed:    true,
+			},
 			"terraform_version": {
 				Type:        schema.TypeString,
 				Description: "Terraform version to use",
@@ -425,6 +430,7 @@ func dataStackRead(ctx context.Context, d *schema.ResourceData, meta interface{}
 	default:
 		d.Set("terraform_version", stack.VendorConfig.Terraform.Version)
 		d.Set("terraform_workspace", stack.VendorConfig.Terraform.Workspace)
+		d.Set("terraform_smart_sanitization", stack.VendorConfig.Terraform.UseSmartSanitization)
 	}
 
 	if workerPool := stack.WorkerPool; workerPool != nil {

--- a/spacelift/data_stack_test.go
+++ b/spacelift/data_stack_test.go
@@ -17,27 +17,28 @@ func TestStackData(t *testing.T) {
 		testSteps(t, []resource.TestStep{{
 			Config: fmt.Sprintf(`
 			resource "spacelift_stack" "test" {
-				administrative      = true
-				after_apply         = ["ls -la", "rm -rf /"]
-				after_destroy       = ["echo 'after_destroy'"]
-				after_init          = ["terraform fmt -check", "tflint"]
-				after_perform       = ["echo 'after_perform'"]
-				after_plan          = ["echo 'after_plan'"]
-				autodeploy          = true
-				autoretry           = false
-				before_apply        = ["ls -la", "rm -rf /"]
-				before_destroy      = ["echo 'before_destroy'"]
-				before_init         = ["terraform fmt -check", "tflint"]
-				before_perform      = ["echo 'before_perform'"]
-				before_plan         = ["echo 'before_plan'"]
-				branch              = "master"
-				description         = "description"
-				labels              = ["one", "two"]
-				name                = "Test stack %s"
-				project_root        = "root"
-				repository          = "demo"
-				runner_image        = "custom_image:runner"
-				terraform_workspace = "bacon"
+				administrative               = true
+				after_apply                  = ["ls -la", "rm -rf /"]
+				after_destroy                = ["echo 'after_destroy'"]
+				after_init                   = ["terraform fmt -check", "tflint"]
+				after_perform                = ["echo 'after_perform'"]
+				after_plan                   = ["echo 'after_plan'"]
+				autodeploy                   = true
+				autoretry                    = false
+				before_apply                 = ["ls -la", "rm -rf /"]
+				before_destroy               = ["echo 'before_destroy'"]
+				before_init                  = ["terraform fmt -check", "tflint"]
+				before_perform               = ["echo 'before_perform'"]
+				before_plan                  = ["echo 'before_plan'"]
+				branch                       = "master"
+				description                  = "description"
+				labels                       = ["one", "two"]
+				name                         = "Test stack %s"
+				project_root                 = "root"
+				repository                   = "demo"
+				runner_image                 = "custom_image:runner"
+				terraform_workspace          = "bacon"
+				terraform_smart_sanitization = true
 			}
 			data "spacelift_stack" "test" {
 				stack_id = spacelift_stack.test.id
@@ -81,6 +82,7 @@ func TestStackData(t *testing.T) {
 				Attribute("repository", Equals("demo")),
 				Attribute("runner_image", Equals("custom_image:runner")),
 				Attribute("terraform_workspace", Equals("bacon")),
+				Attribute("terraform_smart_sanitization", Equals("true")),
 			),
 		}})
 	})
@@ -219,28 +221,29 @@ func TestStackDataSpace(t *testing.T) {
 		testSteps(t, []resource.TestStep{{
 			Config: fmt.Sprintf(`
 			resource "spacelift_stack" "test" {
-				administrative      = true
-				after_apply         = ["ls -la", "rm -rf /"]
-				after_destroy       = ["echo 'after_destroy'"]
-				after_init          = ["terraform fmt -check", "tflint"]
-				after_perform       = ["echo 'after_perform'"]
-				after_plan          = ["echo 'after_plan'"]
-				autodeploy          = true
-				autoretry           = false
-				before_apply        = ["ls -la", "rm -rf /"]
-				before_destroy      = ["echo 'before_destroy'"]
-				before_init         = ["terraform fmt -check", "tflint"]
-				before_perform      = ["echo 'before_perform'"]
-				before_plan         = ["echo 'before_plan'"]
-				branch              = "master"
-				description         = "description"
-				labels              = ["one", "two"]
-				name                = "Test stack %s"
-				project_root        = "root"
-				repository          = "demo"
-				runner_image        = "custom_image:runner"
-				space_id            = "root"
-				terraform_workspace = "bacon"
+				administrative               = true
+				after_apply                  = ["ls -la", "rm -rf /"]
+				after_destroy                = ["echo 'after_destroy'"]
+				after_init                   = ["terraform fmt -check", "tflint"]
+				after_perform                = ["echo 'after_perform'"]
+				after_plan                   = ["echo 'after_plan'"]
+				autodeploy                   = true
+				autoretry                    = false
+				before_apply                 = ["ls -la", "rm -rf /"]
+				before_destroy               = ["echo 'before_destroy'"]
+				before_init                  = ["terraform fmt -check", "tflint"]
+				before_perform               = ["echo 'before_perform'"]
+				before_plan                  = ["echo 'before_plan'"]
+				branch                       = "master"
+				description                  = "description"
+				labels                       = ["one", "two"]
+				name                         = "Test stack %s"
+				project_root                 = "root"
+				repository                   = "demo"
+				runner_image                 = "custom_image:runner"
+				space_id                     = "root"
+				terraform_workspace          = "bacon"
+				terraform_smart_sanitization = true
 			}
 
 			data "spacelift_stack" "test" {
@@ -286,6 +289,7 @@ func TestStackDataSpace(t *testing.T) {
 				Attribute("space_id", Equals("root")),
 				Attribute("runner_image", Equals("custom_image:runner")),
 				Attribute("terraform_workspace", Equals("bacon")),
+				Attribute("terraform_smart_sanitization", Equals("true")),
 			),
 		}})
 	})

--- a/spacelift/internal/structs/stack.go
+++ b/spacelift/internal/structs/stack.go
@@ -72,8 +72,9 @@ type Stack struct {
 			StackName string `graphql:"stackName"`
 		} `graphql:"... on StackConfigVendorPulumi"`
 		Terraform struct {
-			Version   *string `graphql:"version"`
-			Workspace *string `graphql:"workspace"`
+			UseSmartSanitization bool    `graphql:"useSmartSanitization"`
+			Version              *string `graphql:"version"`
+			Workspace            *string `graphql:"workspace"`
 		} `graphql:"... on StackConfigVendorTerraform"`
 	} `graphql:"vendorConfig"`
 	WorkerPool *struct {

--- a/spacelift/internal/structs/stack_input.go
+++ b/spacelift/internal/structs/stack_input.go
@@ -69,6 +69,7 @@ type PulumiInput struct {
 
 // TerraformInput represents Terraform-specific configuration.
 type TerraformInput struct {
-	Version   *graphql.String `json:"version"`
-	Workspace *graphql.String `json:"workspace"`
+	UseSmartSanitization *graphql.Boolean `json:"useSmartSanitization"`
+	Version              *graphql.String  `json:"version"`
+	Workspace            *graphql.String  `json:"workspace"`
 }

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -382,6 +382,12 @@ func resourceStack() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"terraform_smart_sanitization": {
+				Type:        schema.TypeBool,
+				Description: "Indicates whether runs on this will use terraform's sensitive value system to sanitize the outputs of Terraform state and plans in spacelift. Note: Requires the terraform version to be v1.0.1 or above. Defaults to `false`.",
+				Optional:    true,
+				Default:     false,
+			},
 			"terraform_version": {
 				Type:             schema.TypeString,
 				Description:      "Terraform version to use",
@@ -541,6 +547,7 @@ func resourceStackRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 		d.Set("pulumi", []interface{}{m})
 	default:
+		d.Set("terraform_smart_sanitization", stack.VendorConfig.Terraform.UseSmartSanitization)
 		d.Set("terraform_version", stack.VendorConfig.Terraform.Version)
 		d.Set("terraform_workspace", stack.VendorConfig.Terraform.Workspace)
 	}
@@ -784,6 +791,12 @@ func stackInput(d *schema.ResourceData) structs.StackInput {
 
 		if terraformWorkspace, ok := d.GetOk("terraform_workspace"); ok {
 			terraformConfig.Workspace = toOptionalString(terraformWorkspace)
+		}
+
+		if terraformSmartSanitization, ok := d.GetOk("terraform_smart_sanitization"); ok {
+			terraformConfig.UseSmartSanitization = toOptionalBool(terraformSmartSanitization)
+		} else {
+			terraformConfig.UseSmartSanitization = toOptionalBool(false)
 		}
 
 		ret.VendorConfig = &structs.VendorConfigInput{Terraform: terraformConfig}

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -384,7 +384,7 @@ func resourceStack() *schema.Resource {
 			},
 			"terraform_smart_sanitization": {
 				Type:        schema.TypeBool,
-				Description: "Indicates whether runs on this will use terraform's sensitive value system to sanitize the outputs of Terraform state and plans in spacelift. Note: Requires the terraform version to be v1.0.1 or above. Defaults to `false`.",
+				Description: "Indicates whether runs on this will use terraform's sensitive value system to sanitize the outputs of Terraform state and plans in spacelift instead of sanitizing all fields. Note: Requires the terraform version to be v1.0.1 or above. Defaults to `false`.",
 				Optional:    true,
 				Default:     false,
 			},

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -402,27 +402,28 @@ func TestStackResource(t *testing.T) {
 
 		before := fmt.Sprintf(`
 			resource "spacelift_stack" "test" {
-				administrative      = true
-				after_apply         = ["ls -la", "rm -rf /"]
-				after_destroy       = ["echo 'after_destroy'"]
-				after_init          = ["terraform fmt -check", "tflint"]
-				after_perform       = ["echo 'after_perform'"]
-				after_plan          = ["echo 'after_plan'"]
-				autodeploy          = true
-				before_apply        = ["ls -la", "rm -rf /"]
-				before_destroy      = ["echo 'before_destroy'"]
-				before_init         = ["terraform fmt -check", "tflint"]
-				before_perform      = ["echo 'before_perform'"]
-				before_plan         = ["echo 'before_plan'"]
-				branch              = "master"
-				description         = "bacon"
-				labels              = ["one", "two"]
-				name                = "Provider test stack %s"
-				project_root        = "root"
-				repository          = "demo"
-				runner_image        = "custom_image:runner"
-				terraform_version   = "0.12.5"
-				terraform_workspace = "bacon"
+				administrative               = true
+				after_apply                  = ["ls -la", "rm -rf /"]
+				after_destroy                = ["echo 'after_destroy'"]
+				after_init                   = ["terraform fmt -check", "tflint"]
+				after_perform                = ["echo 'after_perform'"]
+				after_plan                   = ["echo 'after_plan'"]
+				autodeploy                   = true
+				before_apply                 = ["ls -la", "rm -rf /"]
+				before_destroy               = ["echo 'before_destroy'"]
+				before_init                  = ["terraform fmt -check", "tflint"]
+				before_perform               = ["echo 'before_perform'"]
+				before_plan                  = ["echo 'before_plan'"]
+				branch                       = "master"
+				description                  = "bacon"
+				labels                       = ["one", "two"]
+				name                         = "Provider test stack %s"
+				project_root                 = "root"
+				repository                   = "demo"
+				runner_image                 = "custom_image:runner"
+				terraform_version            = "1.0.1"
+				terraform_workspace          = "bacon"
+				terraform_smart_sanitization = true
 			}
 		`, randomID)
 
@@ -455,8 +456,9 @@ func TestStackResource(t *testing.T) {
 					SetEquals("labels", "one", "two"),
 					Attribute("project_root", Equals("root")),
 					Attribute("runner_image", Equals("custom_image:runner")),
-					Attribute("terraform_version", Equals("0.12.5")),
+					Attribute("terraform_version", Equals("1.0.1")),
 					Attribute("terraform_workspace", Equals("bacon")),
+					Attribute("terraform_smart_sanitization", Equals("true")),
 				),
 			},
 			{
@@ -484,8 +486,9 @@ func TestStackResource(t *testing.T) {
 					Attribute("labels.#", Equals("0")),
 					Attribute("project_root", IsEmpty()),
 					Attribute("runner_image", IsEmpty()),
-					Attribute("terraform_version", Equals("0.12.5")),
+					Attribute("terraform_version", Equals("1.0.1")),
 					Attribute("terraform_workspace", IsEmpty()),
+					Attribute("terraform_smart_sanitization", Equals("false")),
 				),
 			},
 		})

--- a/spacelift/type_conversions.go
+++ b/spacelift/type_conversions.go
@@ -2,6 +2,14 @@ package spacelift
 
 import "github.com/shurcooL/graphql"
 
+func toBool(input interface{}) graphql.Boolean {
+	return graphql.Boolean(input.(bool))
+}
+
+func toOptionalBool(input interface{}) *graphql.Boolean {
+	return graphql.NewBoolean(toBool(input))
+}
+
 func toID(input interface{}) graphql.ID {
 	return graphql.ID(input)
 }


### PR DESCRIPTION
## Description of the change

This comit enables the ability to set smart sanitization on terraform based stacks.

If the stack uses terraform version 1.0.1 or above, spacelift will sanitize the data output from
`terraform plan` and `terraform apply` using the sensitive field values provided by terraform.


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] `tfplugindocs` has been run to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
