### PR TITLE
Change tfplugindocs to go generate in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@
 - [ ] All tests related to the changed code pass in development
 - [ ] Examples for new resources and data sources have been added
 - [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
-- [ ] `tfplugindocs` has been run to make sure the docs are up to date
+- [ ] `go generate` has been run to make sure the docs are up to date
 
 ### Code review
 


### PR DESCRIPTION
## Description of the change

Change tfplugindocs check in PR template to go generate

## Type of change

- [x] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] `tfplugindocs` has been run to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The target branch is `future` unless the change is going directly into production
