### PR TITLE
Disallow empty strings wherever they are required

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/spacelift-io/terraform-provider-spacelift
 
 require (
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0

--- a/spacelift/data_aws_integration.go
+++ b/spacelift/data_aws_integration.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataAWSIntegration() *schema.Resource {
@@ -27,9 +28,10 @@ func dataAWSIntegration() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"integration_id": {
-				Type:        schema.TypeString,
-				Description: "immutable ID of the integration",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "immutable ID of the integration",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/spacelift/data_aws_integration_attachment.go
+++ b/spacelift/data_aws_integration_attachment.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataAWSIntegrationAttachment() *schema.Resource {
@@ -21,9 +22,10 @@ func dataAWSIntegrationAttachment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"integration_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the integration to attach",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the integration to attach",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"module_id": {
 				Type:         schema.TypeString,

--- a/spacelift/data_aws_integration_attachment_external_id.go
+++ b/spacelift/data_aws_integration_attachment_external_id.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shurcooL/graphql"
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataAWSIntegrationAttachmentExternalID() *schema.Resource {
@@ -21,9 +22,10 @@ func dataAWSIntegrationAttachmentExternalID() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"integration_id": {
-				Type:        schema.TypeString,
-				Description: "immutable ID (slug) of the AWS integration",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "immutable ID (slug) of the AWS integration",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"stack_id": {
 				Type:         schema.TypeString,

--- a/spacelift/data_azure_integration_attachment.go
+++ b/spacelift/data_azure_integration_attachment.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataAzureIntegrationAttachment() *schema.Resource {
@@ -21,9 +22,10 @@ func dataAzureIntegrationAttachment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"integration_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the integration to attach",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the integration to attach",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"module_id": {
 				Type:         schema.TypeString,

--- a/spacelift/data_context.go
+++ b/spacelift/data_context.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataContext() *schema.Resource {
@@ -23,9 +24,10 @@ func dataContext() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"context_id": {
-				Type:        schema.TypeString,
-				Description: "immutable ID (slug) of the context",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "immutable ID (slug) of the context",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"description": {
 				Type:        schema.TypeString,

--- a/spacelift/data_context_attachment.go
+++ b/spacelift/data_context_attachment.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataContextAttachment() *schema.Resource {
@@ -20,9 +21,10 @@ func dataContextAttachment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"context_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the attached context",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the attached context",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"module_id": {
 				Type:         schema.TypeString,

--- a/spacelift/data_drift_detection.go
+++ b/spacelift/data_drift_detection.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataDriftDetection() *schema.Resource {
@@ -24,9 +26,10 @@ func dataDriftDetection() *schema.Resource {
 				Computed:    true,
 			},
 			"stack_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the stack for which to set up drift detection",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the stack for which to set up drift detection",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"schedule": {
 				Type:        schema.TypeList,

--- a/spacelift/data_environment_variable.go
+++ b/spacelift/data_environment_variable.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataEnvironmentVariable() *schema.Resource {
@@ -39,9 +40,10 @@ func dataEnvironmentVariable() *schema.Resource {
 				Optional:    true,
 			},
 			"name": {
-				Type:        schema.TypeString,
-				Description: "name of the environment variable",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "name of the environment variable",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"stack_id": {
 				Type:        schema.TypeString,

--- a/spacelift/data_module.go
+++ b/spacelift/data_module.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataModule() *schema.Resource {
@@ -135,9 +136,10 @@ func dataModule() *schema.Resource {
 				Computed:    true,
 			},
 			"module_id": {
-				Type:        schema.TypeString,
-				Description: "ID (slug) of the module",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "ID (slug) of the module",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"shared_accounts": {
 				Type:        schema.TypeSet,

--- a/spacelift/data_mounted_file.go
+++ b/spacelift/data_mounted_file.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataMountedFile() *schema.Resource {
@@ -48,9 +49,10 @@ func dataMountedFile() *schema.Resource {
 				Optional:     true,
 			},
 			"relative_path": {
-				Type:        schema.TypeString,
-				Description: "relative path to the mounted file",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "relative path to the mounted file",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"stack_id": {
 				Type:         schema.TypeString,

--- a/spacelift/data_policy.go
+++ b/spacelift/data_policy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataPolicy() *schema.Resource {
@@ -21,9 +22,10 @@ func dataPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"policy_id": {
-				Type:        schema.TypeString,
-				Description: "immutable ID (slug) of the policy",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "immutable ID (slug) of the policy",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"body": {
 				Type:        schema.TypeString,

--- a/spacelift/data_space.go
+++ b/spacelift/data_space.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataSpace() *schema.Resource {
@@ -19,9 +20,10 @@ func dataSpace() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"space_id": {
-				Type:        schema.TypeString,
-				Description: "immutable ID (slug) of the space",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "immutable ID (slug) of the space",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"parent_space_id": {
 				Type:        schema.TypeString,

--- a/spacelift/data_stack.go
+++ b/spacelift/data_stack.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataStack() *schema.Resource {
@@ -317,9 +318,10 @@ func dataStack() *schema.Resource {
 				Computed:    true,
 			},
 			"stack_id": {
-				Type:        schema.TypeString,
-				Description: "ID (slug) of the stack",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "ID (slug) of the stack",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"terraform_smart_sanitization": {
 				Type:        schema.TypeBool,

--- a/spacelift/data_vcs_agent_pool.go
+++ b/spacelift/data_vcs_agent_pool.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataVCSAgentPool() *schema.Resource {
@@ -21,9 +22,10 @@ func dataVCSAgentPool() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"vcs_agent_pool_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the VCS agent pool to retrieve",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the VCS agent pool to retrieve",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"description": {
 				Type:        schema.TypeString,

--- a/spacelift/data_webhook.go
+++ b/spacelift/data_webhook.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataWebhook() *schema.Resource {
@@ -46,9 +47,10 @@ func dataWebhook() *schema.Resource {
 				Optional:    true,
 			},
 			"webhook_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the webhook",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the webhook",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 		},
 	}

--- a/spacelift/data_worker_pool.go
+++ b/spacelift/data_worker_pool.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func dataWorkerPool() *schema.Resource {
@@ -36,9 +37,10 @@ func dataWorkerPool() *schema.Resource {
 				Computed:    true,
 			},
 			"worker_pool_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the worker pool",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the worker pool",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"labels": {
 				Type:     schema.TypeSet,

--- a/spacelift/internal/validations/validations.go
+++ b/spacelift/internal/validations/validations.go
@@ -1,0 +1,15 @@
+package validations
+
+import (
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+// DisallowEmptyString ensures that the given value is not an empty string.
+func DisallowEmptyString(in interface{}, path cty.Path) diag.Diagnostics {
+	if in == "" {
+		return diag.Errorf("%s must not be an empty string", path)
+	}
+
+	return nil
+}

--- a/spacelift/resource_aws_integration.go
+++ b/spacelift/resource_aws_integration.go
@@ -44,9 +44,10 @@ func resourceAWSIntegration() *schema.Resource {
 				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"role_arn": {
-				Type:        schema.TypeString,
-				Description: "ARN of the AWS IAM role to attach",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "ARN of the AWS IAM role to attach",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"generate_credentials_in_worker": {
 				Type:        schema.TypeBool,

--- a/spacelift/resource_aws_integration.go
+++ b/spacelift/resource_aws_integration.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceAWSIntegration() *schema.Resource {
@@ -37,9 +38,10 @@ func resourceAWSIntegration() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			// Required.
 			"name": {
-				Type:        schema.TypeString,
-				Description: "The friendly name of the integration",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "The friendly name of the integration",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"role_arn": {
 				Type:        schema.TypeString,

--- a/spacelift/resource_aws_integration_attachment.go
+++ b/spacelift/resource_aws_integration_attachment.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceAWSIntegrationAttachment() *schema.Resource {
@@ -33,10 +34,11 @@ func resourceAWSIntegrationAttachment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"integration_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the integration to attach",
-				Required:    true,
-				ForceNew:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the integration to attach",
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"module_id": {
 				Type:         schema.TypeString,

--- a/spacelift/resource_aws_role.go
+++ b/spacelift/resource_aws_role.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 // Deprecated: Used for backwards compatibility.
@@ -56,9 +57,10 @@ func resourceAWSRole() *schema.Resource {
 				ForceNew:     true,
 			},
 			"role_arn": {
-				Type:        schema.TypeString,
-				Description: "ARN of the AWS IAM role to attach",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "ARN of the AWS IAM role to attach",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"stack_id": {
 				Type:        schema.TypeString,

--- a/spacelift/resource_azure_integration.go
+++ b/spacelift/resource_azure_integration.go
@@ -37,10 +37,11 @@ func resourceAzureIntegration() *schema.Resource {
 				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"tenant_id": {
-				Type:        schema.TypeString,
-				Description: "The Azure AD tenant ID",
-				Required:    true,
-				ForceNew:    true,
+				Type:             schema.TypeString,
+				Description:      "The Azure AD tenant ID",
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			// Optional.
 			"default_subscription_id": {

--- a/spacelift/resource_azure_integration.go
+++ b/spacelift/resource_azure_integration.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceAzureIntegration() *schema.Resource {
@@ -30,9 +31,10 @@ func resourceAzureIntegration() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			// Required.
 			"name": {
-				Type:        schema.TypeString,
-				Description: "The friendly name of the integration",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "The friendly name of the integration",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"tenant_id": {
 				Type:        schema.TypeString,
@@ -51,8 +53,11 @@ func resourceAzureIntegration() *schema.Resource {
 			"labels": {
 				Type:        schema.TypeSet,
 				Description: "Labels to set on the integration",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
+				Optional: true,
 			},
 			// Read-only.
 			"admin_consent_provided": {

--- a/spacelift/resource_azure_integration_attachment.go
+++ b/spacelift/resource_azure_integration_attachment.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceAzureIntegrationAttachment() *schema.Resource {
@@ -30,10 +31,11 @@ func resourceAzureIntegrationAttachment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"integration_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the integration to attach",
-				Required:    true,
-				ForceNew:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the integration to attach",
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"module_id": {
 				Type:         schema.TypeString,

--- a/spacelift/resource_context.go
+++ b/spacelift/resource_context.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceContext() *schema.Resource {
@@ -36,15 +37,19 @@ func resourceContext() *schema.Resource {
 				Optional:    true,
 			},
 			"labels": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
 				Optional: true,
 			},
 			"name": {
-				Type:        schema.TypeString,
-				Description: "Name of the context - should be unique in one account",
-				Required:    true,
-				ForceNew:    true,
+				Type:             schema.TypeString,
+				Description:      "Name of the context - should be unique in one account",
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"space_id": {
 				Type:        schema.TypeString,

--- a/spacelift/resource_context_attachment.go
+++ b/spacelift/resource_context_attachment.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceContextAttachment() *schema.Resource {
@@ -31,10 +32,11 @@ func resourceContextAttachment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"context_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the context to attach",
-				Required:    true,
-				ForceNew:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the context to attach",
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"module_id": {
 				Type:         schema.TypeString,

--- a/spacelift/resource_drift_detection.go
+++ b/spacelift/resource_drift_detection.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceDriftDetection() *schema.Resource {
@@ -33,14 +34,18 @@ func resourceDriftDetection() *schema.Resource {
 				Optional:    true,
 			},
 			"stack_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the stack for which to set up drift detection",
-				Required:    true,
-				ForceNew:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the stack for which to set up drift detection",
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"schedule": {
-				Type:        schema.TypeList,
-				Elem:        &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
 				MinItems:    1,
 				Description: "List of cron schedule expressions based on which drift detection should be triggered.",
 				Required:    true,

--- a/spacelift/resource_environment_variable.go
+++ b/spacelift/resource_environment_variable.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceEnvironmentVariable() *schema.Resource {
@@ -53,10 +54,11 @@ func resourceEnvironmentVariable() *schema.Resource {
 				ForceNew:    true,
 			},
 			"name": {
-				Type:        schema.TypeString,
-				Description: "Name of the environment variable",
-				Required:    true,
-				ForceNew:    true,
+				Type:             schema.TypeString,
+				Description:      "Name of the environment variable",
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"stack_id": {
 				Type:        schema.TypeString,
@@ -71,6 +73,7 @@ func resourceEnvironmentVariable() *schema.Resource {
 				Sensitive:        true,
 				Required:         true,
 				ForceNew:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"write_only": {
 				Type:        schema.TypeBool,

--- a/spacelift/resource_gcp_service_account.go
+++ b/spacelift/resource_gcp_service_account.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 // Deprecated: Used for backwards compatibility.
@@ -61,8 +62,11 @@ func resourceGCPServiceAccount() *schema.Resource {
 				ForceNew:    true,
 			},
 			"token_scopes": {
-				Type:        schema.TypeSet,
-				Elem:        &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
 				MinItems:    1,
 				Description: "List of scopes that will be requested when generating temporary GCP service account credentials",
 				Required:    true,

--- a/spacelift/resource_module.go
+++ b/spacelift/resource_module.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceModule() *schema.Resource {
@@ -49,9 +50,10 @@ func resourceModule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"project": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The name of the Azure DevOps project",
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "The name of the Azure DevOps project",
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
@@ -65,9 +67,10 @@ func resourceModule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"namespace": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The Bitbucket project containing the repository",
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "The Bitbucket project containing the repository",
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
@@ -81,9 +84,10 @@ func resourceModule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"namespace": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The Bitbucket project containing the repository",
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "The Bitbucket project containing the repository",
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
@@ -107,9 +111,10 @@ func resourceModule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"namespace": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The GitHub organization / user the repository belongs to",
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "The GitHub organization / user the repository belongs to",
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
@@ -123,16 +128,20 @@ func resourceModule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"namespace": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The GitLab namespace containing the repository",
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "The GitLab namespace containing the repository",
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
 			},
 			"labels": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
 				Optional: true,
 			},
 			"name": {
@@ -158,9 +167,10 @@ func resourceModule() *schema.Resource {
 				Default:     false,
 			},
 			"repository": {
-				Type:        schema.TypeString,
-				Description: "Name of the repository, without the owner part",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "Name of the repository, without the owner part",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"shared_accounts": {
 				Type:        schema.TypeSet,

--- a/spacelift/resource_mounted_file.go
+++ b/spacelift/resource_mounted_file.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceMountedFile() *schema.Resource {
@@ -45,6 +46,7 @@ func resourceMountedFile() *schema.Resource {
 				Sensitive:        true,
 				Required:         true,
 				ForceNew:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"context_id": {
 				Type:         schema.TypeString,

--- a/spacelift/resource_policy.go
+++ b/spacelift/resource_policy.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 var policyTypes = []string{
@@ -51,19 +52,24 @@ func resourcePolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:        schema.TypeString,
-				Description: "Name of the policy - should be unique in one account",
-				Required:    true,
-				ForceNew:    true,
+				Type:             schema.TypeString,
+				Description:      "Name of the policy - should be unique in one account",
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"body": {
-				Type:        schema.TypeString,
-				Description: "Body of the policy",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "Body of the policy",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"labels": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
 				Optional: true,
 			},
 			"space_id": {

--- a/spacelift/resource_policy_attachment.go
+++ b/spacelift/resource_policy_attachment.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourcePolicyAttachment() *schema.Resource {
@@ -34,10 +35,11 @@ func resourcePolicyAttachment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"policy_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the policy to attach",
-				Required:    true,
-				ForceNew:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the policy to attach",
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"module_id": {
 				Type:         schema.TypeString,

--- a/spacelift/resource_run.go
+++ b/spacelift/resource_run.go
@@ -8,6 +8,7 @@ import (
 	"github.com/shurcooL/graphql"
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceRun() *schema.Resource {
@@ -22,10 +23,11 @@ func resourceRun() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"stack_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the stack on which the run is to be triggered.",
-				Required:    true,
-				ForceNew:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the stack on which the run is to be triggered.",
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"commit_sha": {
 				Description: "The commit SHA for which to trigger a run.",

--- a/spacelift/resource_space.go
+++ b/spacelift/resource_space.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceSpace() *schema.Resource {
@@ -38,9 +39,10 @@ func resourceSpace() *schema.Resource {
 				Optional:    true,
 			},
 			"name": {
-				Type:        schema.TypeString,
-				Description: "name of the space",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "name of the space",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"inherit_entities": {
 				Type:        schema.TypeBool,

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceStack() *schema.Resource {
@@ -49,9 +50,10 @@ func resourceStack() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"playbook": {
-							Type:        schema.TypeString,
-							Description: "The playbook Ansible should run.",
-							Required:    true,
+							Type:             schema.TypeString,
+							Description:      "The playbook Ansible should run.",
+							Required:         true,
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
@@ -59,32 +61,47 @@ func resourceStack() *schema.Resource {
 			"after_apply": {
 				Type:        schema.TypeList,
 				Description: "List of after-apply scripts",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
+				Optional: true,
 			},
 			"after_destroy": {
 				Type:        schema.TypeList,
 				Description: "List of after-destroy scripts",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
+				Optional: true,
 			},
 			"after_init": {
 				Type:        schema.TypeList,
 				Description: "List of after-init scripts",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
+				Optional: true,
 			},
 			"after_perform": {
 				Type:        schema.TypeList,
 				Description: "List of after-perform scripts",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
+				Optional: true,
 			},
 			"after_plan": {
 				Type:        schema.TypeList,
 				Description: "List of after-plan scripts",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
+				Optional: true,
 			},
 			"autodeploy": {
 				Type:        schema.TypeBool,
@@ -112,9 +129,10 @@ func resourceStack() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"project": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The name of the Azure DevOps project",
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "The name of the Azure DevOps project",
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
@@ -122,37 +140,53 @@ func resourceStack() *schema.Resource {
 			"before_apply": {
 				Type:        schema.TypeList,
 				Description: "List of before-apply scripts",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
+				Optional: true,
 			},
 			"before_destroy": {
 				Type:        schema.TypeList,
 				Description: "List of before-destroy scripts",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
+				Optional: true,
 			},
 			"before_init": {
 				Type:        schema.TypeList,
 				Description: "List of before-init scripts",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
+				Optional: true,
 			},
 			"before_perform": {
 				Type:        schema.TypeList,
 				Description: "List of before-perform scripts",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
+				Optional: true,
 			},
 			"before_plan": {
 				Type:        schema.TypeList,
 				Description: "List of before-plan scripts",
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
+				Optional: true,
 			},
 			"branch": {
-				Type:        schema.TypeString,
-				Description: "GitHub branch to apply changes to",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "GitHub branch to apply changes to",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"bitbucket_cloud": {
 				Type:          schema.TypeList,
@@ -163,9 +197,10 @@ func resourceStack() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"namespace": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The Bitbucket project containing the repository",
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "The Bitbucket project containing the repository",
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
@@ -179,9 +214,10 @@ func resourceStack() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"namespace": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The Bitbucket project containing the repository",
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "The Bitbucket project containing the repository",
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
@@ -195,24 +231,28 @@ func resourceStack() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"entry_template_file": {
-							Type:        schema.TypeString,
-							Description: "Template file `cloudformation package` will be called on",
-							Required:    true,
+							Type:             schema.TypeString,
+							Description:      "Template file `cloudformation package` will be called on",
+							Required:         true,
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 						"region": {
-							Type:        schema.TypeString,
-							Description: "AWS region to use",
-							Required:    true,
+							Type:             schema.TypeString,
+							Description:      "AWS region to use",
+							Required:         true,
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 						"stack_name": {
-							Type:        schema.TypeString,
-							Description: "CloudFormation stack name",
-							Required:    true,
+							Type:             schema.TypeString,
+							Description:      "CloudFormation stack name",
+							Required:         true,
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 						"template_bucket": {
-							Type:        schema.TypeString,
-							Description: "S3 bucket to save CloudFormation templates to",
-							Required:    true,
+							Type:             schema.TypeString,
+							Description:      "S3 bucket to save CloudFormation templates to",
+							Required:         true,
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
@@ -243,9 +283,10 @@ func resourceStack() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"namespace": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The GitHub organization / user the repository belongs to",
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "The GitHub organization / user the repository belongs to",
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
@@ -259,9 +300,10 @@ func resourceStack() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"namespace": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "The GitLab namespace containing the repository",
+							Type:             schema.TypeString,
+							Required:         true,
+							Description:      "The GitLab namespace containing the repository",
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
@@ -290,9 +332,10 @@ func resourceStack() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"namespace": {
-							Type:        schema.TypeString,
-							Description: "Namespace of the Kubernetes cluster to run commands on. Leave empty for multi-namespace Stacks.",
-							Optional:    true,
+							Type:             schema.TypeString,
+							Description:      "Namespace of the Kubernetes cluster to run commands on. Leave empty for multi-namespace Stacks.",
+							Optional:         true,
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
@@ -310,9 +353,10 @@ func resourceStack() *schema.Resource {
 				ForceNew:    true,
 			},
 			"name": {
-				Type:        schema.TypeString,
-				Description: "Name of the stack - should be unique in one account",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "Name of the stack - should be unique in one account",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"project_root": {
 				Type:        schema.TypeString,
@@ -334,14 +378,16 @@ func resourceStack() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"login_url": {
-							Type:        schema.TypeString,
-							Description: "State backend to log into on Run initialize.",
-							Required:    true,
+							Type:             schema.TypeString,
+							Description:      "State backend to log into on Run initialize.",
+							Required:         true,
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 						"stack_name": {
-							Type:        schema.TypeString,
-							Description: "Pulumi stack name to use with the state backend.",
-							Required:    true,
+							Type:             schema.TypeString,
+							Description:      "Pulumi stack name to use with the state backend.",
+							Required:         true,
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},
@@ -354,9 +400,10 @@ func resourceStack() *schema.Resource {
 				Computed:    true,
 			},
 			"repository": {
-				Type:        schema.TypeString,
-				Description: "Name of the repository, without the owner part",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "Name of the repository, without the owner part",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"runner_image": {
 				Type:        schema.TypeString,
@@ -370,8 +417,9 @@ func resourceStack() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"namespace": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
 					},
 				},

--- a/spacelift/resource_stack_destructor.go
+++ b/spacelift/resource_stack_destructor.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceStackDestructor() *schema.Resource {
@@ -38,9 +39,10 @@ func resourceStackDestructor() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"stack_id": {
-				Type:        schema.TypeString,
-				Description: "ID of the stack to delete and destroy on destruction",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "ID of the stack to delete and destroy on destruction",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"deactivated": {
 				Type:        schema.TypeBool,

--- a/spacelift/resource_vcs_agent_pool.go
+++ b/spacelift/resource_vcs_agent_pool.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceVCSAgentPool() *schema.Resource {
@@ -34,9 +35,10 @@ func resourceVCSAgentPool() *schema.Resource {
 				Optional:    true,
 			},
 			"name": {
-				Type:        schema.TypeString,
-				Description: "Name of the VCS agent pool, must be unique within an account",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "Name of the VCS agent pool, must be unique within an account",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"config": {
 				Type:        schema.TypeString,

--- a/spacelift/resource_webhook.go
+++ b/spacelift/resource_webhook.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceWebhook() *schema.Resource {
@@ -59,9 +60,10 @@ func resourceWebhook() *schema.Resource {
 				Default:     true,
 			},
 			"endpoint": {
-				Type:        schema.TypeString,
-				Description: "endpoint to send the POST request to",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "endpoint to send the POST request to",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"module_id": {
 				Type:         schema.TypeString,

--- a/spacelift/resource_worker_pool.go
+++ b/spacelift/resource_worker_pool.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
 func resourceWorkerPool() *schema.Resource {
@@ -41,9 +42,10 @@ func resourceWorkerPool() *schema.Resource {
 				Sensitive:   true,
 			},
 			"name": {
-				Type:        schema.TypeString,
-				Description: "name of the worker pool",
-				Required:    true,
+				Type:             schema.TypeString,
+				Description:      "name of the worker pool",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
 			"csr": {
 				Type:        schema.TypeString,
@@ -70,8 +72,11 @@ func resourceWorkerPool() *schema.Resource {
 				Computed:    true,
 			},
 			"labels": {
-				Type:     schema.TypeSet,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
 				Optional: true,
 			},
 		},


### PR DESCRIPTION
## Description of the change

HCL treats empty string and null interchangeably so embedded blocks with just empty strings as values will fail on interface conversions. While at it, we can add validations everywhere an empty string would not make sense.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes #340 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] `tfplugindocs` has been run to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
