### PR TITLE
Update docs related to v1 vs v2 AWS resources

### DIFF
--- a/docs/resources/aws_integration.md
+++ b/docs/resources/aws_integration.md
@@ -3,14 +3,11 @@
 page_title: "spacelift_aws_integration Resource - terraform-provider-spacelift"
 subcategory: ""
 description: |-
-  Note: This resource is experimental. Please continue to use spacelift_aws_role.
   spacelift_aws_integration represents an integration with an AWS account. This integration is account-level and needs to be explicitly attached to individual stacks in order to take effect.
   Note: when assuming credentials for shared workers, Spacelift will use $accountName-$integrationID@$stackID-$suffix or $accountName-$integrationID@$moduleID-$suffix as external ID https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html and $runID@$stackID@$accountName truncated to 64 characters as session ID https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole,$suffix will be read or write.
 ---
 
 # spacelift_aws_integration (Resource)
-
-**Note:** This resource is experimental. Please continue to use `spacelift_aws_role`.
 
 `spacelift_aws_integration` represents an integration with an AWS account. This integration is account-level and needs to be explicitly attached to individual stacks in order to take effect.
 

--- a/docs/resources/aws_integration_attachment.md
+++ b/docs/resources/aws_integration_attachment.md
@@ -3,13 +3,10 @@
 page_title: "spacelift_aws_integration_attachment Resource - terraform-provider-spacelift"
 subcategory: ""
 description: |-
-  Note: This resource is experimental. Please continue to use spacelift_aws_role.
   spacelift_aws_integration_attachment represents the attachment between a reusable AWS integration and a single stack or module.
 ---
 
 # spacelift_aws_integration_attachment (Resource)
-
-**Note:** This resource is experimental. Please continue to use `spacelift_aws_role`.
 
 `spacelift_aws_integration_attachment` represents the attachment between a reusable AWS integration and a single stack or module.
 

--- a/docs/resources/aws_role.md
+++ b/docs/resources/aws_role.md
@@ -3,12 +3,15 @@
 page_title: "spacelift_aws_role Resource - terraform-provider-spacelift"
 subcategory: ""
 description: |-
+  NOTE: while this resource continues to work, we have replaced it with the spacelift_aws_integration resource. The new resource allows integrations to be shared by multiple stacks/modules and also supports separate read vs write roles. Please use the spacelift_aws_integration resource instead.
   spacelift_aws_role represents cross-account IAM role delegation https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html between the Spacelift worker and an individual stack or module. If this is set, Spacelift will use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment.
   If you use private workers, you can also assume IAM role on the worker side using your own AWS credentials (e.g. from EC2 instance profile).
   Note: when assuming credentials for shared worker, Spacelift will use $accountName@$stackID or $accountName@$moduleID as external ID https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html and $runID@$stackID@$accountName truncated to 64 characters as session ID https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.
 ---
 
 # spacelift_aws_role (Resource)
+
+**NOTE:** while this resource continues to work, we have replaced it with the `spacelift_aws_integration` resource. The new resource allows integrations to be shared by multiple stacks/modules and also supports separate read vs write roles. Please use the `spacelift_aws_integration` resource instead.
 
 `spacelift_aws_role` represents [cross-account IAM role delegation](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) between the Spacelift worker and an individual stack or module. If this is set, Spacelift will use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment.
 

--- a/docs/resources/stack_aws_role.md
+++ b/docs/resources/stack_aws_role.md
@@ -4,6 +4,7 @@ page_title: "spacelift_stack_aws_role Resource - terraform-provider-spacelift"
 subcategory: ""
 description: |-
   ~> Note: spacelift_stack_aws_role is deprecated. Please use spacelift_aws_role instead. The functionality is identical.
+  NOTE: while this resource continues to work, we have replaced it with the spacelift_aws_integration resource. The new resource allows integrations to be shared by multiple stacks/modules and also supports separate read vs write roles. Please use the spacelift_aws_integration resource instead.
   spacelift_stack_aws_role represents cross-account IAM role delegation https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html between the Spacelift worker and an individual stack or module. If this is set, Spacelift will use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment.
   If you use private workers, you can also assume IAM role on the worker side using your own AWS credentials (e.g. from EC2 instance profile).
   Note: when assuming credentials for shared worker, Spacelift will use $accountName@$stackID or $accountName@$moduleID as external ID https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html and $runID@$stackID@$accountName truncated to 64 characters as session ID https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.
@@ -12,6 +13,8 @@ description: |-
 # spacelift_stack_aws_role (Resource)
 
 ~> **Note:** `spacelift_stack_aws_role` is deprecated. Please use `spacelift_aws_role` instead. The functionality is identical.
+
+**NOTE:** while this resource continues to work, we have replaced it with the `spacelift_aws_integration` resource. The new resource allows integrations to be shared by multiple stacks/modules and also supports separate read vs write roles. Please use the `spacelift_aws_integration` resource instead.
 
 `spacelift_stack_aws_role` represents [cross-account IAM role delegation](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) between the Spacelift worker and an individual stack or module. If this is set, Spacelift will use AWS STS to assume the supplied IAM role and put its temporary credentials in the runtime environment.
 

--- a/spacelift/resource_aws_integration.go
+++ b/spacelift/resource_aws_integration.go
@@ -15,8 +15,6 @@ import (
 func resourceAWSIntegration() *schema.Resource {
 	return &schema.Resource{
 		Description: "" +
-			"**Note:** This resource is experimental. Please continue to use `spacelift_aws_role`." +
-			"\n\n" +
 			"`spacelift_aws_integration` represents an integration with an AWS " +
 			"account. This integration is account-level and needs to be explicitly " +
 			"attached to individual stacks in order to take effect." +

--- a/spacelift/resource_aws_integration_attachment.go
+++ b/spacelift/resource_aws_integration_attachment.go
@@ -18,8 +18,6 @@ import (
 func resourceAWSIntegrationAttachment() *schema.Resource {
 	return &schema.Resource{
 		Description: "" +
-			"**Note:** This resource is experimental. Please continue to use `spacelift_aws_role`." +
-			"\n\n" +
 			"`spacelift_aws_integration_attachment` represents the attachment between " +
 			"a reusable AWS integration and a single stack or module.",
 

--- a/spacelift/resource_aws_role.go
+++ b/spacelift/resource_aws_role.go
@@ -29,6 +29,9 @@ func resourceStackAWSRole() *schema.Resource {
 func resourceAWSRole() *schema.Resource {
 	return &schema.Resource{
 		Description: "" +
+			"**NOTE:** while this resource continues to work, we have replaced it with the `spacelift_aws_integration` " +
+			"resource. The new resource allows integrations to be shared by multiple stacks/modules " +
+			"and also supports separate read vs write roles. Please use the `spacelift_aws_integration` resource instead.\n\n" +
 			"`spacelift_aws_role` represents [cross-account IAM role delegation](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) " +
 			"between the Spacelift worker and an individual stack or module. " +
 			"If this is set, Spacelift will use AWS STS to assume the supplied IAM role and " +


### PR DESCRIPTION
## Description of the change

I've removed the experimental notes against the new v2 resources and added a deprecation note against the v1 resources. I haven't actually marked the old resources as deprecated yet because I don't want to immediately start generating warnings in logs for customers until we're completely certain we want to deprecate the old resources.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The target branch is `future` unless the change is going directly into production
