### PR TITLE
Fix worker_pool datasource example

### DIFF
--- a/docs/data-sources/worker_pool.md
+++ b/docs/data-sources/worker_pool.md
@@ -14,7 +14,7 @@ description: |-
 
 ```terraform
 data "spacelift_worker_pool" "k8s-core" {
-  worker_pool_id = "k8s-core"
+  worker_pool_id = "01G1KTZ4BA86RBN3XNN3YK9EWT"
 }
 ```
 

--- a/examples/data-sources/spacelift_worker_pool/data-source.tf
+++ b/examples/data-sources/spacelift_worker_pool/data-source.tf
@@ -1,3 +1,3 @@
 data "spacelift_worker_pool" "k8s-core" {
-  worker_pool_id = "k8s-core"
+  worker_pool_id = "01G1KTZ4BA86RBN3XNN3YK9EWT"
 }


### PR DESCRIPTION
## Description of the change

Use an actual ID instead of the slug in the example.

## Type of change

- [x] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
