### PR TITLE
Better error message when using spacelift_current_space

### DIFF
--- a/spacelift/data_current_space.go
+++ b/spacelift/data_current_space.go
@@ -50,6 +50,9 @@ func dataCurrentSpaceRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	variables := map[string]interface{}{"id": toID(strings.TrimRight(stackID, "/"))}
 	if err := meta.(*internal.Client).Query(ctx, "StackRead", &query, variables); err != nil {
+		if strings.Contains(err.Error(), "denied") {
+			return diag.Errorf("could not query for stack: %v, is this stack administrative?", err)
+		}
 		return diag.Errorf("could not query for stack: %v", err)
 	}
 


### PR DESCRIPTION
## Description of the change

When running in a non-administrative stack this data source cannot be accessed, but error message is not so clear.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The target branch is `future` unless the change is going directly into production
