### PR TITLE
Mention spaces in error messages

### DIFF
--- a/spacelift/internal/error.go
+++ b/spacelift/internal/error.go
@@ -11,5 +11,5 @@ func FromSpaceliftError(err error) error {
 	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
 		return err
 	}
-	return fmt.Errorf("%w - is it an administrative stack?", err)
+	return fmt.Errorf("%w - is it an administrative stack in the appropriate space?", err)
 }


### PR DESCRIPTION
## Description of the change

Improved error messaging to indicate errors due to stacks being in wrong spaces.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
