### PR TITLE
Remove deprecated field from StackDependency API

### DIFF
--- a/spacelift/internal/structs/stack_dependency.go
+++ b/spacelift/internal/structs/stack_dependency.go
@@ -2,10 +2,14 @@ package structs
 
 import "github.com/shurcooL/graphql"
 
+type StackDependencyDetail struct {
+	ID string `graphql:"id"`
+}
+
 type StackDependency struct {
-	ID               string `graphql:"id"`
-	StackID          string `graphql:"stackId"`
-	DependsOnStackID string `graphql:"dependsOnStackId"`
+	ID             string                `graphql:"id"`
+	Stack          StackDependencyDetail `graphql:"stack"`
+	DependsOnStack StackDependencyDetail `graphql:"dependsOnStack"`
 }
 
 type StackDependencyInput struct {

--- a/spacelift/resource_stack_dependency.go
+++ b/spacelift/resource_stack_dependency.go
@@ -60,7 +60,7 @@ func resourceStackDependencyCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("could not create stack dependency: %s", err)
 	}
 
-	d.SetId(path.Join(query.StackDependency.StackID, query.StackDependency.ID))
+	d.SetId(path.Join(query.StackDependency.Stack.ID, query.StackDependency.ID))
 
 	return resourceStackDependencyRead(ctx, d, meta)
 }
@@ -101,8 +101,8 @@ func resourceStackDependencyRead(ctx context.Context, d *schema.ResourceData, me
 		return nil
 	}
 
-	d.Set("stack_id", query.Stack.Dependency.StackID)
-	d.Set("depends_on_stack_id", query.Stack.Dependency.DependsOnStackID)
+	d.Set("stack_id", query.Stack.Dependency.Stack.ID)
+	d.Set("depends_on_stack_id", query.Stack.Dependency.DependsOnStack.ID)
 
 	return nil
 }


### PR DESCRIPTION
## Description of the change

We have modified the backend API and deprecated two fields (`StackID`, `DependsOnStackID`). Let's not use those fields anymore.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The target branch is `future` unless the change is going directly into production
