### PR TITLE
Support for after-run hooks

### DIFF
--- a/docs/data-sources/stack.md
+++ b/docs/data-sources/stack.md
@@ -32,6 +32,7 @@ data "spacelift_stack" "k8s-core" {
 - `after_init` (List of String) List of after-init scripts
 - `after_perform` (List of String) List of after-perform scripts
 - `after_plan` (List of String) List of after-plan scripts
+- `after_run` (List of String) List of after-run scripts
 - `before_apply` (List of String) List of before-apply scripts
 - `before_destroy` (List of String) List of before-destroy scripts
 - `before_init` (List of String) List of before-init scripts

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -184,6 +184,7 @@ resource "spacelift_stack" "ansible-stack" {
 - `after_init` (List of String) List of after-init scripts
 - `after_perform` (List of String) List of after-perform scripts
 - `after_plan` (List of String) List of after-plan scripts
+- `after_run` (List of String) List of after-run scripts
 - `ansible` (Block List, Max: 1) Ansible-specific configuration. Presence means this Stack is an Ansible Stack. (see [below for nested schema](#nestedblock--ansible))
 - `autodeploy` (Boolean) Indicates whether changes to this stack can be automatically deployed. Defaults to `false`.
 - `autoretry` (Boolean) Indicates whether obsolete proposed changes should automatically be retried. Defaults to `false`.

--- a/spacelift/data_stack.go
+++ b/spacelift/data_stack.go
@@ -71,6 +71,12 @@ func dataStack() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
 			},
+			"after_run": {
+				Type:        schema.TypeList,
+				Description: "List of after-run scripts",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+			},
 			"autodeploy": {
 				Type:        schema.TypeBool,
 				Description: "indicates whether changes to this stack can be automatically deployed",
@@ -370,6 +376,7 @@ func dataStackRead(ctx context.Context, d *schema.ResourceData, meta interface{}
 	d.Set("after_init", stack.AfterInit)
 	d.Set("after_perform", stack.AfterPerform)
 	d.Set("after_plan", stack.AfterPlan)
+	d.Set("after_run", stack.AfterRun)
 	d.Set("autodeploy", stack.Autodeploy)
 	d.Set("autoretry", stack.Autoretry)
 	d.Set("aws_assume_role_policy_statement", stack.Integrations.AWS.AssumeRolePolicyStatement)

--- a/spacelift/data_stack_test.go
+++ b/spacelift/data_stack_test.go
@@ -23,6 +23,7 @@ func TestStackData(t *testing.T) {
 				after_init                   = ["terraform fmt -check", "tflint"]
 				after_perform                = ["echo 'after_perform'"]
 				after_plan                   = ["echo 'after_plan'"]
+				after_run                    = ["echo 'after_run'"]
 				autodeploy                   = true
 				autoretry                    = false
 				before_apply                 = ["ls -la", "rm -rf /"]
@@ -60,6 +61,8 @@ func TestStackData(t *testing.T) {
 				Attribute("after_perform.0", Equals("echo 'after_perform'")),
 				Attribute("after_plan.#", Equals("1")),
 				Attribute("after_plan.0", Equals("echo 'after_plan'")),
+				Attribute("after_run.#", Equals("1")),
+				Attribute("after_run.0", Equals("echo 'after_run'")),
 				Attribute("autodeploy", Equals("true")),
 				Attribute("autoretry", Equals("false")),
 				Attribute("before_apply.#", Equals("2")),

--- a/spacelift/internal/structs/stack.go
+++ b/spacelift/internal/structs/stack.go
@@ -29,6 +29,7 @@ type Stack struct {
 	AfterInit           []string      `graphql:"afterInit"`
 	AfterPerform        []string      `graphql:"afterPerform"`
 	AfterPlan           []string      `graphql:"afterPlan"`
+	AfterRun            []string      `graphql:"afterRun"`
 	Autodeploy          bool          `graphql:"autodeploy"`
 	Autoretry           bool          `graphql:"autoretry"`
 	BeforeApply         []string      `graphql:"beforeApply"`

--- a/spacelift/internal/structs/stack_input.go
+++ b/spacelift/internal/structs/stack_input.go
@@ -10,6 +10,7 @@ type StackInput struct {
 	AfterInit           *[]graphql.String  `json:"afterInit"`
 	AfterPerform        *[]graphql.String  `json:"afterPerform"`
 	AfterPlan           *[]graphql.String  `json:"afterPlan"`
+	AfterRun            *[]graphql.String  `json:"afterRun"`
 	Autodeploy          graphql.Boolean    `json:"autodeploy"`
 	Autoretry           graphql.Boolean    `json:"autoretry"`
 	BeforeApply         *[]graphql.String  `json:"beforeApply"`

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -103,6 +103,15 @@ func resourceStack() *schema.Resource {
 				},
 				Optional: true,
 			},
+			"after_run": {
+				Type:        schema.TypeList,
+				Description: "List of after-run scripts",
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validations.DisallowEmptyString,
+				},
+				Optional: true,
+			},
 			"autodeploy": {
 				Type:        schema.TypeBool,
 				Description: "Indicates whether changes to this stack can be automatically deployed. Defaults to `false`.",
@@ -534,6 +543,7 @@ func resourceStackRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("after_init", stack.AfterInit)
 	d.Set("after_perform", stack.AfterPerform)
 	d.Set("after_plan", stack.AfterPlan)
+	d.Set("after_run", stack.AfterRun)
 	d.Set("autodeploy", stack.Autodeploy)
 	d.Set("autoretry", stack.Autoretry)
 	d.Set("aws_assume_role_policy_statement", stack.Integrations.AWS.AssumeRolePolicyStatement)
@@ -696,6 +706,14 @@ func stackInput(d *schema.ResourceData) structs.StackInput {
 		}
 	}
 	ret.AfterPlan = &afterPlans
+
+	afterRuns := []graphql.String{}
+	if commands, ok := d.GetOk("after_run"); ok {
+		for _, cmd := range commands.([]interface{}) {
+			afterRuns = append(afterRuns, graphql.String(cmd.(string)))
+		}
+	}
+	ret.AfterRun = &afterRuns
 
 	beforeApplies := []graphql.String{}
 	if commands, ok := d.GetOk("before_apply"); ok {

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -25,6 +25,7 @@ func TestStackResource(t *testing.T) {
 					after_init            = ["terraform fmt -check", "tflint"]
 					after_perform         = ["echo 'after_perform'"]
 					after_plan            = ["echo 'after_plan'"]
+					after_run             = ["echo 'after_run'"]
 					autodeploy            = true
 					autoretry             = false
 					before_apply          = ["ls -la", "rm -rf /"]
@@ -65,6 +66,8 @@ func TestStackResource(t *testing.T) {
 					Attribute("after_perform.0", Equals("echo 'after_perform'")),
 					Attribute("after_plan.#", Equals("1")),
 					Attribute("after_plan.0", Equals("echo 'after_plan'")),
+					Attribute("after_run.#", Equals("1")),
+					Attribute("after_run.0", Equals("echo 'after_run'")),
 					Attribute("administrative", Equals("true")),
 					Attribute("autodeploy", Equals("true")),
 					Attribute("autoretry", Equals("false")),


### PR DESCRIPTION
## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The target branch is `future` unless the change is going directly into production
