### PR TITLE
Deprecate github_action_deploy and add allow_run_promotion as a replacement

### DIFF
--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -185,6 +185,7 @@ resource "spacelift_stack" "ansible-stack" {
 - `after_perform` (List of String) List of after-perform scripts
 - `after_plan` (List of String) List of after-plan scripts
 - `after_run` (List of String) List of after-run scripts
+- `allow_run_promotion` (Boolean) Allows promotion for proposed runs (GitHub users can deploy from the Checks API as well as from the spacelift UI). Defaults to `true`.
 - `ansible` (Block List, Max: 1) Ansible-specific configuration. Presence means this Stack is an Ansible Stack. (see [below for nested schema](#nestedblock--ansible))
 - `autodeploy` (Boolean) Indicates whether changes to this stack can be automatically deployed. Defaults to `false`.
 - `autoretry` (Boolean) Indicates whether obsolete proposed changes should automatically be retried. Defaults to `false`.
@@ -199,7 +200,7 @@ resource "spacelift_stack" "ansible-stack" {
 - `cloudformation` (Block List, Max: 1) CloudFormation-specific configuration. Presence means this Stack is a CloudFormation Stack. (see [below for nested schema](#nestedblock--cloudformation))
 - `description` (String) Free-form stack description for users
 - `enable_local_preview` (Boolean) Indicates whether local preview runs can be triggered on this Stack. Defaults to `false`.
-- `github_action_deploy` (Boolean) Indicates whether GitHub users can deploy from the Checks API. Defaults to `true`.
+- `github_action_deploy` (Boolean, Deprecated) Indicates whether GitHub users can deploy from the Checks API. Defaults to `true`.
 - `github_enterprise` (Block List, Max: 1) VCS settings for [GitHub custom application](https://docs.spacelift.io/integrations/source-control/github#setting-up-the-custom-application) (see [below for nested schema](#nestedblock--github_enterprise))
 - `gitlab` (Block List, Max: 1) GitLab VCS settings (see [below for nested schema](#nestedblock--gitlab))
 - `import_state` (String, Sensitive) State file to upload when creating a new stack

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -86,6 +86,7 @@ func TestStackResource(t *testing.T) {
 					Attribute("branch", Equals("master")),
 					Attribute("description", Equals("old description")),
 					Attribute("github_action_deploy", Equals("true")),
+					Attribute("allow_run_promotion", Equals("true")),
 					SetEquals("labels", "one", "two"),
 					Attribute("name", StartsWith("Provider test stack")),
 					Attribute("project_root", Equals("root")),
@@ -527,6 +528,55 @@ func TestStackResource(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("can set run promotion", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		const resourceName = "spacelift_stack.test"
+
+		testSteps(t, []resource.TestStep{
+			{
+				// test deprecated
+				Config: fmt.Sprintf(`
+					resource "spacelift_stack" "test" {
+						administrative        = true
+						branch                = "master"
+						import_state          = "{}"
+						labels                = ["one", "two"]
+						name                  = "Provider test stack %s"
+						project_root          = "root"
+						repository            = "demo"
+						github_action_deploy  = false
+					}
+				`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("github_action_deploy", Equals("false")),
+					Attribute("allow_run_promotion", Equals("false")),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "spacelift_stack" "test" {
+						administrative        = true
+						branch                = "master"
+						import_state          = "{}"
+						labels                = ["one", "two"]
+						name                  = "Provider test stack %s"
+						project_root          = "root"
+						repository            = "demo"
+						allow_run_promotion   = false
+					}
+				`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("allow_run_promotion", Equals("false")),
+					Attribute("github_action_deploy", Equals("false")),
+				),
+			},
+		})
+
+	})
 }
 
 func TestStackResourceSpace(t *testing.T) {
@@ -603,6 +653,7 @@ func TestStackResourceSpace(t *testing.T) {
 					Attribute("branch", Equals("master")),
 					Attribute("description", Equals("old description")),
 					Attribute("github_action_deploy", Equals("true")),
+					Attribute("allow_run_promotion", Equals("true")),
 					SetEquals("labels", "one", "two"),
 					Attribute("name", StartsWith("Provider test stack")),
 					Attribute("project_root", Equals("root")),


### PR DESCRIPTION
- Add allow_run_promotion attribute
- Deprecate github_action_deploy

## Description of the change

> Description here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The target branch is `future` unless the change is going directly into production
