### PR TITLE
Refer to allow run promotion in the github_action_deploy description

### DIFF
--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -199,7 +199,7 @@ resource "spacelift_stack" "ansible-stack" {
 - `cloudformation` (Block List, Max: 1) CloudFormation-specific configuration. Presence means this Stack is a CloudFormation Stack. (see [below for nested schema](#nestedblock--cloudformation))
 - `description` (String) Free-form stack description for users
 - `enable_local_preview` (Boolean) Indicates whether local preview runs can be triggered on this Stack. Defaults to `false`.
-- `github_action_deploy` (Boolean) Indicates whether GitHub users can deploy from the Checks API. Defaults to `true`.
+- `github_action_deploy` (Boolean) Indicates whether GitHub users can deploy from the Checks API. Defaults to `true`. This is called allow run promotion in the UI.
 - `github_enterprise` (Block List, Max: 1) VCS settings for [GitHub custom application](https://docs.spacelift.io/integrations/source-control/github#setting-up-the-custom-application) (see [below for nested schema](#nestedblock--github_enterprise))
 - `gitlab` (Block List, Max: 1) GitLab VCS settings (see [below for nested schema](#nestedblock--gitlab))
 - `import_state` (String, Sensitive) State file to upload when creating a new stack

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -279,7 +279,7 @@ func resourceStack() *schema.Resource {
 			},
 			"github_action_deploy": {
 				Type:        schema.TypeBool,
-				Description: "Indicates whether GitHub users can deploy from the Checks API. Defaults to `true`.",
+				Description: "Indicates whether GitHub users can deploy from the Checks API. Defaults to `true`. This is called allow run promotion in the UI.",
 				Optional:    true,
 				Default:     true,
 			},


### PR DESCRIPTION
## Type of change

- [x] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
- [ ] The target branch is `future` unless the change is going directly into production
