### PR TITLE
Better error message when importing missing stack

### DIFF
--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -858,7 +858,7 @@ func resourceStackImport(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if stack == nil {
-		return nil, fmt.Errorf("stack with ID %q does not exist", stackID)
+		return nil, fmt.Errorf("stack with ID %q does not exist (or you may not have access to it)", stackID)
 	}
 
 	if err := structs.PopulateStack(d, stack); err != nil {

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -2,6 +2,7 @@ package spacelift
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -1040,6 +1041,29 @@ func TestStackResourceSpace(t *testing.T) {
 					"spacelift_stack.test",
 					SetEquals("labels"),
 				),
+			},
+		})
+	})
+
+	t.Run("importing non-existent resource", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		stackID := fmt.Sprintf("non-existent-stack-%s", resourceName)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch                = "master"
+					name                  = "Provider test stack %s"
+					project_root          = "root"
+					repository            = "demo"
+				}
+			`, randomID),
+				ImportState:   true,
+				ResourceName:  "spacelift_stack.test",
+				ImportStateId: stackID,
+				ExpectError:   regexp.MustCompile(fmt.Sprintf("stack with ID %q does not exist", stackID)),
 			},
 		})
 	})

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -1063,7 +1063,7 @@ func TestStackResourceSpace(t *testing.T) {
 				ImportState:   true,
 				ResourceName:  "spacelift_stack.test",
 				ImportStateId: stackID,
-				ExpectError:   regexp.MustCompile(fmt.Sprintf("stack with ID %q does not exist", stackID)),
+				ExpectError:   regexp.MustCompile(fmt.Sprintf(`stack with ID %q does not exist \(or you may not have access to it\)`, stackID)),
 			},
 		})
 	})


### PR DESCRIPTION
## Description of the change

The terraform import handling for stacks was reusing the `resourceStackRead()` function, which sets the ID to an empty string if no stack is found. To solve this I've pulled out query for a stack and updating the state based on a stack struct into separate functions, and I've updated the import handling to detect when the stack can't be found an output a decent error message.

I pulled the `PopulateStack()` function into the structs package to follow the pattern we've taken for the scheduled task structs.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

- Fixes [#405](https://github.com/spacelift-io/terraform-provider-spacelift/issues/405)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [x] Changes have been reviewed by at least one other engineer
- [x] The target branch is `future` unless the change is going directly into production
