### PR TITLE
Clarify worker_pool_id is required in self-hosting

### DIFF
--- a/docs/resources/module.md
+++ b/docs/resources/module.md
@@ -58,7 +58,7 @@ resource "spacelift_module" "example-module" {
 - `shared_accounts` (Set of String) List of the accounts (subdomains) which should have access to the Module
 - `space_id` (String) ID (slug) of the space the module is in
 - `terraform_provider` (String) The module provider will by default be inferred from the repository name if it follows the terraform-provider-name naming convention. However, if the repository doesn't follow this convention, or you gave the module a custom name, you can provide the provider name here.
-- `worker_pool_id` (String) ID of the worker pool to use
+- `worker_pool_id` (String) ID of the worker pool to use. NOTE: worker_pool_id is required when using a self-hosted instance of Spacelift.
 
 ### Read-Only
 

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -218,7 +218,7 @@ resource "spacelift_stack" "ansible-stack" {
 - `terraform_smart_sanitization` (Boolean) Indicates whether runs on this will use terraform's sensitive value system to sanitize the outputs of Terraform state and plans in spacelift instead of sanitizing all fields. Note: Requires the terraform version to be v1.0.1 or above. Defaults to `false`.
 - `terraform_version` (String) Terraform version to use
 - `terraform_workspace` (String) Terraform workspace to select
-- `worker_pool_id` (String) ID of the worker pool to use
+- `worker_pool_id` (String) ID of the worker pool to use. NOTE: worker_pool_id is required when using a self-hosted instance of Spacelift.
 
 ### Read-Only
 

--- a/spacelift/resource_module.go
+++ b/spacelift/resource_module.go
@@ -199,7 +199,7 @@ func resourceModule() *schema.Resource {
 			},
 			"worker_pool_id": {
 				Type:        schema.TypeString,
-				Description: "ID of the worker pool to use",
+				Description: "ID of the worker pool to use. NOTE: worker_pool_id is required when using a self-hosted instance of Spacelift.",
 				Optional:    true,
 			},
 		},

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -465,7 +465,7 @@ func resourceStack() *schema.Resource {
 			},
 			"worker_pool_id": {
 				Type:        schema.TypeString,
-				Description: "ID of the worker pool to use",
+				Description: "ID of the worker pool to use. NOTE: worker_pool_id is required when using a self-hosted instance of Spacelift.",
 				Optional:    true,
 			},
 		},


### PR DESCRIPTION
## Description of the change

Self-hosting instances don't have a concept of a default worker pool, so the worker pool always needs to be specified for stacks and modules.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
