### PR TITLE
Add integration_id to AWS, Azure integrations list

### DIFF
--- a/spacelift/data_aws_integrations.go
+++ b/spacelift/data_aws_integrations.go
@@ -98,7 +98,9 @@ func flattenDataIntegrationsList(integrations []*structs.AWSIntegration) []map[s
 	mapped := make([]map[string]interface{}, len(integrations))
 
 	for index, integration := range integrations {
-		mapped[index] = integration.ToMap()
+		integrationToMap := integration.ToMap()
+		integrationToMap["integration_id"] = integration.ID
+		mapped[index] = integrationToMap
 	}
 
 	return mapped

--- a/spacelift/data_aws_integrations_test.go
+++ b/spacelift/data_aws_integrations_test.go
@@ -72,13 +72,17 @@ func labelsAsString(labels []string) string {
 func awsIntegrationChecks(i *structs.AWSIntegration) []resource.TestCheckFunc {
 	return []resource.TestCheckFunc{
 		Resource("data.spacelift_aws_integrations.test",
-			Nested("integrations", CheckInList(Attribute("name", Equals(i.Name)))),
-			Nested("integrations", CheckInList(Attribute("integration_id", IsNotEmpty()))),
-			Nested("integrations", CheckInList(Attribute("role_arn", Equals(i.RoleARN)))),
-			Nested("integrations", CheckInList(Attribute("space_id", Equals(i.Space)))),
-			Nested("integrations", CheckInList(Attribute("duration_seconds", Equals(fmt.Sprintf("%d", i.DurationSeconds))))),
-			Nested("integrations", CheckInList(Attribute("generate_credentials_in_worker", Equals(fmt.Sprintf("%t", i.GenerateCredentialsInWorker))))),
-			Nested("integrations", CheckInList(SetEquals("labels", i.Labels...))),
+			Nested("integrations",
+				CheckInList(
+					Attribute("name", Equals(i.Name)),
+					Attribute("integration_id", IsNotEmpty()),
+					Attribute("role_arn", Equals(i.RoleARN)),
+					Attribute("space_id", Equals(i.Space)),
+					Attribute("duration_seconds", Equals(fmt.Sprintf("%d", i.DurationSeconds))),
+					Attribute("generate_credentials_in_worker", Equals(fmt.Sprintf("%t", i.GenerateCredentialsInWorker))),
+					SetEquals("labels", i.Labels...),
+				),
+			),
 		),
 	}
 }

--- a/spacelift/data_aws_integrations_test.go
+++ b/spacelift/data_aws_integrations_test.go
@@ -69,14 +69,16 @@ func labelsAsString(labels []string) string {
 	return fmt.Sprintf(`["%s"]`, strings.Join(labels, `", "`))
 }
 
-func awsIntegrationChecks(first *structs.AWSIntegration) []resource.TestCheckFunc {
-	resourceName := fmt.Sprintf("spacelift_aws_integration.%s", first.Name)
+func awsIntegrationChecks(i *structs.AWSIntegration) []resource.TestCheckFunc {
 	return []resource.TestCheckFunc{
-		Resource(resourceName, Attribute("name", Equals(first.Name))),
-		Resource(resourceName, Attribute("role_arn", Equals(first.RoleARN))),
-		Resource(resourceName, Attribute("space_id", Equals(first.Space))),
-		Resource(resourceName, Attribute("duration_seconds", Equals(fmt.Sprintf("%d", first.DurationSeconds)))),
-		Resource(resourceName, Attribute("generate_credentials_in_worker", Equals(fmt.Sprintf("%t", first.GenerateCredentialsInWorker)))),
-		Resource(resourceName, SetEquals("labels", first.Labels...)),
+		Resource("data.spacelift_aws_integrations.test",
+			Nested("integrations", CheckInList(Attribute("name", Equals(i.Name)))),
+			Nested("integrations", CheckInList(Attribute("integration_id", IsNotEmpty()))),
+			Nested("integrations", CheckInList(Attribute("role_arn", Equals(i.RoleARN)))),
+			Nested("integrations", CheckInList(Attribute("space_id", Equals(i.Space)))),
+			Nested("integrations", CheckInList(Attribute("duration_seconds", Equals(fmt.Sprintf("%d", i.DurationSeconds))))),
+			Nested("integrations", CheckInList(Attribute("generate_credentials_in_worker", Equals(fmt.Sprintf("%t", i.GenerateCredentialsInWorker))))),
+			Nested("integrations", CheckInList(SetEquals("labels", i.Labels...))),
+		),
 	}
 }

--- a/spacelift/data_azure_integrations.go
+++ b/spacelift/data_azure_integrations.go
@@ -121,7 +121,9 @@ func flattenDataAzureIntegrationsList(integrations []*structs.AzureIntegration) 
 	mapped := make([]map[string]interface{}, len(integrations))
 
 	for index, integration := range integrations {
-		mapped[index] = integration.ToMap()
+		integrationToMap := integration.ToMap()
+		integrationToMap["integration_id"] = integration.ID
+		mapped[index] = integrationToMap
 	}
 
 	return mapped

--- a/spacelift/data_azure_integrations_test.go
+++ b/spacelift/data_azure_integrations_test.go
@@ -73,12 +73,18 @@ func azureIntegrationToResource(i *structs.AzureIntegration) string {
 }
 
 func azureIntegrationChecks(i *structs.AzureIntegration) []resource.TestCheckFunc {
-	resourceName := fmt.Sprintf("spacelift_azure_integration.%s", i.Name)
 	return []resource.TestCheckFunc{
-		Resource(resourceName, Attribute("name", Equals(i.Name))),
-		Resource(resourceName, Attribute("tenant_id", Equals(i.TenantID))),
-		Resource(resourceName, Attribute("default_subscription_id", Equals(*i.DefaultSubscriptionID))),
-		Resource(resourceName, SetEquals("labels", i.Labels...)),
-		Resource(resourceName, Attribute("space_id", Equals(i.Space))),
+		Resource("data.spacelift_azure_integrations.test",
+			Nested("integrations",
+				CheckInList(
+					Attribute("name", Equals(i.Name)),
+					Attribute("tenant_id", Equals(i.TenantID)),
+					Attribute("default_subscription_id", Equals(*i.DefaultSubscriptionID)),
+					SetEquals("labels", i.Labels...),
+					Attribute("space_id", Equals(i.Space)),
+					Attribute("integration_id", IsNotEmpty()),
+				),
+			),
+		),
 	}
 }

--- a/spacelift/internal/testhelpers/helpers.go
+++ b/spacelift/internal/testhelpers/helpers.go
@@ -108,52 +108,53 @@ func Attribute(name string, check ValueCheck) AttributeCheck {
 // The nested attributes will be stripped of the attributeName prefix.
 func Nested(attributeName string, check AttributeCheck) AttributeCheck {
 	return func(m map[string]string) error {
-		filtered := make(map[string]string, len(m))
-		for key, value := range m {
-			if strings.HasPrefix(key, attributeName) {
-				filtered[strings.TrimLeft(key, attributeName+".")] = value
-			}
-		}
-		return check(filtered)
+		filteredAttributes := filter(attributeName, m)
+		trimmedAttributes := trimPrefix(attributeName, filteredAttributes)
+		return check(trimmedAttributes)
 	}
 }
 
 // CheckInList will group attributes by index and run the check on each group.
 // If check passes for a single group, the check will pass.
-func CheckInList(check AttributeCheck) AttributeCheck {
+func CheckInList(checks ...AttributeCheck) AttributeCheck {
 	return func(flattenedAttributes map[string]string) error {
 		nestedAttributes := make([]map[string]string, len(flattenedAttributes))
 		for key, value := range flattenedAttributes {
 			index := strings.Split(key, ".")[0]
 			indexInt, err := strconv.Atoi(index)
+			// if attribute doesn't start with an index, we skip it
 			if err != nil {
 				continue
 			}
 			if nestedAttributes[indexInt] == nil {
 				nestedAttributes[indexInt] = make(map[string]string)
 			}
-			nestedAttributes[indexInt][strings.TrimLeft(key, index+".")] = value
+			nestedAttributes[indexInt][strings.TrimPrefix(key, index+".")] = value
 		}
 
-		for _, nestedAttribute := range nestedAttributes {
-			for key, value := range nestedAttribute {
-				println(key, value)
-			}
-
-		}
-
-		// since we don't know in which order the attributes will be returned, we iterate through all
-		// and check if any of them matches the check
-		var err error
-		for _, nestedAttribute := range nestedAttributes {
-			err = check(nestedAttribute)
-			// if we found matching attributes, we return nil
-			if err == nil {
-				return nil
+		// if one of the checks fail, we return the error
+		for _, check := range checks {
+			if err := singleCheck(nestedAttributes, check); err != nil {
+				return err
 			}
 		}
-		return err
+
+		return nil
 	}
+}
+
+// singleCheck runs a check on a single nested attribute.
+// if it passes for one of the attributes, it will return nil.
+func singleCheck(nestedAttributes []map[string]string, check AttributeCheck) error {
+	var err error
+	for _, nestedAttribute := range nestedAttributes {
+		err = check(nestedAttribute)
+		// if we found matching attributes, we return nil
+		if err == nil {
+			return nil
+		}
+	}
+	return err
 }
 
 // AttributeNotPresent ensures that an attribute is not set on the resource.
@@ -316,4 +317,23 @@ func SetDoesNotContain(name string, values ...string) AttributeCheck {
 
 		return nil
 	}
+}
+
+// trimPrefix will trim the prefix from all keys in the map.
+func trimPrefix(prefix string, m map[string]string) map[string]string {
+	trimmed := make(map[string]string, len(m))
+	for key, value := range m {
+		trimmed[strings.TrimPrefix(key, prefix+".")] = value
+	}
+	return trimmed
+}
+
+func filter(prefix string, m map[string]string) map[string]string {
+	filtered := make(map[string]string, len(m))
+	for key, value := range m {
+		if strings.HasPrefix(key, prefix) {
+			filtered[key] = value
+		}
+	}
+	return filtered
 }


### PR DESCRIPTION
## Description of the change

This is a bugfix there `integration_id` is missing from the data sources. I've also added some helpers that help asserting nested attributes and checking lists of items for content

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
