### PR TITLE
Clarify the purpose of the `write_only` argument of the `spacelift_environment_variable` resource type

### DIFF
--- a/docs/resources/environment_variable.md
+++ b/docs/resources/environment_variable.md
@@ -51,7 +51,7 @@ resource "spacelift_environment_variable" "core-kubeconfig" {
 - `module_id` (String) ID of the module on which the environment variable is defined
 - `stack_id` (String) ID of the stack on which the environment variable is defined
 - `value` (String, Sensitive) Value of the environment variable. Defaults to an empty string.
-- `write_only` (Boolean) Indicates whether the value can be read back outside a Run. Defaults to `true`.
+- `write_only` (Boolean) Indicates whether the value is secret or not. Defaults to `true`.
 
 ### Read-Only
 

--- a/spacelift/resource_environment_variable.go
+++ b/spacelift/resource_environment_variable.go
@@ -77,7 +77,7 @@ func resourceEnvironmentVariable() *schema.Resource {
 			},
 			"write_only": {
 				Type:        schema.TypeBool,
-				Description: "Indicates whether the value can be read back outside a Run. Defaults to `true`.",
+				Description: "Indicates whether the value is secret or not. Defaults to `true`.",
 				Optional:    true,
 				Default:     true,
 				ForceNew:    true,


### PR DESCRIPTION
## Description of the change

Clarify the purpose of the `write_only` argument of the `spacelift_environment_variable` resource type.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Related issues

None

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
