### PR TITLE
Explain ips datasource doesn't include workers

### DIFF
--- a/docs/data-sources/ips.md
+++ b/docs/data-sources/ips.md
@@ -3,12 +3,12 @@
 page_title: "spacelift_ips Data Source - terraform-provider-spacelift"
 subcategory: ""
 description: |-
-  spacelift_ips returns the list of Spacelift's outgoing IP addresses, which you can use to whitelist connections coming from the Spacelift's "mothership".
+  spacelift_ips returns the list of Spacelift's outgoing IP addresses, which you can use to whitelist connections coming from the Spacelift's "mothership". NOTE: this does not include the IP addresses of the workers in Spacelift's public worker pool. If you need to ensure that requests made during runs originate from a known set of IP addresses, please consider setting up a private worker pool https://docs.spacelift.io/concepts/worker-pools.
 ---
 
 # spacelift_ips (Data Source)
 
-`spacelift_ips` returns the list of Spacelift's outgoing IP addresses, which you can use to whitelist connections coming from the Spacelift's "mothership".
+`spacelift_ips` returns the list of Spacelift's outgoing IP addresses, which you can use to whitelist connections coming from the Spacelift's "mothership". **NOTE:** this does not include the IP addresses of the workers in Spacelift's public worker pool. If you need to ensure that requests made during runs originate from a known set of IP addresses, please consider setting up a [private worker pool](https://docs.spacelift.io/concepts/worker-pools).
 
 ## Example Usage
 

--- a/spacelift/data_ips.go
+++ b/spacelift/data_ips.go
@@ -14,7 +14,10 @@ func dataIPs() *schema.Resource {
 		Description: "" +
 			"`spacelift_ips` returns the list of Spacelift's outgoing IP addresses, " +
 			"which you can use to whitelist connections coming from the " +
-			"Spacelift's \"mothership\".",
+			"Spacelift's \"mothership\". **NOTE:** this does not include the IP addresses " +
+			"of the workers in Spacelift's public worker pool. If you need to ensure " +
+			"that requests made during runs originate from a known set of IP addresses, " +
+			"please consider setting up a [private worker pool](https://docs.spacelift.io/concepts/worker-pools).",
 		ReadContext: ipsRead,
 		Schema: map[string]*schema.Schema{
 			"ips": {


### PR DESCRIPTION
## Description of the change

Adding a note to the description of the `spacelift_ips` data source to make it more obvious that this doesn't include the IPs of the public worker pool, and to link to the docs on setting up private worker pools.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
