### PR TITLE
Add space ID to space not found error message

### DIFF
--- a/spacelift/data_space.go
+++ b/spacelift/data_space.go
@@ -60,7 +60,7 @@ func dataSpaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}
 		Space *structs.Space `graphql:"space(id: $id)"`
 	}
 
-  spaceID := d.Get("space_id")
+	spaceID := d.Get("space_id")
 
 	variables := map[string]interface{}{"id": toID(spaceID)}
 	if err := meta.(*internal.Client).Query(ctx, "SpaceRead", &query, variables); err != nil {

--- a/spacelift/data_space.go
+++ b/spacelift/data_space.go
@@ -60,14 +60,16 @@ func dataSpaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}
 		Space *structs.Space `graphql:"space(id: $id)"`
 	}
 
-	variables := map[string]interface{}{"id": toID(d.Get("space_id"))}
+  spaceID := d.Get("space_id")
+
+	variables := map[string]interface{}{"id": toID(spaceID)}
 	if err := meta.(*internal.Client).Query(ctx, "SpaceRead", &query, variables); err != nil {
 		return diag.Errorf("could not query for space: %v", err)
 	}
 
 	space := query.Space
 	if space == nil {
-		return diag.Errorf("space not found")
+		return diag.Errorf("could not find space %s", spaceID)
 	}
 
 	d.SetId(space.ID)

--- a/spacelift/resource_space.go
+++ b/spacelift/resource_space.go
@@ -120,7 +120,7 @@ func resourceSpaceRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	space := query.Space
 	if space == nil {
-		return diag.Errorf("space not found")
+		return diag.Errorf("could not find space %s", d.Id())
 	}
 
 	d.SetId(space.ID)


### PR DESCRIPTION
## Description of the change

Customer is receiving the following error: `Planning failed. Terraform encountered an error while generating this plan. ╷ │ Error: space not found │ │ ╵`

Lets add the space ID to the error message to make troubleshooting easier.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
