### PR TITLE
feat: add debug flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift"
@@ -10,7 +12,14 @@ var commit = "dev"
 var version = "dev"
 
 func main() {
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
 	plugin.Serve(&plugin.ServeOpts{
+		ProviderAddr: "spacelift.io/spacelift-io/spacelift",
+		Debug:        debug,
 		ProviderFunc: spacelift.Provider(commit, version),
 	})
 }


### PR DESCRIPTION
## Description of the change

This add support a `-debug` flag so we could enable debug mode. See [terraform doc](https://developer.hashicorp.com/terraform/plugin/debugging#enabling-debugging-in-a-provider) for more details.

That allows us to run the provider in debug mode, and make terraform attach a running provider using `TF_REATTACH_PROVIDERS `. Thus we could add breakpoints and debug the provider at runtime.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
