### PR TITLE
Add `webhook_url` to Bitbucket Cloud integration data source

### DIFF
--- a/docs/data-sources/bitbucket_cloud_integration.md
+++ b/docs/data-sources/bitbucket_cloud_integration.md
@@ -23,3 +23,4 @@ data "spacelift_bitbucket_cloud_integration" "bitbucket_cloud_integration" {}
 
 - `id` (String) The ID of this resource.
 - `username` (String) Bitbucket Cloud username
+- `webhook_url` (String) Bitbucket Cloud integration webhook URL

--- a/spacelift/data_bitbucket_cloud_integration.go
+++ b/spacelift/data_bitbucket_cloud_integration.go
@@ -10,9 +10,11 @@ import (
 )
 
 var bitbucketCloudFields = struct {
-	Username string
+	Username   string
+	WebhookURL string
 }{
-	Username: "username",
+	Username:   "username",
+	WebhookURL: "webhook_url",
 }
 
 func dataBitbucketCloudIntegration() *schema.Resource {
@@ -27,6 +29,11 @@ func dataBitbucketCloudIntegration() *schema.Resource {
 				Description: "Bitbucket Cloud username",
 				Computed:    true,
 			},
+			bitbucketCloudFields.WebhookURL: {
+				Type:        schema.TypeString,
+				Description: "Bitbucket Cloud integration webhook URL",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -34,7 +41,8 @@ func dataBitbucketCloudIntegration() *schema.Resource {
 func dataBitbucketCloudIntegrationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var query struct {
 		BitbucketCloudIntegration *struct {
-			Username string `graphql:"username"`
+			Username   string `graphql:"username"`
+			WebhookURL string `graphql:"webhookUrl"`
 		} `graphql:"bitbucketCloudIntegration"`
 	}
 
@@ -49,6 +57,7 @@ func dataBitbucketCloudIntegrationRead(ctx context.Context, d *schema.ResourceDa
 
 	d.SetId("spacelift_bitbucket_cloud_integration_id") // TF expects id to be set otherwise it will fail
 	d.Set(bitbucketCloudFields.Username, bitbucketCloudIntegration.Username)
+	d.Set(bitbucketCloudFields.WebhookURL, bitbucketCloudIntegration.WebhookURL)
 
 	return nil
 }

--- a/spacelift/data_bitbucket_cloud_integration_test.go
+++ b/spacelift/data_bitbucket_cloud_integration_test.go
@@ -9,13 +9,24 @@ import (
 )
 
 func TestBitbucketCloudIntegrationData(t *testing.T) {
-	testSteps(t, []resource.TestStep{{
-		Config: `
+	testSteps(t, []resource.TestStep{
+		{
+			Config: `
 			data "spacelift_bitbucket_cloud_integration" "test" {}
 		`,
-		Check: Resource(
-			"data.spacelift_bitbucket_cloud_integration.test",
-			Attribute("username", IsNotEmpty()),
-		),
-	}})
+			Check: Resource(
+				"data.spacelift_bitbucket_cloud_integration.test",
+				Attribute("username", IsNotEmpty()),
+			),
+		},
+		{
+			Config: `
+			data "spacelift_bitbucket_cloud_integration" "test" {}
+		`,
+			Check: Resource(
+				"data.spacelift_bitbucket_cloud_integration.test",
+				Attribute("webhook_url", IsNotEmpty()),
+			),
+		},
+	})
 }


### PR DESCRIPTION
## Description of the change

Expose Bitbucket Cloud integration webhook URL.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
