### PR TITLE
Enable releasing beta versions of provider

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -7,6 +7,9 @@ on:
       providerType:
         description: 'Provider type'
         required: true
+      ref:
+          description: 'The branch, tag or SHA to use'
+          required: true
 
 jobs:
   goreleaser:
@@ -21,6 +24,8 @@ jobs:
           exit 1
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,0 +1,67 @@
+name: Release beta
+
+# Beta releases are triggered manually to a specific provider from spacelift-io inputs
+on:
+  workflow_dispatch:
+    inputs:
+      providerType:
+        description: 'Provider type'
+        required: true
+
+jobs:
+  goreleaser:
+    name: Release beta
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validation for provider type
+        if: ${{ inputs.providerType == 'spacelift' }}
+        run: |
+          echo "It is not possible to release a provider with the name 'spacelift' to the Spacelift registry using manual workflow."
+          exit 1
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with: { go-version: 1.19 }
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v5
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Run GoReleaser to create draft release
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          args: release --clean --snapshot
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install spacectl
+        uses: spacelift-io/setup-spacectl@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release to Spacelift registry (preprod)
+        run: spacectl provider create-version --type=${{ inputs.providerType }}
+        env:
+          GPG_KEY_ID: ${{ steps.import_gpg.outputs.keyid }}
+          SPACELIFT_API_KEY_ENDPOINT: https://spacelift-io.app.spacelift.dev
+          SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_PREPROD_API_KEY_ID }}
+          SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_PREPROD_API_KEY_SECRET }}
+
+      - name: Release to Spacelift registry (prod)
+        run: spacectl provider create-version --type=${{ inputs.providerType }}
+        env:
+          GPG_KEY_ID: ${{ steps.import_gpg.outputs.keyid }}
+          SPACELIFT_API_KEY_ENDPOINT: https://spacelift-io.app.spacelift.io
+          SPACELIFT_API_KEY_ID: ${{ secrets.SPACELIFT_PROD_API_KEY_ID }}
+          SPACELIFT_API_KEY_SECRET: ${{ secrets.SPACELIFT_PROD_API_KEY_SECRET }}


### PR DESCRIPTION
## Description of the change

A GH Action to allow us to publish beta versions of terraform provider manually.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
