### PR TITLE
Use correct retry logic when handling AWS roles and their attatchments

### DIFF
--- a/spacelift/resource_aws_integration_attachment.go
+++ b/spacelift/resource_aws_integration_attachment.go
@@ -79,7 +79,7 @@ func resourceAWSIntegrationAttachmentCreate(ctx context.Context, d *schema.Resou
 	var err error
 	for i := 0; i < 5; i++ {
 		err = resourceAWSIntegrationAttachmentAttach(ctx, meta.(*internal.Client), projectID, d)
-		if err == nil || !strings.Contains(err.Error(), "could not assume") || i == 4 {
+		if err == nil || !strings.Contains(err.Error(), "you need to configure trust relationship") || i == 4 {
 			break
 		}
 

--- a/spacelift/resource_aws_role.go
+++ b/spacelift/resource_aws_role.go
@@ -113,7 +113,7 @@ func resourceAWSRoleCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	for i := 0; i < 5; i++ {
 		err = resourceAWSRoleSet(ctx, meta.(*internal.Client), ID, d)
-		if err == nil || !strings.Contains(err.Error(), "could not assume") || i == 4 {
+		if err == nil || !strings.Contains(err.Error(), "you need to configure trust relationship") || i == 4 {
 			break
 		}
 


### PR DESCRIPTION
## Description of the change

We recently updated the error message returned from our server to help clarify to users of the spacelift UI what actions they need to take to resolve their issue. However we missed updating the retry loop here specifically checking for the text of the old error.

I will be making a comment internally too to ensure that any future changes to those error messages are also reflected here in the provider.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

Fixes #493 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
