### PR TITLE
Multi VCS - add missing webhook_url for GitHub (#477)

### DIFF
--- a/docs/data-sources/github_enterprise_integration.md
+++ b/docs/data-sources/github_enterprise_integration.md
@@ -33,3 +33,4 @@ data "spacelift_github_enterprise_integration" "github_enterprise_integration" {
 - `name` (String) Github integration name
 - `space_id` (String) Github integration space id
 - `webhook_secret` (String) Github integration webhook secret
+- `webhook_url` (String) Github integration webhook url

--- a/spacelift/data_github_enterprise_integration.go
+++ b/spacelift/data_github_enterprise_integration.go
@@ -19,6 +19,7 @@ const (
 	ghEnterpriseAppID         = "app_id"
 	ghEnterpriseAPIHost       = "api_host"
 	ghEnterpriseWebhookSecret = "webhook_secret"
+	ghEnterpriseWebhookURL    = "webhook_url"
 
 	defaultGHEIntegrationID = "github-enterprise-default-integration"
 )
@@ -73,6 +74,11 @@ func dataGithubEnterpriseIntegration() *schema.Resource {
 				Description: "Github integration webhook secret",
 				Computed:    true,
 			},
+			ghEnterpriseWebhookURL: {
+				Type:        schema.TypeString,
+				Description: "Github integration webhook url",
+				Computed:    true,
+			},
 			ghEnterpriseAppID: {
 				Type:        schema.TypeString,
 				Description: "Github integration app id",
@@ -88,6 +94,7 @@ func dataGithubEnterpriseIntegrationRead(ctx context.Context, d *schema.Resource
 			AppID         string `graphql:"appID"`
 			APIHost       string `graphql:"apiHost"`
 			WebhookSecret string `graphql:"webhookSecret"`
+			WebhookURL    string `graphql:"webhookUrl"`
 			ID            string `graphql:"id"`
 			Name          string `graphql:"name"`
 			Description   string `graphql:"description"`
@@ -117,6 +124,7 @@ func dataGithubEnterpriseIntegrationRead(ctx context.Context, d *schema.Resource
 	d.SetId(githubEnterpriseIntegration.ID)
 	d.Set(ghEnterpriseAPIHost, githubEnterpriseIntegration.APIHost)
 	d.Set(ghEnterpriseWebhookSecret, githubEnterpriseIntegration.WebhookSecret)
+	d.Set(ghEnterpriseWebhookURL, githubEnterpriseIntegration.WebhookURL)
 	d.Set(ghEnterpriseAppID, githubEnterpriseIntegration.AppID)
 	d.Set(ghEnterpriseId, githubEnterpriseIntegration.ID)
 	d.Set(ghEnterpriseName, githubEnterpriseIntegration.Name)

--- a/spacelift/data_github_enterprise_integration_test.go
+++ b/spacelift/data_github_enterprise_integration_test.go
@@ -23,6 +23,7 @@ func TestGithubEnterpriseIntegrationData(t *testing.T) {
 				Attribute("space_id", IsNotEmpty()),
 				Attribute("api_host", Equals(os.Getenv("SPACELIFT_PROVIDER_TEST_GITHUB_ENTERPRISE_API_HOST"))),
 				Attribute("webhook_secret", Equals(os.Getenv("SPACELIFT_PROVIDER_TEST_GITHUB_ENTERPRISE_WEBHOOK_SECRET"))),
+				Attribute("webhook_url", IsNotEmpty()),
 				Attribute("app_id", Equals(os.Getenv("SPACELIFT_PROVIDER_TEST_GITHUB_ENTERPRISE_APP_ID"))),
 			),
 		}})
@@ -43,6 +44,7 @@ func TestGithubEnterpriseIntegrationData(t *testing.T) {
 				Attribute("space_id", IsNotEmpty()),
 				Attribute("api_host", Equals(os.Getenv("SPACELIFT_PROVIDER_TEST_GITHUB_ENTERPRISE_API_HOST"))),
 				Attribute("webhook_secret", Equals(os.Getenv("SPACELIFT_PROVIDER_TEST_GITHUB_ENTERPRISE_WEBHOOK_SECRET"))),
+				Attribute("webhook_url", IsNotEmpty()),
 				Attribute("app_id", Equals(os.Getenv("SPACELIFT_PROVIDER_TEST_GITHUB_ENTERPRISE_APP_ID"))),
 			),
 		}})


### PR DESCRIPTION
## Description of the change

Azure DevOps, Bitbucket Cloud, Bitbucket Datacenter, and GitLab have `webhook_url,`, but GitHub hasn't. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
