### PR TITLE
docs: document root admin requirement for spacelift_space

### DIFF
--- a/docs/resources/space.md
+++ b/docs/resources/space.md
@@ -4,11 +4,14 @@ page_title: "spacelift_space Resource - terraform-provider-spacelift"
 subcategory: ""
 description: |-
   spacelift_space represents a Spacelift space - a collection of resources such as stacks, modules, policies, etc. Allows for more granular access control. Can have a parent space.
+  Please note: the spacelift_space resource requires root Admin permissions, and can only be used by administrative stacks in the root space, or using an API key or user session that has root space access.
 ---
 
 # spacelift_space (Resource)
 
 `spacelift_space` represents a Spacelift **space** - a collection of resources such as stacks, modules, policies, etc. Allows for more granular access control. Can have a parent space.
+
+**Please note:** the `spacelift_space` resource requires root Admin permissions, and can only be used by administrative stacks in the root space, or using an API key or user session that has root space access.
 
 ## Example Usage
 

--- a/spacelift/resource_space.go
+++ b/spacelift/resource_space.go
@@ -17,7 +17,9 @@ import (
 func resourceSpace() *schema.Resource {
 	return &schema.Resource{
 		Description: "`spacelift_space` represents a Spacelift **space** - " +
-			"a collection of resources such as stacks, modules, policies, etc. Allows for more granular access control. Can have a parent space.",
+			"a collection of resources such as stacks, modules, policies, etc. Allows for more granular access control. Can have a parent space.\n\n" +
+			"**Please note:** the `spacelift_space` resource requires root Admin permissions, and can only be used by administrative stacks " +
+			"in the root space, or using an API key or user session that has root space access.",
 
 		CreateContext: resourceSpaceCreate,
 		ReadContext:   resourceSpaceRead,


### PR DESCRIPTION
## Description of the change

The `spacelift_space` resource requires root space admin permissions to work. This means that it can only be used by administrative stacks that live in the root space.

I've added a note to the provider docs to make that more obvious.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
