### PR TITLE
MultiVCS: Added is_default into stack/module data source and prevent panic on detached VCS integration

### DIFF
--- a/docs/data-sources/module.md
+++ b/docs/data-sources/module.md
@@ -55,6 +55,7 @@ data "spacelift_module" "k8s-module" {
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `project` (String)
 
 
@@ -64,6 +65,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `namespace` (String)
 
 
@@ -73,6 +75,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `namespace` (String)
 
 
@@ -82,6 +85,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `namespace` (String)
 
 
@@ -91,4 +95,5 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `namespace` (String)

--- a/docs/data-sources/stack.md
+++ b/docs/data-sources/stack.md
@@ -90,6 +90,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `project` (String)
 
 
@@ -99,6 +100,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `namespace` (String)
 
 
@@ -108,6 +110,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `namespace` (String)
 
 
@@ -128,6 +131,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `namespace` (String)
 
 
@@ -137,6 +141,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `namespace` (String)
 
 

--- a/docs/data-sources/stacks.md
+++ b/docs/data-sources/stacks.md
@@ -187,6 +187,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `project` (String)
 
 
@@ -196,6 +197,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `namespace` (String)
 
 
@@ -205,6 +207,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `namespace` (String)
 
 
@@ -225,6 +228,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `namespace` (String)
 
 
@@ -234,6 +238,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `is_default` (Boolean)
 - `namespace` (String)
 
 

--- a/spacelift/data_module.go
+++ b/spacelift/data_module.go
@@ -46,6 +46,11 @@ func dataModule() *schema.Resource {
 							Description: "ID of the Azure Devops integration",
 							Computed:    true,
 						},
+						"is_default": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether this is the default Azure Devops integration",
+						},
 						"project": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -65,6 +70,11 @@ func dataModule() *schema.Resource {
 							Description: "ID of the Bitbucket Cloud integration",
 							Computed:    true,
 						},
+						"is_default": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether this is the default Bitbucket Cloud integration",
+						},
 						"namespace": {
 							Type:        schema.TypeString,
 							Description: "Bitbucket Cloud namespace of the stack's repository",
@@ -83,6 +93,11 @@ func dataModule() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: "ID of the Bitbucket Datacenter integration",
 							Computed:    true,
+						},
+						"is_default": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether this is the default Bitbucket Datacenter integration",
 						},
 						"namespace": {
 							Type:        schema.TypeString,
@@ -108,6 +123,11 @@ func dataModule() *schema.Resource {
 							Description: "GitHub Enterprise namespace of the stack's repository",
 							Computed:    true,
 						},
+						"is_default": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether this is the default GitHub Enterprise integration",
+						},
 						"id": {
 							Type:        schema.TypeString,
 							Description: "ID of the GitHub Enterprise integration",
@@ -125,6 +145,11 @@ func dataModule() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: "ID of the Gitlab integration",
 							Computed:    true,
+						},
+						"is_default": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether this is the default Gitlab integration",
 						},
 						"namespace": {
 							Type:        schema.TypeString,

--- a/spacelift/data_stack.go
+++ b/spacelift/data_stack.go
@@ -108,6 +108,11 @@ func dataStack() *schema.Resource {
 							Description: "ID of the Azure Devops VCS integration",
 							Computed:    true,
 						},
+						"is_default": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether this is the default Azure Devops VCS integration",
+						},
 						"project": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -162,6 +167,11 @@ func dataStack() *schema.Resource {
 							Description: "ID of the Bitbucket Cloud integration",
 							Computed:    true,
 						},
+						"is_default": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether this is the default Bitbucket Cloud integration",
+						},
 						"namespace": {
 							Type:        schema.TypeString,
 							Description: "Bitbucket Cloud namespace of the stack's repository",
@@ -180,6 +190,11 @@ func dataStack() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: "ID of the Bitbucket Datacenter integration",
 							Computed:    true,
+						},
+						"is_default": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether this is the default Bitbucket Datacenter integration",
 						},
 						"namespace": {
 							Type:        schema.TypeString,
@@ -239,6 +254,11 @@ func dataStack() *schema.Resource {
 							Description: "ID of the GitHub Enterprise integration",
 							Computed:    true,
 						},
+						"is_default": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether this is the default GitHub Enterprise integration",
+						},
 						"namespace": {
 							Type:        schema.TypeString,
 							Description: "GitHub Enterprise namespace of the stack's repository",
@@ -257,6 +277,11 @@ func dataStack() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: "ID of the Gitlab integration",
 							Computed:    true,
+						},
+						"is_default": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates whether this is the default Gitlab integration",
 						},
 						"namespace": {
 							Type:        schema.TypeString,

--- a/spacelift/data_stacks.go
+++ b/spacelift/data_stacks.go
@@ -135,7 +135,11 @@ func dataStacksRead(ctx context.Context, d *schema.ResourceData, meta interface{
 			}
 
 			if vcsKey, vcsSettings := node.VCSSettings(); vcsKey != "" {
-				stack[vcsKey] = []interface{}{vcsSettings}
+				vcsValue := []interface{}{vcsSettings}
+				if vcsSettings == nil {
+					vcsValue = nil
+				}
+				stack[vcsKey] = vcsValue
 			}
 
 			if iacKey, iacSettings := node.IaCSettings(); iacKey != "" {

--- a/spacelift/internal/structs/module.go
+++ b/spacelift/internal/structs/module.go
@@ -36,33 +36,53 @@ type Module struct {
 // ExportVCSSettings exports VCS settings into Terraform schema.
 func (m *Module) ExportVCSSettings(d *schema.ResourceData) error {
 	var fieldName string
-	vcsSettings := make(map[string]interface{})
+	var vcsSettings map[string]interface{}
 
 	switch m.Provider {
 	case VCSProviderAzureDevOps:
-		vcsSettings["id"] = m.VCSIntegration.ID
-		vcsSettings["project"] = m.Namespace
-		vcsSettings["is_default"] = m.VCSIntegration.IsDefault
+		if m.VCSIntegration != nil {
+			vcsSettings = map[string]interface{}{
+				"id":         m.VCSIntegration.ID,
+				"project":    m.Namespace,
+				"is_default": m.VCSIntegration.IsDefault,
+			}
+		}
 		fieldName = "azure_devops"
 	case VCSProviderBitbucketCloud:
-		vcsSettings["id"] = m.VCSIntegration.ID
-		vcsSettings["namespace"] = m.Namespace
-		vcsSettings["is_default"] = m.VCSIntegration.IsDefault
+		if m.VCSIntegration != nil {
+			vcsSettings = map[string]interface{}{
+				"id":         m.VCSIntegration.ID,
+				"namespace":  m.Namespace,
+				"is_default": m.VCSIntegration.IsDefault,
+			}
+		}
 		fieldName = "bitbucket_cloud"
 	case VCSProviderBitbucketDatacenter:
-		vcsSettings["id"] = m.VCSIntegration.ID
-		vcsSettings["namespace"] = m.Namespace
-		vcsSettings["is_default"] = m.VCSIntegration.IsDefault
+		if m.VCSIntegration != nil {
+			vcsSettings = map[string]interface{}{
+				"id":         m.VCSIntegration.ID,
+				"namespace":  m.Namespace,
+				"is_default": m.VCSIntegration.IsDefault,
+			}
+		}
 		fieldName = "bitbucket_datacenter"
 	case VCSProviderGitHubEnterprise:
-		vcsSettings["id"] = m.VCSIntegration.ID
-		vcsSettings["namespace"] = m.Namespace
-		vcsSettings["is_default"] = m.VCSIntegration.IsDefault
+		if m.VCSIntegration != nil {
+			vcsSettings = map[string]interface{}{
+				"id":         m.VCSIntegration.ID,
+				"namespace":  m.Namespace,
+				"is_default": m.VCSIntegration.IsDefault,
+			}
+		}
 		fieldName = "github_enterprise"
 	case VCSProviderGitlab:
-		vcsSettings["id"] = m.VCSIntegration.ID
-		vcsSettings["namespace"] = m.Namespace
-		vcsSettings["is_default"] = m.VCSIntegration.IsDefault
+		if m.VCSIntegration != nil {
+			vcsSettings = map[string]interface{}{
+				"id":         m.VCSIntegration.ID,
+				"namespace":  m.Namespace,
+				"is_default": m.VCSIntegration.IsDefault,
+			}
+		}
 		fieldName = "gitlab"
 	}
 

--- a/spacelift/internal/structs/stack.go
+++ b/spacelift/internal/structs/stack.go
@@ -96,7 +96,11 @@ type Stack struct {
 // ExportVCSSettings exports VCS settings into Terraform schema.
 func (s *Stack) ExportVCSSettings(d *schema.ResourceData) error {
 	if fieldName, vcsSettings := s.VCSSettings(); fieldName != "" {
-		if err := d.Set(fieldName, []interface{}{vcsSettings}); err != nil {
+		fieldValue := []interface{}{vcsSettings}
+		if vcsSettings == nil {
+			fieldValue = nil
+		}
+		if err := d.Set(fieldName, fieldValue); err != nil {
 			return errors.Wrapf(err, "error setting %s (resource)", fieldName)
 		}
 	}
@@ -135,30 +139,45 @@ func (s *Stack) IaCSettings() (string, map[string]interface{}) {
 func (s *Stack) VCSSettings() (string, map[string]interface{}) {
 	switch s.Provider {
 	case VCSProviderAzureDevOps:
+		if s.VCSIntegration == nil {
+			return "azure_devops", nil
+		}
 		return "azure_devops", map[string]interface{}{
 			"id":         s.VCSIntegration.ID,
 			"project":    s.Namespace,
 			"is_default": s.VCSIntegration.IsDefault,
 		}
 	case VCSProviderBitbucketCloud:
+		if s.VCSIntegration == nil {
+			return "bitbucket_cloud", nil
+		}
 		return "bitbucket_cloud", map[string]interface{}{
 			"id":         s.VCSIntegration.ID,
 			"namespace":  s.Namespace,
 			"is_default": s.VCSIntegration.IsDefault,
 		}
 	case VCSProviderBitbucketDatacenter:
+		if s.VCSIntegration == nil {
+			return "bitbucket_datacenter", nil
+		}
 		return "bitbucket_datacenter", map[string]interface{}{
 			"id":         s.VCSIntegration.ID,
 			"namespace":  s.Namespace,
 			"is_default": s.VCSIntegration.IsDefault,
 		}
 	case VCSProviderGitHubEnterprise:
+		if s.VCSIntegration == nil {
+			return "github_enterprise", nil
+		}
 		return "github_enterprise", map[string]interface{}{
 			"id":         s.VCSIntegration.ID,
 			"namespace":  s.Namespace,
 			"is_default": s.VCSIntegration.IsDefault,
 		}
 	case VCSProviderGitlab:
+		if s.VCSIntegration == nil {
+			return "gitlab", nil
+		}
 		return "gitlab", map[string]interface{}{
 			"id":         s.VCSIntegration.ID,
 			"namespace":  s.Namespace,

--- a/spacelift/resource_module.go
+++ b/spacelift/resource_module.go
@@ -53,6 +53,7 @@ func resourceModule() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: "ID of the Azure Devops integration. If not specified, the default integration will be used.",
 							Optional:    true,
+							Computed:    true,
 							DiffSuppressFunc: func(_, _, new string, res *schema.ResourceData) bool {
 								isDefault := res.Get("azure_devops.0.is_default").(bool)
 
@@ -84,6 +85,7 @@ func resourceModule() *schema.Resource {
 						"id": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "The ID of the Bitbucket Cloud integration. If not specified, the default integration will be used.",
 							DiffSuppressFunc: func(_, _, new string, res *schema.ResourceData) bool {
 								isDefault := res.Get("bitbucket_cloud.0.is_default").(bool)
@@ -116,6 +118,7 @@ func resourceModule() *schema.Resource {
 						"id": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "The ID of the Bitbucket Datacenter integration. If not specified, the default integration will be used.",
 							DiffSuppressFunc: func(_, _, new string, res *schema.ResourceData) bool {
 								isDefault := res.Get("bitbucket_datacenter.0.is_default").(bool)
@@ -170,6 +173,7 @@ func resourceModule() *schema.Resource {
 						"id": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "The ID of the GitHub Enterprise integration. If not specified, the default integration will be used.",
 							DiffSuppressFunc: func(_, _, new string, res *schema.ResourceData) bool {
 								isDefault := res.Get("github_enterprise.0.is_default").(bool)
@@ -197,6 +201,7 @@ func resourceModule() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: "ID of the Gitlab integration. If not specified, the default integration will be used.",
 							Optional:    true,
+							Computed:    true,
 							DiffSuppressFunc: func(_, _, new string, res *schema.ResourceData) bool {
 								isDefault := res.Get("gitlab.0.is_default").(bool)
 

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -140,6 +140,7 @@ func resourceStack() *schema.Resource {
 						"id": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "The ID of the Azure Devops integration. If not specified, the default integration will be used.",
 							DiffSuppressFunc: func(_, _, new string, res *schema.ResourceData) bool {
 								isDefault := res.Get("azure_devops.0.is_default").(bool)
@@ -223,6 +224,7 @@ func resourceStack() *schema.Resource {
 						"id": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "The ID of the Bitbucket Cloud integration. If not specified, the default integration will be used.",
 							DiffSuppressFunc: func(_, _, new string, res *schema.ResourceData) bool {
 								isDefault := res.Get("bitbucket_cloud.0.is_default").(bool)
@@ -255,6 +257,7 @@ func resourceStack() *schema.Resource {
 						"id": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "The ID of the Bitbucket Datacenter integration. If not specified, the default integration will be used.",
 							DiffSuppressFunc: func(_, _, new string, res *schema.ResourceData) bool {
 								isDefault := res.Get("bitbucket_datacenter.0.is_default").(bool)
@@ -345,6 +348,7 @@ func resourceStack() *schema.Resource {
 						"id": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "The ID of the GitHub Enterprise integration. If not specified, the default integration will be used.",
 							DiffSuppressFunc: func(_, _, new string, res *schema.ResourceData) bool {
 								isDefault := res.Get("github_enterprise.0.is_default").(bool)
@@ -371,6 +375,7 @@ func resourceStack() *schema.Resource {
 						"id": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 							Description: "The ID of the Gitlab integration. If not specified, the default integration will be used.",
 							DiffSuppressFunc: func(_, _, new string, res *schema.ResourceData) bool {
 								isDefault := res.Get("gitlab.0.is_default").(bool)


### PR DESCRIPTION
## Description of the change

- We've added is_default into stack/module resource. We need to do the same with data sources as well.
- Prevent panic on detached VCS integration

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [x] Changes have been reviewed by at least one other engineer
