### PR TITLE
added default state importer for bitbucket_datacenter_integration

### DIFF
--- a/spacelift/resource_bitbucket_datacenter_integration.go
+++ b/spacelift/resource_bitbucket_datacenter_integration.go
@@ -23,6 +23,9 @@ func resourceBitbucketDatacenterIntegration() *schema.Resource {
 		ReadContext:   resourceBitbucketDatacenterIntegrationRead,
 		UpdateContext: resourceBitbucketDatacenterIntegrationUpdate,
 		DeleteContext: resourceBitbucketDatacenterIntegrationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			bitbucketDatacenterID: {


### PR DESCRIPTION
## Description of the change

Looks like the merged PR https://github.com/spacelift-io/terraform-provider-spacelift/pull/498/ accidently lost the state importer: https://github.com/spacelift-io/terraform-provider-spacelift/pull/498/commits/27ab68ff80d97192d8ad8fa65cae728cb0b9c03b#r1522752906
Can we add it back?

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
