### PR TITLE
feat: Add support for description on policies

### DIFF
--- a/docs/data-sources/policies.md
+++ b/docs/data-sources/policies.md
@@ -45,6 +45,7 @@ output "policy_ids" {
 
 Read-Only:
 
+- `description` (String)
 - `id` (String)
 - `labels` (Set of String)
 - `name` (String)

--- a/docs/data-sources/policy.md
+++ b/docs/data-sources/policy.md
@@ -32,6 +32,7 @@ output "policy_body" {
 ### Read-Only
 
 - `body` (String) body of the policy
+- `description` (String) description of the policy
 - `id` (String) The ID of this resource.
 - `labels` (Set of String)
 - `name` (String) name of the policy

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -42,6 +42,7 @@ resource "spacelift_policy_attachment" "no-weekend-deploys" {
 
 ### Optional
 
+- `description` (String) Description of the policy
 - `labels` (Set of String)
 - `space_id` (String) ID (slug) of the space the policy is in
 

--- a/spacelift/data_policies.go
+++ b/spacelift/data_policies.go
@@ -59,6 +59,11 @@ func dataPolicies() *schema.Resource {
 							Description: "Type of the policy",
 							Computed:    true,
 						},
+						"description": {
+							Type:        schema.TypeString,
+							Description: "description of the policy",
+							Computed:    true,
+						},
 					},
 				},
 			},
@@ -70,11 +75,12 @@ func dataPoliciesRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.SetId(fmt.Sprintf("policies/%s/%s", d.Get("type").(string), d.Get("labels").(*schema.Set).List()))
 	var query struct {
 		Policies []struct {
-			ID     string   `graphql:"id"`
-			Labels []string `graphql:"labels"`
-			Name   string   `graphql:"name"`
-			Type   string   `graphql:"type"`
-			Space  string   `graphql:"space"`
+			ID          string   `graphql:"id"`
+			Labels      []string `graphql:"labels"`
+			Name        string   `graphql:"name"`
+			Type        string   `graphql:"type"`
+			Space       string   `graphql:"space"`
+			Description string   `graphql:"description"`
 		} `graphql:"policies()"`
 	}
 
@@ -110,11 +116,12 @@ func dataPoliciesRead(ctx context.Context, d *schema.ResourceData, meta interfac
 			}
 		}
 		policies = append(policies, map[string]interface{}{
-			"id":       policy.ID,
-			"labels":   policy.Labels,
-			"name":     policy.Name,
-			"type":     policy.Type,
-			"space_id": policy.Space,
+			"id":          policy.ID,
+			"labels":      policy.Labels,
+			"name":        policy.Name,
+			"type":        policy.Type,
+			"space_id":    policy.Space,
+			"description": policy.Description,
 		})
 	}
 

--- a/spacelift/data_policy.go
+++ b/spacelift/data_policy.go
@@ -42,6 +42,11 @@ func dataPolicy() *schema.Resource {
 				Description: "name of the policy",
 				Computed:    true,
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "description of the policy",
+				Computed:    true,
+			},
 			"space_id": {
 				Type:        schema.TypeString,
 				Description: "ID (slug) of the space the policy is in",
@@ -76,6 +81,7 @@ func dataPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{
 	d.Set("body", policy.Body)
 	d.Set("type", policy.Type)
 	d.Set("space_id", policy.Space)
+	d.Set("description", policy.Description)
 
 	labels := schema.NewSet(schema.HashString, []interface{}{})
 	for _, label := range policy.Labels {

--- a/spacelift/data_policy_test.go
+++ b/spacelift/data_policy_test.go
@@ -19,6 +19,7 @@ func TestPolicyData(t *testing.T) {
 				resource "spacelift_policy" "test" {
 					name = "My first policy %s"
 					labels = ["one", "two"]
+					description = "My awesome policy"
 					body = <<EOF
 					package spacelift
 					deny["boom"] { true }
@@ -35,6 +36,7 @@ func TestPolicyData(t *testing.T) {
 				Attribute("body", Contains("boom")),
 				Attribute("type", Equals("PLAN")),
 				SetEquals("labels", "one", "two"),
+				Attribute("description", Equals("My awesome policy")),
 			),
 		}})
 	})
@@ -48,6 +50,7 @@ func TestPolicyDataSpace(t *testing.T) {
 			Config: fmt.Sprintf(`
 				resource "spacelift_policy" "test" {
 					name = "My first policy %s"
+					description = "My awesome policy"
 					labels = ["one", "two"]
 					space_id = "root"
 					body = <<EOF
@@ -69,6 +72,7 @@ func TestPolicyDataSpace(t *testing.T) {
 				Attribute("type", Equals("PLAN")),
 				Attribute("space_id", Equals("root")),
 				SetEquals("labels", "one", "two"),
+				Attribute("description", Equals("My awesome policy")),
 			),
 		}})
 	})

--- a/spacelift/internal/structs/policy.go
+++ b/spacelift/internal/structs/policy.go
@@ -5,10 +5,11 @@ type PolicyType string
 
 // Policy represents Policy data relevant to the provider.
 type Policy struct {
-	ID     string   `graphql:"id"`
-	Labels []string `graphql:"labels"`
-	Name   string   `graphql:"name"`
-	Body   string   `graphql:"body"`
-	Type   string   `graphql:"type"`
-	Space  string   `graphql:"space"`
+	ID          string   `graphql:"id"`
+	Labels      []string `graphql:"labels"`
+	Name        string   `graphql:"name"`
+	Body        string   `graphql:"body"`
+	Type        string   `graphql:"type"`
+	Space       string   `graphql:"space"`
+	Description string   `graphql:"description"`
 }

--- a/spacelift/resource_policy.go
+++ b/spacelift/resource_policy.go
@@ -97,21 +97,28 @@ func resourcePolicy() *schema.Resource {
 					false, // case-sensitive match
 				),
 			},
+			"description": {
+				Type:             schema.TypeString,
+				Description:      "Description of the policy",
+				Optional:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
+			},
 		},
 	}
 }
 
 func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var mutation struct {
-		CreatePolicy structs.Policy `graphql:"policyCreate(name: $name, body: $body, type: $type, labels: $labels, space: $space)"`
+		CreatePolicy structs.Policy `graphql:"policyCreate(name: $name, body: $body, type: $type, labels: $labels, space: $space, description: $description)"`
 	}
 
 	variables := map[string]interface{}{
-		"name":   toString(d.Get("name")),
-		"body":   toString(d.Get("body")),
-		"type":   structs.PolicyType(d.Get("type").(string)),
-		"labels": (*[]graphql.String)(nil),
-		"space":  (*graphql.ID)(nil),
+		"name":        toString(d.Get("name")),
+		"body":        toString(d.Get("body")),
+		"type":        structs.PolicyType(d.Get("type").(string)),
+		"labels":      (*[]graphql.String)(nil),
+		"space":       (*graphql.ID)(nil),
+		"description": toString(d.Get("description")),
 	}
 
 	if labelSet, ok := d.Get("labels").(*schema.Set); ok {
@@ -157,6 +164,7 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("body", policy.Body)
 	d.Set("type", policy.Type)
 	d.Set("space_id", policy.Space)
+	d.Set("description", policy.Description)
 
 	labels := schema.NewSet(schema.HashString, []interface{}{})
 	for _, label := range policy.Labels {
@@ -176,15 +184,16 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var mutation struct {
-		UpdatePolicy structs.Policy `graphql:"policyUpdate(id: $id, name: $name, body: $body, labels: $labels, space: $space)"`
+		UpdatePolicy structs.Policy `graphql:"policyUpdate(id: $id, name: $name, body: $body, labels: $labels, space: $space, description: $description)"`
 	}
 
 	variables := map[string]interface{}{
-		"id":     toID(d.Id()),
-		"name":   toString(d.Get("name")),
-		"body":   toString(d.Get("body")),
-		"labels": (*[]graphql.String)(nil),
-		"space":  (*graphql.ID)(nil),
+		"id":          toID(d.Id()),
+		"name":        toString(d.Get("name")),
+		"body":        toString(d.Get("body")),
+		"labels":      (*[]graphql.String)(nil),
+		"space":       (*graphql.ID)(nil),
+		"description": toString(d.Get("description")),
 	}
 
 	if labelSet, ok := d.Get("labels").(*schema.Set); ok {

--- a/spacelift/resource_policy_test.go
+++ b/spacelift/resource_policy_test.go
@@ -21,6 +21,7 @@ func TestPolicyResource(t *testing.T) {
 				resource "spacelift_policy" "test" {
 					name = "My first policy %s"
 					labels = ["one", "two"]
+					description = "My awesome policy"
 					body = <<EOF
 					package spacelift
 					deny["%s"] { true }
@@ -39,6 +40,7 @@ func TestPolicyResource(t *testing.T) {
 					Attribute("body", Contains("boom")),
 					Attribute("type", Equals("PLAN")),
 					SetEquals("labels", "one", "two"),
+					Attribute("description", Equals("My awesome policy")),
 				),
 			},
 			{
@@ -99,6 +101,7 @@ func TestPolicyResourceSpace(t *testing.T) {
 				resource "spacelift_policy" "test" {
 					name = "My first policy %s"
 					labels = ["one", "two"]
+					description = "My awesome policy"
 					space_id = "root"
 					body = <<EOF
 					package spacelift
@@ -120,6 +123,7 @@ func TestPolicyResourceSpace(t *testing.T) {
 					Attribute("type", Equals("PLAN")),
 					SetEquals("labels", "one", "two"),
 					Attribute("space_id", Equals("root")),
+					Attribute("description", Equals("My awesome policy")),
 				),
 			},
 			{


### PR DESCRIPTION
## Description of the change

This PR adds support for setting the `description` of policies.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
