### PR TITLE
 feat: wait for run in resource `spacelift_run`

### DIFF
--- a/docs/resources/run.md
+++ b/docs/resources/run.md
@@ -60,6 +60,6 @@ Optional:
 
 Optional:
 
-- `continue_on_state` (Set of String) Continue on the specified states of a finished run. If not specified, the default is `[ 'finished' ]`
+- `continue_on_state` (Set of String) Continue on the specified states of a finished run. If not specified, the default is `[ 'finished' ]`. You can use following states: `applying`, `canceled`, `confirmed`, `destroying`, `discarded`, `failed`, `finished`, `initializing`, `pending_review`, `performing`, `planning`, `preparing_apply`, `preparing_replan`, `preparing`, `queued`, `ready`, `replan_requested`, `skipped`, `stopped`, `unconfirmed`.
 - `continue_on_timeout` (Boolean) Continue if run timed out, i.e. did not reach any defined end state in time. Default: `false`
 - `disabled` (Boolean) Whether waiting for a job is disabled or not. Default: `false`

--- a/docs/resources/run.md
+++ b/docs/resources/run.md
@@ -40,7 +40,27 @@ resource "spacelift_run" "this" {
 - `commit_sha` (String) The commit SHA for which to trigger a run.
 - `keepers` (Map of String) Arbitrary map of values that, when changed, will trigger recreation of the resource.
 - `proposed` (Boolean) Whether the run is a proposed run. Defaults to `false`.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `wait` (Block List, Max: 1) Wait for the run to finish (see [below for nested schema](#nestedblock--wait))
 
 ### Read-Only
 
 - `id` (String) The ID of the triggered run.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String)
+
+
+<a id="nestedblock--wait"></a>
+### Nested Schema for `wait`
+
+Optional:
+
+- `continue_on_discarded` (Boolean) Continue if run has been discarded. Default: `false`
+- `continue_on_failed` (Boolean) Continue if run failed. Default: `false`
+- `continue_on_timeout` (Boolean) Continue if run timed out, i.e. did not reach end state `finished` in time. Default: `false`
+- `enabled` (Boolean) Whether waiting for a job is enabled or not. Default: `false`

--- a/docs/resources/run.md
+++ b/docs/resources/run.md
@@ -62,4 +62,4 @@ Optional:
 
 - `continue_on_state` (Set of String) Continue on the specified states of a finished run. If not specified, the default is `[ 'finished' ]`
 - `continue_on_timeout` (Boolean) Continue if run timed out, i.e. did not reach any defined end state in time. Default: `false`
-- `enabled` (Boolean) Whether waiting for a job is enabled or not. Default: `false`
+- `disabled` (Boolean) Whether waiting for a job is disabled or not. Default: `false`

--- a/docs/resources/run.md
+++ b/docs/resources/run.md
@@ -60,7 +60,6 @@ Optional:
 
 Optional:
 
-- `continue_on_discarded` (Boolean) Continue if run has been discarded. Default: `false`
-- `continue_on_failed` (Boolean) Continue if run failed. Default: `false`
-- `continue_on_timeout` (Boolean) Continue if run timed out, i.e. did not reach end state `finished` in time. Default: `false`
+- `continue_on_state` (Set of String) Continue on the specified states of a finished run. If not specified, the default is `[ 'finished' ]`
+- `continue_on_timeout` (Boolean) Continue if run timed out, i.e. did not reach any defined end state in time. Default: `false`
 - `enabled` (Boolean) Whether waiting for a job is enabled or not. Default: `false`

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.4
+	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/errors v0.9.1
@@ -36,7 +37,6 @@ require (
 	github.com/hashicorp/terraform-exec v0.19.0 // indirect
 	github.com/hashicorp/terraform-json v0.17.1 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.19.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.2 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/spacelift/internal/error.go
+++ b/spacelift/internal/error.go
@@ -46,3 +46,17 @@ func parseExtensions(ext map[string]interface{}) string {
 
 	return strings.Join(errorParts, ", ")
 }
+
+// AsError is an inline form of errors.As.
+func AsError[TError error](err error) (TError, bool) {
+	var as TError
+	ok := errors.As(err, &as)
+	return as, ok
+}
+
+// IsErrorType reports whether or not the type of any error in err's chain matches
+// the Error type.
+func IsErrorType[TError error](err error) bool {
+	_, ok := AsError[TError](err)
+	return ok
+}

--- a/spacelift/resource_run.go
+++ b/spacelift/resource_run.go
@@ -165,7 +165,7 @@ func resourceRunCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 		if !wait.disabled {
 			stateConf := &retry.StateChangeConf{
 				ContinuousTargetOccurence: 1,
-				Delay:                     10 * time.Second, // TODO: Delay must be a multiple of Timeout
+				Delay:                     10 * time.Second,
 				MinTimeout:                10 * time.Second,
 				Pending: []string{
 					"running",
@@ -205,7 +205,7 @@ func resourceRunCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 				if !wait.continueOnTimeout {
 					return diag.Errorf("run %s on stack %s has timed out", mutation.ID, stackID)
 				} else {
-					tflog.Info(ctx, "run timed out but continue_on_discarded=true",
+					tflog.Info(ctx, "run timed out but continue_on_timeout=true",
 						map[string]any{
 							"stackID": stackID,
 							"runID":   mutation.ID,

--- a/spacelift/resource_run.go
+++ b/spacelift/resource_run.go
@@ -74,9 +74,9 @@ func resourceRun() *schema.Resource {
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"enabled": {
+						"disabled": {
 							Type:        schema.TypeBool,
-							Description: "Whether waiting for a job is enabled or not. Default: `false`",
+							Description: "Whether waiting for a job is disabled or not. Default: `false`",
 							Optional:    true,
 							Default:     false,
 						},
@@ -102,7 +102,7 @@ func resourceRun() *schema.Resource {
 }
 
 type waitConfiguration struct {
-	enabled           bool
+	disabled          bool
 	continueOnState   []string
 	continueOnTimeout bool
 }
@@ -113,7 +113,7 @@ func expandWaitConfiguration(input []interface{}) *waitConfiguration {
 	}
 	v := input[0].(map[string]interface{})
 	cfg := &waitConfiguration{
-		enabled:           v["enabled"].(bool),
+		disabled:          v["disabled"].(bool),
 		continueOnState:   []string{},
 		continueOnTimeout: v["continue_on_timeout"].(bool),
 	}
@@ -162,7 +162,7 @@ func resourceRunCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	if waitRaw, ok := d.GetOk("wait"); ok {
 		wait := expandWaitConfiguration(waitRaw.([]interface{}))
 
-		if wait.enabled {
+		if !wait.disabled {
 			stateConf := &retry.StateChangeConf{
 				ContinuousTargetOccurence: 1,
 				Delay:                     10 * time.Second, // TODO: Delay must be a multiple of Timeout

--- a/spacelift/resource_run.go
+++ b/spacelift/resource_run.go
@@ -172,6 +172,9 @@ func resourceRunCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 				},
 				Target: []string{
 					"finished",
+					"unconfirmed", // Let's treat unconfirmed as the target state.
+					// It's not finished, but we don't want to wait for it because it requires confirmation from someone.
+
 				},
 				Refresh: checkStackStatusFunc(ctx, client, stackID, mutation.ID),
 				Timeout: d.Timeout(schema.TimeoutCreate),
@@ -238,6 +241,11 @@ func checkStackStatusFunc(ctx context.Context, client *internal.Client, stackID 
 		state = "running"
 		if finished {
 			state = "finished"
+		}
+		// Let's treat unconfirmed as the target state.
+		// It's not finished, but we don't want to wait for it because it requires confirmation from someone.
+		if result == "unconfirmed" {
+			state = "unconfirmed"
 		}
 		return
 	}

--- a/spacelift/resource_run_test.go
+++ b/spacelift/resource_run_test.go
@@ -47,3 +47,50 @@ func TestRunResource(t *testing.T) {
 		})
 	})
 }
+
+func TestRunResourceWait(t *testing.T) {
+
+	t.Run("on a new stack", func(t *testing.T) {
+		const resourceName = "spacelift_run.test"
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		randomIDwp := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_worker_pool" "test" {
+					name        = "Let's create a dummy worker pool to avoid running the job %s"
+				}
+
+				resource "spacelift_stack" "test" {
+					name           = "Test stack %s"
+					repository     = "demo"
+					branch         = "master"
+					worker_pool_id = spacelift_worker_pool.test.id
+				}
+
+				resource "spacelift_run" "test" {
+					stack_id = spacelift_stack.test.id
+
+					keepers = { "bacon" = "tasty" }
+
+					timeouts {
+						create = "30s"
+					}
+
+					wait {
+						enabled             = true
+						continue_on_timeout = true
+					}
+				}
+			`, randomIDwp, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("id", IsNotEmpty()),
+					Attribute("stack_id", Contains(randomID)),
+				),
+			},
+		})
+	})
+}

--- a/spacelift/resource_run_test.go
+++ b/spacelift/resource_run_test.go
@@ -80,7 +80,7 @@ func TestRunResourceWait(t *testing.T) {
 					}
 
 					wait {
-						enabled             = true
+						disabled            = false
 						continue_on_timeout = true
 					}
 				}

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -146,10 +146,10 @@ func TestStackResource(t *testing.T) {
 					worker_pool_id       = spacelift_worker_pool.test.id
 				}
 				resource "spacelift_worker_pool" "test" {
-					name        = "Autoretryable worker pool."
+					name        = "Autoretryable worker pool (%s)."
 					description = "test worker pool"
 				}
-			`, description, randomID, randomID)
+			`, description, randomID, randomID, randomID)
 		}
 
 		testSteps(t, []resource.TestStep{
@@ -801,10 +801,10 @@ func TestStackResourceSpace(t *testing.T) {
 				}
 
 				resource "spacelift_worker_pool" "test" {
-					name        = "Autoretryable worker pool."
+					name        = "Autoretryable worker pool (%s)."
 					description = "test worker pool"
 				}
-			`, description, randomID, randomID)
+			`, description, randomID, randomID, randomID)
 		}
 
 		testSteps(t, []resource.TestStep{


### PR DESCRIPTION
## Description of the change

From [PR](https://github.com/spacelift-io/terraform-provider-spacelift/pull/522)

This PR contains an extension of the resource spacelift_run, which makes it possible to wait for the completion of a run.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
