### PR TITLE
Fix deleting non-existing stack dependency references

### DIFF
--- a/spacelift/resource_stack_dependency_reference.go
+++ b/spacelift/resource_stack_dependency_reference.go
@@ -2,6 +2,7 @@ package spacelift
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"strings"
 
@@ -102,19 +103,31 @@ func resourceStackDependencyReferenceRead(ctx context.Context, d *schema.Resourc
 		return diag.Errorf("could not query for stack dependency reference: %s", err)
 	}
 
+	var nonExistenceWarning string
+
 	if query.Stack == nil {
-		return diag.Errorf("could not find stack (%s), maybe it was deleted manually", stackID)
+		nonExistenceWarning = fmt.Sprintf("could not find stack (%s), maybe it was deleted manually", stackID)
+	} else if query.Stack.Dependency == nil {
+		nonExistenceWarning = fmt.Sprintf("could not find stack dependency (%s), maybe it was deleted manually", depID)
+	} else if query.Stack.Dependency.Reference == nil {
+		nonExistenceWarning = fmt.Sprintf("could not find stack dependency reference (%s), maybe it was deleted manually", refID)
 	}
-	if query.Stack.Dependency == nil {
-		return diag.Errorf("could not find stack dependency (%s), maybe it was deleted manually", depID)
-	}
-	if query.Stack.Dependency.Reference == nil {
-		return diag.Errorf("could not find stack dependency reference (%s), maybe it was deleted manually", refID)
+
+	if nonExistenceWarning != "" {
+		d.SetId("")
+
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  nonExistenceWarning,
+			},
+		}
 	}
 
 	d.Set("stack_dependency_id", path.Join(stackID, depID))
 	d.Set("output_name", query.Stack.Dependency.Reference.OutputName)
 	d.Set("input_name", query.Stack.Dependency.Reference.InputName)
+
 	return nil
 }
 

--- a/spacelift/resource_stack_dependency_reference.go
+++ b/spacelift/resource_stack_dependency_reference.go
@@ -116,12 +116,10 @@ func resourceStackDependencyReferenceRead(ctx context.Context, d *schema.Resourc
 	if nonExistenceWarning != "" {
 		d.SetId("")
 
-		return diag.Diagnostics{
-			diag.Diagnostic{
-				Severity: diag.Warning,
-				Summary:  nonExistenceWarning,
-			},
-		}
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  nonExistenceWarning,
+		}}
 	}
 
 	d.Set("stack_dependency_id", path.Join(stackID, depID))


### PR DESCRIPTION
## Description of the change

If the stack or the dependency is removed manually, it will not be possible to delete stack dependency reference. Throughout the rest of the provider we use a consistent pattern of just removing these resources from the state, and not treating it as an error. We will emit a warning here in case anyone misses the old error messages, but otherwise let's have this resource behave like all other resources.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [x] Changes have been reviewed by at least one other engineer
