### PR TITLE
adds word "module" to spacelift_version

### DIFF
--- a/docs/resources/version.md
+++ b/docs/resources/version.md
@@ -8,7 +8,7 @@ description: |-
 
 # spacelift_version (Resource)
 
-`spacelift_version` allows to programmatically trigger a module version creation in response to arbitrary changes in the keepers section.
+`spacelift_version` allows to programmatically trigger a *module* version creation in response to arbitrary changes in the keepers section.
 
 
 

--- a/docs/resources/version.md
+++ b/docs/resources/version.md
@@ -3,7 +3,7 @@
 page_title: "spacelift_version Resource - terraform-provider-spacelift"
 subcategory: ""
 description: |-
-  spacelift_version allows to programmatically trigger a version creation in response to arbitrary changes in the keepers section.
+  spacelift_version allows to programmatically trigger a module version creation in response to arbitrary changes in the keepers section.
 ---
 
 # spacelift_version (Resource)

--- a/docs/resources/version.md
+++ b/docs/resources/version.md
@@ -8,7 +8,7 @@ description: |-
 
 # spacelift_version (Resource)
 
-`spacelift_version` allows to programmatically trigger a *module* version creation in response to arbitrary changes in the keepers section.
+`spacelift_version` allows to programmatically trigger a version creation in response to arbitrary changes in the keepers section.
 
 
 

--- a/docs/resources/version.md
+++ b/docs/resources/version.md
@@ -8,7 +8,7 @@ description: |-
 
 # spacelift_version (Resource)
 
-`spacelift_version` allows to programmatically trigger a version creation in response to arbitrary changes in the keepers section.
+`spacelift_version` allows to programmatically trigger a module version creation in response to arbitrary changes in the keepers section.
 
 
 

--- a/spacelift/resource_version.go
+++ b/spacelift/resource_version.go
@@ -15,7 +15,7 @@ import (
 func resourceVersion() *schema.Resource {
 	return &schema.Resource{
 		Description: "" +
-			"`spacelift_version` allows to programmatically trigger a version creation " +
+			"`spacelift_version` allows to programmatically trigger a module version creation " +
 			"in response to arbitrary changes in the keepers section.",
 
 		CreateContext: resourceVersionCreate,


### PR DESCRIPTION
## Description of the change

adds the word "module" to clarify this resource is specifically for modules as it can be confusing to (especially self hosted) customers when they see spacelift_version 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
