### PR TITLE
Add `trigger_always` option to Stack Dependency References

### DIFF
--- a/docs/resources/stack_dependency_reference.md
+++ b/docs/resources/stack_dependency_reference.md
@@ -46,6 +46,10 @@ resource "spacelift_stack_dependency_reference" "test" {
 - `output_name` (String) Name of the output of stack to depend on
 - `stack_dependency_id` (String) Immutable ID of stack dependency
 
+### Optional
+
+- `trigger_always` (Boolean) Whether the dependents should be triggered even if the value of the reference did not change.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/spacelift/internal/structs/stack_dependency_reference.go
+++ b/spacelift/internal/structs/stack_dependency_reference.go
@@ -3,21 +3,24 @@ package structs
 import "github.com/shurcooL/graphql"
 
 type StackDependencyReference struct {
-	ID         string `graphql:"id"`
-	OutputName string `graphql:"outputName"`
-	InputName  string `graphql:"inputName"`
-	Type       string `graphql:"type"`
+	ID            string          `graphql:"id"`
+	OutputName    string          `graphql:"outputName"`
+	InputName     string          `graphql:"inputName"`
+	Type          string          `graphql:"type"`
+	TriggerAlways graphql.Boolean `json:"triggerAlways"`
 }
 
 type StackDependencyReferenceInput struct {
-	OutputName graphql.String `json:"outputName"`
-	InputName  graphql.String `json:"inputName"`
-	Type       graphql.String `json:"type"`
+	OutputName    graphql.String  `json:"outputName"`
+	InputName     graphql.String  `json:"inputName"`
+	Type          graphql.String  `json:"type"`
+	TriggerAlways graphql.Boolean `json:"triggerAlways"`
 }
 
 type StackDependencyReferenceUpdateInput struct {
-	ID         graphql.ID     `json:"id"`
-	OutputName graphql.String `json:"outputName"`
-	InputName  graphql.String `json:"inputName"`
-	Type       graphql.String `json:"type"`
+	ID            graphql.ID      `json:"id"`
+	OutputName    graphql.String  `json:"outputName"`
+	InputName     graphql.String  `json:"inputName"`
+	Type          graphql.String  `json:"type"`
+	TriggerAlways graphql.Boolean `json:"triggerAlways"`
 }

--- a/spacelift/resource_stack_dependency_reference.go
+++ b/spacelift/resource_stack_dependency_reference.go
@@ -46,6 +46,12 @@ func resourceStackDependencyReference() *schema.Resource {
 				Description: "Name of the input of the stack dependency reference",
 				Required:    true,
 			},
+			"trigger_always": {
+				Type:        schema.TypeBool,
+				Description: "Whether the dependents should be triggered even if the value of the reference did not change.",
+				Default:     false,
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -63,9 +69,10 @@ func resourceStackDependencyReferenceCreate(ctx context.Context, d *schema.Resou
 	variables := map[string]interface{}{
 		"stackDependencyID": toID(depID),
 		"reference": structs.StackDependencyReferenceInput{
-			OutputName: toString(d.Get("output_name")),
-			InputName:  toString(d.Get("input_name")),
-			Type:       toString("ENVIRONMENT_VARIABLE"),
+			OutputName:    toString(d.Get("output_name")),
+			InputName:     toString(d.Get("input_name")),
+			Type:          toString("ENVIRONMENT_VARIABLE"),
+			TriggerAlways: toBool(d.Get("trigger_always")),
 		},
 	}
 
@@ -76,6 +83,8 @@ func resourceStackDependencyReferenceCreate(ctx context.Context, d *schema.Resou
 	d.SetId(path.Join(stackID, depID, query.StackDependencyReference.ID))
 	d.Set("output_name", query.StackDependencyReference.OutputName)
 	d.Set("input_name", query.StackDependencyReference.InputName)
+	d.Set("trigger_always", query.StackDependencyReference.TriggerAlways)
+
 	return nil
 }
 
@@ -125,6 +134,7 @@ func resourceStackDependencyReferenceRead(ctx context.Context, d *schema.Resourc
 	d.Set("stack_dependency_id", path.Join(stackID, depID))
 	d.Set("output_name", query.Stack.Dependency.Reference.OutputName)
 	d.Set("input_name", query.Stack.Dependency.Reference.InputName)
+	d.Set("trigger_always", query.Stack.Dependency.Reference.TriggerAlways)
 
 	return nil
 }
@@ -141,10 +151,11 @@ func resourceStackDependencyReferenceUpdate(ctx context.Context, d *schema.Resou
 
 	variables := map[string]interface{}{
 		"reference": structs.StackDependencyReferenceUpdateInput{
-			ID:         toID(refID),
-			OutputName: toString(d.Get("output_name")),
-			InputName:  toString(d.Get("input_name")),
-			Type:       toString("ENVIRONMENT_VARIABLE"),
+			ID:            toID(refID),
+			OutputName:    toString(d.Get("output_name")),
+			InputName:     toString(d.Get("input_name")),
+			Type:          toString("ENVIRONMENT_VARIABLE"),
+			TriggerAlways: toBool(d.Get("trigger_always")),
 		},
 	}
 
@@ -155,6 +166,8 @@ func resourceStackDependencyReferenceUpdate(ctx context.Context, d *schema.Resou
 	d.Set("stack_dependency_id", path.Join(stackID, depID))
 	d.Set("output_name", query.StackDependencyReference.OutputName)
 	d.Set("input_name", query.StackDependencyReference.InputName)
+	d.Set("trigger_always", query.StackDependencyReference.TriggerAlways)
+
 	return nil
 }
 

--- a/spacelift/resource_stack_dependency_reference_test.go
+++ b/spacelift/resource_stack_dependency_reference_test.go
@@ -37,41 +37,45 @@ func TestStackDependencyReferenceResource(t *testing.T) {
 				}`, randomID, randomID)
 		}
 
-		configWithReference := func(outputName, inputName string) string {
+		configWithReference := func(outputName, inputName string, triggerAlways bool) string {
 			return configWithoutReference() + fmt.Sprintf(`
 				resource "spacelift_stack_dependency_reference" "test" {
 					stack_dependency_id = spacelift_stack_dependency.test.id
 					output_name = "%s"
 					input_name = "%s"
-				}`, outputName, inputName)
+					trigger_always = %v
+				}`, outputName, inputName, triggerAlways)
 		}
 
 		testSteps(t, []resource.TestStep{
 			{ // creates reference
-				Config: configWithReference("output_abc", "input_123"),
+				Config: configWithReference("output_abc", "input_123", false),
 				Check: Resource(
 					resourceName,
 					Attribute("id", IsNotEmpty()),
 					Attribute("output_name", Equals("output_abc")),
 					Attribute("input_name", Equals("input_123")),
+					Attribute("trigger_always", Equals("false")),
 				),
 			},
 			{ // updates input_name
-				Config: configWithReference("output_abc", "input_456"),
+				Config: configWithReference("output_abc", "input_456", true),
 				Check: Resource(
 					resourceName,
 					Attribute("id", IsNotEmpty()),
 					Attribute("output_name", Equals("output_abc")),
 					Attribute("input_name", Equals("input_456")),
+					Attribute("trigger_always", Equals("true")),
 				),
 			},
 			{ // updates output_name
-				Config: configWithReference("output_xyz", "input_456"),
+				Config: configWithReference("output_xyz", "input_456", true),
 				Check: Resource(
 					resourceName,
 					Attribute("id", IsNotEmpty()),
 					Attribute("output_name", Equals("output_xyz")),
 					Attribute("input_name", Equals("input_456")),
+					Attribute("trigger_always", Equals("true")),
 				),
 			},
 			{ // deletes reference
@@ -89,12 +93,13 @@ func TestStackDependencyReferenceResource(t *testing.T) {
 				},
 			},
 			{ // re-create reference
-				Config: configWithReference("output_final", "input_final"),
+				Config: configWithReference("output_final", "input_final", false),
 				Check: Resource(
 					resourceName,
 					Attribute("id", IsNotEmpty()),
 					Attribute("output_name", Equals("output_final")),
 					Attribute("input_name", Equals("input_final")),
+					Attribute("trigger_always", Equals("false")),
 				),
 			},
 			{


### PR DESCRIPTION
## Description of the change

It's also backward compatible (false by default).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
