### PR TITLE
Terragrunt OpenTofu: reset terraform_version when changing tool

### DIFF
--- a/spacelift/internal/testhelpers/helpers.go
+++ b/spacelift/internal/testhelpers/helpers.go
@@ -179,6 +179,17 @@ func Equals(expected string) ValueCheck {
 	}
 }
 
+// NotEquals checks for inequality against the unexpected value.
+func NotEquals(unexpected string) ValueCheck {
+	return func(actual string) error {
+		if actual != unexpected {
+			return nil
+		}
+
+		return errors.Errorf("unexpectedly got %q", actual)
+	}
+}
+
 // IsEmpty checks that the expected value is empty.
 func IsEmpty() ValueCheck {
 	return func(actual string) error {

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -973,7 +973,7 @@ func getVendorConfig(d *schema.ResourceData) *structs.VendorConfigInput {
 			terragruntConfig.Tool = toOptionalString(tool)
 		}
 
-		if shouldWeReComputeTerraformVersion(d) {
+		if shouldWeReComputeTerraformVersionForTerragrunt(d) {
 			terragruntConfig.TerraformVersion = nil
 		}
 
@@ -990,6 +990,9 @@ func getVendorConfig(d *schema.ResourceData) *structs.VendorConfigInput {
 
 	if terraformWorkflowTool, ok := d.GetOk("terraform_workflow_tool"); ok {
 		terraformConfig.WorkflowTool = toOptionalString(terraformWorkflowTool)
+		if shouldWeReComputeTerraformVersionForTerraformWorkflowTool(d) {
+			terraformConfig.Version = nil
+		}
 	}
 
 	if terraformWorkspace, ok := d.GetOk("terraform_workspace"); ok {
@@ -1011,13 +1014,29 @@ func getVendorConfig(d *schema.ResourceData) *structs.VendorConfigInput {
 	return &structs.VendorConfigInput{Terraform: terraformConfig}
 }
 
-func shouldWeReComputeTerraformVersion(d *schema.ResourceData) bool {
+func shouldWeReComputeTerraformVersionForTerragrunt(d *schema.ResourceData) bool {
 	// When tool is changed, we need to recompute terraform version
 	oldTool, newTool := d.GetChange("terragrunt.0.tool")
 	if oldTool.(string) != newTool.(string) {
 		// but only if version isn't provided manually in the config
 		inConf := d.GetRawConfig().AsValueMap()["terragrunt"].AsValueSlice()[0].AsValueMap()
 		if value, ok := inConf["terraform_version"]; ok {
+			if value.IsNull() || value.AsString() == "" {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func shouldWeReComputeTerraformVersionForTerraformWorkflowTool(d *schema.ResourceData) bool {
+	// When tool is changed, we need to recompute terraform version
+	oldTool, newTool := d.GetChange("terraform_workflow_tool")
+	if oldTool.(string) != newTool.(string) {
+		// but only if version isn't provided manually in the config
+		inConfig := d.GetRawConfig().AsValueMap()
+		if value, ok := inConfig["terraform_version"]; ok {
 			if value.IsNull() || value.AsString() == "" {
 				return true
 			}

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -592,17 +592,6 @@ func resourceStack() *schema.Resource {
 				Optional:      true,
 				MaxItems:      1,
 				Elem: &schema.Resource{
-					/*CustomizeDiff: customdiff.All(
-						customdiff.ComputedIf("terraform_version", func(ctx context.Context, diff *schema.ResourceDiff, v interface{}) bool {
-							f, err := os.OpenFile("/Users/ptru/fabryka/spacelift/terraform-provider-spacelift-extras/test-terragrunt/terragrunt.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-							if err != nil {
-								panic(err)
-							}
-							defer f.Close()
-							fmt.Fprintf(f, "checked! %v\n", diff.HasChange("tool"))
-							return diff.HasChange("tool")
-						}),
-					),*/
 					Schema: map[string]*schema.Schema{
 						"terraform_version": {
 							Type:             schema.TypeString,

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -663,6 +663,114 @@ func TestStackResource(t *testing.T) {
 		})
 	})
 
+	t.Run("with GitHub and Terragrunt changing configuration scenarios", func(t *testing.T) {
+		name := "terragrunt-switch-testing-" + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		config := func(body string) string {
+			return `
+				resource "spacelift_stack" "test" {
+					administrative = true
+					branch = "master"
+					name = "` + name + `"
+					project_root = "root"
+					repository = "demo"
+					runner_image = "custom_image:runner"
+					autodeploy = true
+					terragrunt {
+						` + body + `
+					}
+				}
+			`
+		}
+		testSteps(t, []resource.TestStep{
+			{
+				Config: config(`
+					tool = "TERRAFORM_FOSS"
+				`),
+				Check: Resource(
+					"spacelift_stack.test",
+					Attribute("terragrunt.0.tool", Equals("TERRAFORM_FOSS")),
+					Attribute("terragrunt.0.terraform_version", IsNotEmpty()),
+				),
+			},
+			{ // Change to OPEN_TOFU
+				Config: config(`
+					tool = "OPEN_TOFU"
+				`),
+				Check: Resource(
+					"spacelift_stack.test",
+					Attribute("terragrunt.0.tool", Equals("OPEN_TOFU")),
+					Attribute("terragrunt.0.terraform_version", IsNotEmpty()),
+				),
+			},
+			{ // Change to TERRAFORM with specific version
+				Config: config(`
+					tool = "TERRAFORM_FOSS"
+					terraform_version = "1.5.6"
+				`),
+				Check: Resource(
+					"spacelift_stack.test",
+					Attribute("terragrunt.0.tool", Equals("TERRAFORM_FOSS")),
+					Attribute("terragrunt.0.terraform_version", Equals("1.5.6")),
+				),
+			},
+			{ // Change to OPEN_TOFU with specific version
+				Config: config(`
+					tool = "OPEN_TOFU"
+					terraform_version = "1.6.2"
+				`),
+				Check: Resource(
+					"spacelift_stack.test",
+					Attribute("terragrunt.0.tool", Equals("OPEN_TOFU")),
+					Attribute("terragrunt.0.terraform_version", Equals("1.6.2")),
+				),
+			},
+			{ // Change to TERRAFORM without version specified
+				Config: config(`
+					tool = "TERRAFORM_FOSS"
+				`),
+				Check: Resource(
+					"spacelift_stack.test",
+					Attribute("terragrunt.0.tool", Equals("TERRAFORM_FOSS")),
+					Attribute("terragrunt.0.terraform_version", NotEquals("1.6.2")),
+				),
+			},
+			{ // Change to OPEN_TODU with invalid version
+				Config: config(`
+					tool = "OPEN_TOFU"
+					terraform_version = "1.5.6"
+				`),
+				ExpectError: regexp.MustCompile(`could not update stack: stack has 1 error: terragrunt: no supported OpenTofu version ([^ ]* - [^ ]*) satisfies constraints "1.5.6"`),
+			},
+			{ // Change to TERRAFORM with invalid version
+				Config: config(`
+					tool = "TERRAFORM_FOSS"
+					terraform_version = "1.6.2"
+				`),
+				ExpectError: regexp.MustCompile(`could not update stack: stack has 1 error: terragrunt: no supported Terraform version ([^ ]* - [^ ]*) satisfies constraints "1.6.2"`),
+			},
+			{ // Change to MANUALLY PROVISIONED
+				Config: config(`
+					tool = "MANUALLY_PROVISIONED"
+				`),
+				Check: Resource(
+					"spacelift_stack.test",
+					Attribute("terragrunt.0.tool", Equals("MANUALLY_PROVISIONED")),
+					Attribute("terragrunt.0.terraform_version", IsEmpty()),
+				),
+			},
+			{ // Back to OPEN_TOFU
+				Config: config(`
+					tool = "OPEN_TOFU"
+				`),
+				Check: Resource(
+					"spacelift_stack.test",
+					Attribute("terragrunt.0.tool", Equals("OPEN_TOFU")),
+					Attribute("terragrunt.0.terraform_version", IsNotEmpty()),
+				),
+			},
+		})
+	})
+
 	t.Run("with GitHub and no vendor-specific configuration", func(t *testing.T) {
 		testSteps(t, []resource.TestStep{
 			{

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -1488,6 +1488,43 @@ func TestStackResourceSpace(t *testing.T) {
 					Attribute("terraform_workflow_tool", Equals("CUSTOM")),
 				),
 			},
+			// Check to change from TERRAFORM_FOSS to CUSTOM with a specific version
+			// Actually, we don't need to specify the version, but when we don't do it, it will be
+			// evaluated on the first run. So, it's simpler just to specify a version for that test case.
+			{
+				Config: fmt.Sprintf(`
+					resource "spacelift_stack" "terraform_workflow_tool_custom_with_run" {
+						branch                  = "master"
+						name                    = "Provider test stack workflow_tool with run %s"
+						project_root            = "root"
+						repository              = "demo"
+						terraform_workflow_tool = "TERRAFORM_FOSS"
+						terraform_version       = "1.5.7"
+						autodeploy              = true
+					}
+				`, randomID),
+				Check: Resource(
+					"spacelift_stack.terraform_workflow_tool_custom_with_run",
+					Attribute("terraform_workflow_tool", Equals("TERRAFORM_FOSS")),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "spacelift_stack" "terraform_workflow_tool_custom_with_run" {
+						branch                  = "master"
+						name                    = "Provider test stack workflow_tool with run %s"
+						project_root            = "root"
+						repository              = "demo"
+						terraform_workflow_tool = "CUSTOM"
+						terraform_version       = ""
+						autodeploy              = true
+					}
+				`, randomID),
+				Check: Resource(
+					"spacelift_stack.terraform_workflow_tool_custom_with_run",
+					Attribute("terraform_workflow_tool", Equals("CUSTOM")),
+				),
+			},
 		})
 	})
 }


### PR DESCRIPTION
## Description of the change

Let's reset the version when we're changing the terragrunt tool. 

Step 1 - now we have computed the latest for terraform (1.5.7)
```tf
resource spacelift_stack this {
  ...
  terragrunt {
    tool = "TERRAGRUNT_FOSS"
  }
}
```

Step 2 - we expect the latest for opentofu (1.7.1)
```tf
resource spacelift_stack this {
  ...
  terragrunt {
    tool = "OPEN_TOFU"
  }
}
```

Let's reset `terraform_version` when we're changing `tool` and `terraform_version` is not specified in the config.

Let's also take care of `terraform_workflow_tool`. It's the same situation. We should reset `terraform_version` in the case of the tool change.

```tf
resource spacelift_stack this {
  ...
  terraform_workflow_tool = "TERRAFORM_FOSS"
  ...
}
```
into:
```tf
resource spacelift_stack this {
  ...
  terraform_workflow_tool = "CUSTOM"
  ...
}
```



## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [x] Changes have been reviewed by at least one other engineer
