### PR TITLE
feat(env-vars): Add `description` field to Terraform spacelift_environment_variable resource

### DIFF
--- a/docs/data-sources/environment_variable.md
+++ b/docs/data-sources/environment_variable.md
@@ -48,6 +48,7 @@ data "spacelift_environment_variable" "core-kubeconfig" {
 ### Read-Only
 
 - `checksum` (String) SHA-256 checksum of the value
+- `description` (String) Description of the environment variable
 - `id` (String) The ID of this resource.
 - `value` (String, Sensitive) value of the environment variable
 - `write_only` (Boolean) indicates whether the value can be read back outside a Run

--- a/docs/resources/environment_variable.md
+++ b/docs/resources/environment_variable.md
@@ -15,26 +15,29 @@ description: |-
 ```terraform
 # For a context
 resource "spacelift_environment_variable" "ireland-kubeconfig" {
-  context_id = "prod-k8s-ie"
-  name       = "KUBECONFIG"
-  value      = "/project/spacelift/kubeconfig"
-  write_only = false
+  context_id  = "prod-k8s-ie"
+  name        = "KUBECONFIG"
+  value       = "/project/spacelift/kubeconfig"
+  write_only  = false
+  description = "Kubeconfig for Ireland Kubernetes cluster"
 }
 
 # For a module
 resource "spacelift_environment_variable" "module-kubeconfig" {
-  module_id  = "k8s-module"
-  name       = "KUBECONFIG"
-  value      = "/project/spacelift/kubeconfig"
-  write_only = false
+  module_id   = "k8s-module"
+  name        = "KUBECONFIG"
+  value       = "/project/spacelift/kubeconfig"
+  write_only  = false
+  description = "Kubeconfig for the module"
 }
 
 # For a stack
 resource "spacelift_environment_variable" "core-kubeconfig" {
-  stack_id   = "k8s-core"
-  name       = "KUBECONFIG"
-  value      = "/project/spacelift/kubeconfig"
-  write_only = false
+  stack_id    = "k8s-core"
+  name        = "KUBECONFIG"
+  value       = "/project/spacelift/kubeconfig"
+  write_only  = false
+  description = "Kubeconfig for the core stack"
 }
 ```
 
@@ -48,6 +51,7 @@ resource "spacelift_environment_variable" "core-kubeconfig" {
 ### Optional
 
 - `context_id` (String) ID of the context on which the environment variable is defined
+- `description` (String) Description of the environment variable
 - `module_id` (String) ID of the module on which the environment variable is defined
 - `stack_id` (String) ID of the stack on which the environment variable is defined
 - `value` (String, Sensitive) Value of the environment variable. Defaults to an empty string.

--- a/examples/resources/spacelift_environment_variable/resource.tf
+++ b/examples/resources/spacelift_environment_variable/resource.tf
@@ -1,23 +1,26 @@
 # For a context
 resource "spacelift_environment_variable" "ireland-kubeconfig" {
-  context_id = "prod-k8s-ie"
-  name       = "KUBECONFIG"
-  value      = "/project/spacelift/kubeconfig"
-  write_only = false
+  context_id  = "prod-k8s-ie"
+  name        = "KUBECONFIG"
+  value       = "/project/spacelift/kubeconfig"
+  write_only  = false
+  description = "Kubeconfig for Ireland Kubernetes cluster"
 }
 
 # For a module
 resource "spacelift_environment_variable" "module-kubeconfig" {
-  module_id  = "k8s-module"
-  name       = "KUBECONFIG"
-  value      = "/project/spacelift/kubeconfig"
-  write_only = false
+  module_id   = "k8s-module"
+  name        = "KUBECONFIG"
+  value       = "/project/spacelift/kubeconfig"
+  write_only  = false
+  description = "Kubeconfig for the module"
 }
 
 # For a stack
 resource "spacelift_environment_variable" "core-kubeconfig" {
-  stack_id   = "k8s-core"
-  name       = "KUBECONFIG"
-  value      = "/project/spacelift/kubeconfig"
-  write_only = false
+  stack_id    = "k8s-core"
+  name        = "KUBECONFIG"
+  value       = "/project/spacelift/kubeconfig"
+  write_only  = false
+  description = "Kubeconfig for the core stack"
 }

--- a/spacelift/data_environment_variable.go
+++ b/spacelift/data_environment_variable.go
@@ -61,6 +61,11 @@ func dataEnvironmentVariable() *schema.Resource {
 				Description: "indicates whether the value can be read back outside a Run",
 				Computed:    true,
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "Description of the environment variable",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -192,5 +197,11 @@ func populateEnvironmentVariable(d *schema.ResourceData, el *structs.ConfigEleme
 		d.Set("value", *el.Value)
 	} else {
 		d.Set("value", nil)
+	}
+
+	if el.Description != nil {
+		d.Set("description", *el.Description)
+	} else {
+		d.Set("description", nil)
 	}
 }

--- a/spacelift/data_environment_variable_test.go
+++ b/spacelift/data_environment_variable_test.go
@@ -22,14 +22,15 @@ func TestEnvironmentVariableData(t *testing.T) {
 
 				resource "spacelift_environment_variable" "test" {
 					context_id = spacelift_context.test.id
-					name       = "BACON"
-					value      = "is tasty"
-					write_only = true
+					name        = "BACON"
+					value       = "is tasty"
+					write_only  = true
+					description = "Bacon is tasty"
 				}
 
 				data "spacelift_environment_variable" "test" {
-					context_id = spacelift_environment_variable.test.context_id
-					name       = "BACON"
+					context_id  = spacelift_environment_variable.test.context_id
+					name        = "BACON"
 				}
 			`, randomID),
 			Check: Resource(
@@ -39,6 +40,7 @@ func TestEnvironmentVariableData(t *testing.T) {
 				Attribute("name", Equals("BACON")),
 				Attribute("value", IsEmpty()),
 				Attribute("write_only", Equals("true")),
+				Attribute("description", Equals("Bacon is tasty")),
 				AttributeNotPresent("module_id"),
 				AttributeNotPresent("stack_id"),
 			),
@@ -57,10 +59,10 @@ func TestEnvironmentVariableData(t *testing.T) {
 				}
 	
 				resource "spacelift_environment_variable" "test" {
-					module_id  = spacelift_module.test.id
-					name       = "BACON"
-					value      = "is tasty"
-					write_only = false
+					module_id   = spacelift_module.test.id
+					name        = "BACON"
+					value       = "is tasty"
+					write_only  = false
 				}
 
 				data "spacelift_environment_variable" "test" {
@@ -73,6 +75,7 @@ func TestEnvironmentVariableData(t *testing.T) {
 				Attribute("module_id", Equals(fmt.Sprintf("terraform-default-test-module-%s", randomID))),
 				Attribute("value", Equals("is tasty")),
 				Attribute("write_only", Equals("false")),
+				Attribute("description", IsEmpty()),
 				AttributeNotPresent("context_id"),
 				AttributeNotPresent("stack_id"),
 			),
@@ -92,8 +95,9 @@ func TestEnvironmentVariableData(t *testing.T) {
 	
 				resource "spacelift_environment_variable" "test" {
 					stack_id = spacelift_stack.test.id
-					value    = "is tasty"
-					name     = "BACON"
+					value       = "is tasty"
+					name        = "BACON"
+					description = "Bacon is tasty"
 				}
 
 				data "spacelift_environment_variable" "test" {
@@ -105,6 +109,7 @@ func TestEnvironmentVariableData(t *testing.T) {
 				"data.spacelift_environment_variable.test",
 				Attribute("stack_id", StartsWith("test-stack-")),
 				Attribute("stack_id", Contains(randomID)),
+				Attribute("description", Equals("Bacon is tasty")),
 				AttributeNotPresent("context_id"),
 				AttributeNotPresent("module_id"),
 			),

--- a/spacelift/internal/structs/config_element.go
+++ b/spacelift/internal/structs/config_element.go
@@ -2,9 +2,10 @@ package structs
 
 // ConfigElement represents a single configuration element.
 type ConfigElement struct {
-	ID        string
-	Checksum  string
-	Type      ConfigType
-	Value     *string
-	WriteOnly bool
+	ID          string
+	Checksum    string
+	Type        ConfigType
+	Value       *string
+	WriteOnly   bool
+	Description *string
 }

--- a/spacelift/internal/structs/config_input.go
+++ b/spacelift/internal/structs/config_input.go
@@ -10,8 +10,9 @@ type ConfigType string
 // ConfigInput represents the input required to create or update a config
 // element.
 type ConfigInput struct {
-	ID        graphql.ID      `json:"id"`
-	Type      ConfigType      `json:"type"`
-	Value     graphql.String  `json:"value"`
-	WriteOnly graphql.Boolean `json:"writeOnly"`
+	ID          graphql.ID      `json:"id"`
+	Type        ConfigType      `json:"type"`
+	Value       graphql.String  `json:"value"`
+	WriteOnly   graphql.Boolean `json:"writeOnly"`
+	Description *graphql.String `json:"description"`
 }

--- a/spacelift/resource_environment_variable.go
+++ b/spacelift/resource_environment_variable.go
@@ -82,6 +82,12 @@ func resourceEnvironmentVariable() *schema.Resource {
 				Default:     true,
 				ForceNew:    true,
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "Description of the environment variable",
+				Optional:    true,
+				ForceNew:    true,
+			},
 		},
 	}
 }
@@ -89,10 +95,11 @@ func resourceEnvironmentVariable() *schema.Resource {
 func resourceEnvironmentVariableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	variables := map[string]interface{}{
 		"config": structs.ConfigInput{
-			ID:        toID(d.Get("name")),
-			Type:      structs.ConfigType("ENVIRONMENT_VARIABLE"),
-			Value:     toString(d.Get("value")),
-			WriteOnly: graphql.Boolean(d.Get("write_only").(bool)),
+			ID:          toID(d.Get("name")),
+			Type:        structs.ConfigType("ENVIRONMENT_VARIABLE"),
+			Value:       toString(d.Get("value")),
+			WriteOnly:   graphql.Boolean(d.Get("write_only").(bool)),
+			Description: toOptionalString(d.Get("description")),
 		},
 	}
 
@@ -202,6 +209,12 @@ func resourceEnvironmentVariableRead(ctx context.Context, d *schema.ResourceData
 		d.Set("value", *value)
 	} else {
 		d.Set("value", element.Checksum)
+	}
+
+	if description := element.Description; description != nil {
+		d.Set("description", *description)
+	} else {
+		d.Set("description", nil)
 	}
 
 	return nil


### PR DESCRIPTION
## Description of the change

> Adding a new optional field to spacelift_environment_variable Terraform module called **description**, [more details](https://app.clickup.com/t/8695950mj).

![image](https://github.com/user-attachments/assets/c9d69321-20e9-4a2b-b950-bd72c5dca0da)
<img width="505" alt="image" src="https://github.com/user-attachments/assets/97d67cb7-e990-4824-9539-7bba9916c258">


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
