### PR TITLE
fix: disable audit webhook in tests

### DIFF
--- a/spacelift/resource_audit_trail_webhook_test.go
+++ b/spacelift/resource_audit_trail_webhook_test.go
@@ -41,7 +41,7 @@ func Test_resourceAuditTrailWebhook(t *testing.T) {
 				Config: fmt.Sprintf(auditTrailWebhookSimple, "https://example.com"),
 				Check: Resource(
 					resourceName,
-					Attribute("enabled", Equals("true")),
+					Attribute("enabled", Equals("false")),
 					Attribute("endpoint", Equals("https://example.com")),
 					Attribute("include_runs", Equals("true")),
 					Attribute("secret", Equals("secret")),
@@ -56,7 +56,7 @@ func Test_resourceAuditTrailWebhook(t *testing.T) {
 				Config: fmt.Sprintf(auditTrailWebhookCustomHeaders, "https://example.com"),
 				Check: Resource(
 					resourceName,
-					Attribute("enabled", Equals("true")),
+					Attribute("enabled", Equals("false")),
 					Attribute("endpoint", Equals("https://example.com")),
 					Attribute("include_runs", Equals("true")),
 					Attribute("secret", Equals("secret")),

--- a/spacelift/resource_audit_trail_webhook_test.go
+++ b/spacelift/resource_audit_trail_webhook_test.go
@@ -12,7 +12,7 @@ import (
 
 const auditTrailWebhookSimple = `
 resource "spacelift_audit_trail_webhook" "test" {
-	enabled = true
+	enabled = false
 	endpoint = "%s"
 	include_runs = true
 	secret = "secret"
@@ -21,7 +21,7 @@ resource "spacelift_audit_trail_webhook" "test" {
 
 const auditTrailWebhookCustomHeaders = `
 resource "spacelift_audit_trail_webhook" "test" {
-	enabled = true
+	enabled = false
 	endpoint = "%s"
 	include_runs = true
 	secret = "secret"

--- a/spacelift/resource_audit_trail_webhook_test.go
+++ b/spacelift/resource_audit_trail_webhook_test.go
@@ -68,11 +68,11 @@ func Test_resourceAuditTrailWebhook(t *testing.T) {
 		})
 	})
 
-	t.Run("endpoint has to exist", func(t *testing.T) {
+	t.Run("endpoint has to be valid", func(t *testing.T) {
 		testSteps(t, []resource.TestStep{
 			{
-				Config:      fmt.Sprintf(auditTrailWebhookSimple, "https://invalidendpoint.com/"),
-				ExpectError: regexp.MustCompile(`could not send webhook to given endpoint`),
+				Config:      fmt.Sprintf(auditTrailWebhookSimple, "https:/invalidendpoint.com/"),
+				ExpectError: regexp.MustCompile(`endpoint must be a valid URL`),
 			},
 		})
 	})


### PR DESCRIPTION
## Description of the change

We dont want to send requests to the this domain in tests, lets disable it 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
