### PR TITLE
Handle slash at endpoint

### DIFF
--- a/spacelift/provider.go
+++ b/spacelift/provider.go
@@ -225,7 +225,11 @@ func buildClientFromToken(token string) (*internal.Client, error) {
 
 func buildClientFromAPIKeyData(d *schema.ResourceData) (*internal.Client, error) {
 	// Since validation runs first, we can safely assume that the data is there.
-	endpoint := fmt.Sprintf("%s/graphql", d.Get("api_key_endpoint").(string))
+
+	// Handle / at api_key_endpoint
+	endpoint := strings.TrimSuffix(d.Get("api_key_endpoint").(string), "/")
+	endpoint = fmt.Sprintf("%s/graphql", endpoint)
+
 	apiKeyID := d.Get("api_key_id").(string)
 	apiKeySecret := d.Get("api_key_secret").(string)
 


### PR DESCRIPTION
## Description of the change

Updated the code that builds the URL for the GraphQL API to handle the situation where the `api_key_endpoint` setting includes a trailing `/`.

This is the PR from @akmal-spacelift from [here](https://github.com/spacelift-io/terraform-provider-spacelift/pull/568).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
