### PR TITLE
feat: add additional properties to the spacelift_current_space data source

### DIFF
--- a/docs/data-sources/current_space.md
+++ b/docs/data-sources/current_space.md
@@ -27,4 +27,9 @@ resource "spacelift_context" "prod-k8s-ie" {
 
 ### Read-Only
 
+- `description` (String) free-form space description for users
 - `id` (String) The ID of this resource.
+- `inherit_entities` (Boolean) indication whether access to this space inherits read access to entities from the parent space
+- `labels` (Set of String) list of labels describing a space
+- `name` (String) name of the space
+- `parent_space_id` (String) immutable ID (slug) of parent space

--- a/spacelift/data_current_space.go
+++ b/spacelift/data_current_space.go
@@ -119,5 +119,5 @@ func dataCurrentSpaceRead(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
-	return diag.Errorf("could not find stack or module with ID %s", stackID)
+	return nil
 }

--- a/spacelift/data_current_space.go
+++ b/spacelift/data_current_space.go
@@ -99,7 +99,7 @@ func dataCurrentSpaceRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.SetId(space.ID)
 	d.Set("name", space.Name)
-	d.Set("description", space.Name)
+	d.Set("description", space.Description)
 	d.Set("inherit_entities", space.InheritEntities)
 
 	labels := schema.NewSet(schema.HashString, []interface{}{})

--- a/spacelift/data_space.go
+++ b/spacelift/data_space.go
@@ -55,26 +55,19 @@ func dataSpace() *schema.Resource {
 	}
 }
 
-func queryForSpace(ctx context.Context, client *internal.Client, spaceID string) (*structs.Space, error) {
+func dataSpaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var query struct {
 		Space *structs.Space `graphql:"space(id: $id)"`
 	}
 
-	variables := map[string]interface{}{"id": toID(spaceID)}
-	if err := client.Query(ctx, "SpaceRead", &query, variables); err != nil {
-		return nil, err
-	}
-
-	return query.Space, nil
-}
-
-func dataSpaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	spaceID := d.Get("space_id")
-	space, err := queryForSpace(ctx, meta.(*internal.Client), spaceID.(string))
-	if err != nil {
+
+	variables := map[string]interface{}{"id": toID(spaceID)}
+	if err := meta.(*internal.Client).Query(ctx, "SpaceRead", &query, variables); err != nil {
 		return diag.Errorf("could not query for space: %v", err)
 	}
 
+	space := query.Space
 	if space == nil {
 		return diag.Errorf("could not find space %s", spaceID)
 	}

--- a/spacelift/internal/structs/module.go
+++ b/spacelift/internal/structs/module.go
@@ -23,6 +23,7 @@ type Module struct {
 	RepositoryURL       *string      `graphql:"repositoryURL"`
 	SharedAccounts      []string     `graphql:"sharedAccounts"`
 	Space               string       `graphql:"space"`
+	SpaceDetails        Space        `graphql:"spaceDetails"`
 	TerraformProvider   string       `graphql:"terraformProvider"`
 	VCSIntegration      *struct {
 		ID        string `graphql:"id"`

--- a/spacelift/internal/structs/stack.go
+++ b/spacelift/internal/structs/stack.go
@@ -60,6 +60,7 @@ type Stack struct {
 	RepositoryURL                *string       `graphql:"repositoryURL"`
 	RunnerImage                  *string       `graphql:"runnerImage"`
 	Space                        string        `graphql:"space"`
+	SpaceDetails                 Space         `graphql:"spaceDetails"`
 	TerraformVersion             *string       `graphql:"terraformVersion"`
 	VCSIntegration               *struct {
 		ID        string `graphql:"id"`


### PR DESCRIPTION
## Description of the change

Adds the same properties that `space` data source has to the `spacelift_current_space` data source.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)


### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
