### PR TITLE
Update resource_context.go

### DIFF
--- a/spacelift/resource_context.go
+++ b/spacelift/resource_context.go
@@ -137,6 +137,7 @@ func resourceContext() *schema.Resource {
 			},
 			"labels": {
 				Type: schema.TypeSet,
+				Description: "To leverage the `autoattach` magic label, ensure your label follows the naming convention: `autoattach:<your-label-name>`"
 				Elem: &schema.Schema{
 					Type:             schema.TypeString,
 					ValidateDiagFunc: validations.DisallowEmptyString,


### PR DESCRIPTION
Mentioned that a user can include autoattach if they are creating contexts via our TF provider

## Description of the change

> Description here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
