### PR TITLE
Convert user policies from `List` to `Set`

### DIFF
--- a/docs/resources/idp_group_mapping.md
+++ b/docs/resources/idp_group_mapping.md
@@ -28,7 +28,7 @@ resource "spacelift_idp_group_mapping" "test" {
 ### Required
 
 - `name` (String) Name of the user group - should be unique in one account
-- `policy` (Block List, Min: 1) (see [below for nested schema](#nestedblock--policy))
+- `policy` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--policy))
 
 ### Read-Only
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -17,7 +17,7 @@ description: |-
 
 ### Required
 
-- `policy` (Block List, Min: 1) (see [below for nested schema](#nestedblock--policy))
+- `policy` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--policy))
 - `username` (String) Username of the user
 
 ### Optional

--- a/spacelift/resource_user.go
+++ b/spacelift/resource_user.go
@@ -35,7 +35,7 @@ func resourceUser() *schema.Resource {
 				Description: "Username of the user",
 			},
 			"policy": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				MinItems: 1,
 				Required: true,
 				Elem: &schema.Resource{
@@ -55,6 +55,7 @@ func resourceUser() *schema.Resource {
 						},
 					},
 				},
+				Set: userPolicyHash,
 			},
 			"invitation_email": {
 				Type:        schema.TypeString,
@@ -63,6 +64,19 @@ func resourceUser() *schema.Resource {
 			},
 		},
 	}
+}
+
+func userPolicyHash(v interface{}) int {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return 0
+	}
+
+	spaceID, _ := m["space_id"].(string)
+	role, _ := m["role"].(string)
+
+	key := spaceID + "-" + role
+	return schema.HashString(key)
 }
 
 func resourceUserCreate(ctx context.Context, d *schema.ResourceData, i interface{}) diag.Diagnostics {


### PR DESCRIPTION
## Description of the change

This is essentially @bushong1 's change, plus some additional fixes. Quoting:

https://github.com/spacelift-io/terraform-provider-spacelift/pull/577

> I’ve been having some trouble with the Spacelift Terraform provider when managing user access policies. Every time I add a new policy, Terraform tries to delete and recreate some of the existing ones—even though they haven’t changed at all. It’s like it’s getting confused about what’s actually new and what’s already there.
> I think the problem is with how the policy field is set up in the spacelift_user resource. Right now, it’s defined as a TypeList, which is ordered. So when I insert a new policy somewhere other than the end of the list, it shifts the order, and Terraform thinks the policies have changed.
> To fix this, I think we should change policy from a TypeList to a TypeSet. Sets are unordered, so Terraform won’t care about the order of the policies anymore. Also, by adding a custom hash function that combines space_id and role, we can uniquely identify each policy.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
