### PR TITLE
feat: spacelift_stack save md5 hash of import_state to state and force new

### DIFF
--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -17,6 +17,17 @@ import (
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
+func resourceStackResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"import_state": {
+				Type:             schema.TypeString,
+			},
+		},
+	}
+}
+
+
 func resourceStack() *schema.Resource {
 	return &schema.Resource{
 		Description: "" +
@@ -32,6 +43,19 @@ func resourceStack() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceStackImport,
+		},
+
+		SchemaVersion: 1,
+
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				Type:   resourceStackResourceV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error){
+					rawState["import_state"] = ""
+					return rawState, nil
+				},
+			},
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -405,6 +429,9 @@ func resourceStack() *schema.Resource {
 				Optional:         true,
 				DiffSuppressFunc: ignoreOnceCreated,
 				Sensitive:        true,
+				StateFunc:        func(v interface{}) string {
+					return ""
+				},
 			},
 			"import_state_file": {
 				Type:             schema.TypeString,

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -331,7 +331,7 @@ func TestStackResource(t *testing.T) {
 					name                  = "labelled-module-%s"
 					branch                = "master"
 					labels                = []
-					repository            = "terraform-bacon-tasty"
+					repository            = "demo"
 				}`, randomID),
 				Check: Resource(
 					"spacelift_stack.test",
@@ -1482,7 +1482,7 @@ func TestStackResourceSpace(t *testing.T) {
 					name                  = "labelled-module-%s"
 					branch                = "master"
 					labels                = []
-					repository            = "terraform-bacon-tasty"
+					repository            = "demo"
 				}`, randomID),
 				Check: Resource(
 					"spacelift_stack.test",
@@ -1633,6 +1633,27 @@ func TestStackResourceSpace(t *testing.T) {
 				Check: Resource(
 					"spacelift_stack.terraform_workflow_tool_custom_with_run",
 					Attribute("terraform_workflow_tool", Equals("CUSTOM")),
+				),
+			},
+		})
+	})
+
+	t.Run("with import_state", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "state_import" {
+					branch                  = "master"
+					name                    = "Provider test stack workflow_tool default %s"
+					project_root            = "root"
+					repository              = "demo"
+					import_state            = "{}"
+				}
+			`, randomID),
+				Check: Resource(
+					"spacelift_stack.state_import",
+					Attribute("import_state", Equals("")),
 				),
 			},
 		})


### PR DESCRIPTION
**DO NOT MERGE**

Need to think through how to make this work without causing everyones stack to update on provider update.


We should not save the state to state when using `import_state`. It causes huge amounts of memory to get consumed while terraform validates state and can cause statefiles to bloat dependending on how many stacks are created in one statefile.

One option would be to set `import_state` to an empty string after the stack is created. But wanted to get ideas on if theres a better way to do this, which is why I tried to MD5 it instead.