### PR TITLE
feat: add `kubernete_workflow_tool` property to the kubernetes schema

### DIFF
--- a/docs/data-sources/stack.md
+++ b/docs/data-sources/stack.md
@@ -153,6 +153,7 @@ Read-Only:
 Read-Only:
 
 - `kubectl_version` (String)
+- `kubernetes_workflow_tool` (String)
 - `namespace` (String)
 
 

--- a/docs/data-sources/stacks.md
+++ b/docs/data-sources/stacks.md
@@ -250,6 +250,7 @@ Read-Only:
 Read-Only:
 
 - `kubectl_version` (String)
+- `kubernetes_workflow_tool` (String)
 - `namespace` (String)
 
 

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -367,6 +367,7 @@ Read-Only:
 Optional:
 
 - `kubectl_version` (String) Kubectl version.
+- `kubernetes_workflow_tool` (String) Defines the tool that will be used to execute the workflow. This can be one of `KUBERNETES` or `CUSTOM`. Defaults to `KUBERNETES`.
 - `namespace` (String) Namespace of the Kubernetes cluster to run commands on. Leave empty for multi-namespace Stacks.
 
 

--- a/spacelift/data_stack.go
+++ b/spacelift/data_stack.go
@@ -322,6 +322,11 @@ func dataStack() *schema.Resource {
 							Description: "Kubectl version.",
 							Computed:    true,
 						},
+						"kubernetes_workflow_tool": {
+							Type:             schema.TypeString,
+							Description: "Defines the tool that will be used to execute the workflow. This can be one of `KUBERNETES` or `CUSTOM`. Defaults to `KUBERNETES`.",
+							Computed:         true,
+						},
 					},
 				},
 			},

--- a/spacelift/data_stack_test.go
+++ b/spacelift/data_stack_test.go
@@ -190,6 +190,7 @@ func TestStackData(t *testing.T) {
 			Check: Resource(
 				"data.spacelift_stack.test",
 				Attribute("kubernetes.0.kubectl_version", IsNotEmpty()),
+				Attribute("kubernetes.0.kubernetes_workflow_tool", Equals("KUBERNETES")),
 			),
 		}})
 	})
@@ -214,6 +215,33 @@ func TestStackData(t *testing.T) {
 			Check: Resource(
 				"data.spacelift_stack.test",
 				Attribute("kubernetes.0.kubectl_version", Equals("1.2.3")),
+				Attribute("kubernetes.0.kubernetes_workflow_tool", Equals("KUBERNETES")),
+			),
+		}})
+	})
+
+	t.Run("with Kubernetes stack with a kubernetes workflow tool", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{{
+			Config: fmt.Sprintf(`
+			resource "spacelift_stack" "test" {
+				branch              = "master"
+				name                = "Test stack %s"
+				repository          = "demo"
+				kubernetes {
+					kubectl_version = "1.2.3"
+					kubernetes_workflow_tool = "CUSTOM"
+				}
+			}
+			data "spacelift_stack" "test" {
+				stack_id = spacelift_stack.test.id
+			}
+		`, randomID),
+			Check: Resource(
+				"data.spacelift_stack.test",
+				Attribute("kubernetes.0.kubectl_version", Equals("1.2.3")),
+				Attribute("kubernetes.0.kubernetes_workflow_tool", Equals("CUSTOM")),
 			),
 		}})
 	})

--- a/spacelift/data_stack_test.go
+++ b/spacelift/data_stack_test.go
@@ -230,7 +230,6 @@ func TestStackData(t *testing.T) {
 				name                = "Test stack %s"
 				repository          = "demo"
 				kubernetes {
-					kubectl_version = "1.2.3"
 					kubernetes_workflow_tool = "CUSTOM"
 				}
 			}
@@ -240,7 +239,6 @@ func TestStackData(t *testing.T) {
 		`, randomID),
 			Check: Resource(
 				"data.spacelift_stack.test",
-				Attribute("kubernetes.0.kubectl_version", Equals("1.2.3")),
 				Attribute("kubernetes.0.kubernetes_workflow_tool", Equals("CUSTOM")),
 			),
 		}})

--- a/spacelift/internal/structs/stack.go
+++ b/spacelift/internal/structs/stack.go
@@ -80,6 +80,7 @@ type Stack struct {
 		Kubernetes struct {
 			Namespace      string  `graphql:"namespace"`
 			KubectlVersion *string `graphql:"kubectlVersion"`
+			KubernetesWorkflowTool *string `graphql:"kubernetesWorkflowTool"`
 		} `graphql:"... on StackConfigVendorKubernetes"`
 		Pulumi struct {
 			LoginURL  string `graphql:"loginURL"`
@@ -136,6 +137,7 @@ func (s *Stack) IaCSettings() (string, map[string]interface{}) {
 		return "kubernetes", map[string]interface{}{
 			"namespace":       s.VendorConfig.Kubernetes.Namespace,
 			"kubectl_version": s.VendorConfig.Kubernetes.KubectlVersion,
+			"kubernetes_workflow_tool": s.VendorConfig.Kubernetes.KubernetesWorkflowTool,
 		}
 	case StackConfigVendorPulumi:
 		return "pulumi", map[string]interface{}{
@@ -281,6 +283,7 @@ func PopulateStack(d *schema.ResourceData, stack *Stack) error {
 		m := map[string]interface{}{
 			"namespace":       stack.VendorConfig.Kubernetes.Namespace,
 			"kubectl_version": stack.VendorConfig.Kubernetes.KubectlVersion,
+			"kubernetes_workflow_tool": stack.VendorConfig.Kubernetes.KubernetesWorkflowTool,
 		}
 
 		d.Set("kubernetes", []interface{}{m})

--- a/spacelift/internal/structs/stack_input.go
+++ b/spacelift/internal/structs/stack_input.go
@@ -65,7 +65,8 @@ type CloudFormationInput struct {
 // KubernetesInput represents Kubernetes-specific configuration.
 type KubernetesInput struct {
 	Namespace      graphql.String  `json:"namespace"`
-	KubectlVersion *graphql.String `json:"kubectlVersion"`
+	KubectlVersion *graphql.String `json:"kubectlVersionkubectlVersion"`
+	KubernetesWorkflowTool *graphql.String `json:"kubernetesWorkflowTool"`
 }
 
 // PulumiInput represents Pulumi-specific configuration.

--- a/spacelift/internal/structs/stack_input.go
+++ b/spacelift/internal/structs/stack_input.go
@@ -65,7 +65,7 @@ type CloudFormationInput struct {
 // KubernetesInput represents Kubernetes-specific configuration.
 type KubernetesInput struct {
 	Namespace      graphql.String  `json:"namespace"`
-	KubectlVersion *graphql.String `json:"kubectlVersionkubectlVersion"`
+	KubectlVersion *graphql.String `json:"kubectlVersion"`
 	KubernetesWorkflowTool *graphql.String `json:"kubernetesWorkflowTool"`
 }
 

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -458,6 +458,13 @@ func resourceStack() *schema.Resource {
 							Computed:         true,
 							ValidateDiagFunc: validations.DisallowEmptyString,
 						},
+						"kubernetes_workflow_tool": {
+							Type:             schema.TypeString,
+							Description: "Defines the tool that will be used to execute the workflow. This can be one of `KUBERNETES` or `CUSTOM`. Defaults to `KUBERNETES`.",
+							Optional:         true,
+							Computed:         true,
+							ValidateDiagFunc: validations.DisallowEmptyString,
+						},
 					},
 				},
 			},
@@ -960,6 +967,9 @@ func getVendorConfig(d *schema.ResourceData) *structs.VendorConfigInput {
 			vendorConfig.Kubernetes.Namespace = toString(kubernetesSettings["namespace"])
 			if s := toOptionalString(kubernetesSettings["kubectl_version"]); *s != "" {
 				vendorConfig.Kubernetes.KubectlVersion = s
+			}
+			if s := toOptionalString(kubernetesSettings["kubernetes_workflow_tool"]); *s != "" {
+				vendorConfig.Kubernetes.KubernetesWorkflowTool = s
 			}
 		}
 		return vendorConfig

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -484,7 +484,7 @@ func TestStackResource(t *testing.T) {
 		})
 	})
 
-	t.Run("with GitHub and Kubernetes configuration", func(t *testing.T) {
+	t.Run("with GitHub and Kubernetes (default tool) configuration", func(t *testing.T) {
 		testSteps(t, []resource.TestStep{
 			{
 				Config: getConfig(`kubernetes {}`),
@@ -493,7 +493,7 @@ func TestStackResource(t *testing.T) {
 					Attribute("id", StartsWith("provider-test-stack")),
 					Attribute("kubernetes.0.namespace", Equals("")),
 					Attribute("kubernetes.0.kubectl_version", IsNotEmpty()),
-					Attribute("kubernetes.0.kubernetes_workflow_version", Equals("KUBERNETES")),
+					Attribute("kubernetes.0.kubernetes_workflow_tool", Equals("KUBERNETES")),
 					Attribute("ansible.#", Equals("0")),
 					Attribute("pulumi.#", Equals("0")),
 					Attribute("cloudformation.#", Equals("0")),
@@ -509,7 +509,7 @@ func TestStackResource(t *testing.T) {
 					Attribute("id", StartsWith("provider-test-stack")),
 					Attribute("kubernetes.0.namespace", Equals("myapp-prod")),
 					Attribute("kubernetes.0.kubectl_version", IsNotEmpty()),
-					Attribute("kubernetes.0.kubernetes_workflow_version", Equals("KUBERNETES")),
+					Attribute("kubernetes.0.kubernetes_workflow_tool", Equals("KUBERNETES")),
 					Attribute("ansible.#", Equals("0")),
 					Attribute("pulumi.#", Equals("0")),
 					Attribute("cloudformation.#", Equals("0")),
@@ -524,22 +524,27 @@ func TestStackResource(t *testing.T) {
 					Attribute("id", StartsWith("provider-test-stack")),
 					Attribute("kubernetes.0.namespace", Equals("")),
 					Attribute("kubernetes.0.kubectl_version", Equals("1.2.3")),
-					Attribute("kubernetes.0.kubernetes_workflow_version", Equals("KUBERNETES")),
+					Attribute("kubernetes.0.kubernetes_workflow_tool", Equals("KUBERNETES")),
 					Attribute("ansible.#", Equals("0")),
 					Attribute("pulumi.#", Equals("0")),
 					Attribute("cloudformation.#", Equals("0")),
 				),
 			},
+		})
+	})
+
+	t.Run("with GitHub and Kubernetes (CUSTOM) configuration", func(t *testing.T) {
+		testSteps(t, []resource.TestStep{
 			{
 				Config: getConfig(`kubernetes {
-						kubernetes_workflow_version = "CUSTOM"
+						namespace = "myapp-prod"
+						kubernetes_workflow_tool = "CUSTOM"
 					}`),
 				Check: Resource(
 					resourceName,
 					Attribute("id", StartsWith("provider-test-stack")),
-					Attribute("kubernetes.0.namespace", Equals("")),
-					Attribute("kubernetes.0.kubectl_version", IsNotEmpty()),
-					Attribute("kubernetes.0.kubernetes_workflow_version", Equals("CUSTOM")),
+					Attribute("kubernetes.0.namespace", Equals("myapp-prod")),
+					Attribute("kubernetes.0.kubernetes_workflow_tool", Equals("CUSTOM")),
 					Attribute("ansible.#", Equals("0")),
 					Attribute("pulumi.#", Equals("0")),
 					Attribute("cloudformation.#", Equals("0")),
@@ -1303,6 +1308,8 @@ func TestStackResourceSpace(t *testing.T) {
 					Attribute("repository", Equals("demo")),
 					Attribute("runner_image", Equals("custom_image:runner")),
 					Attribute("kubernetes.0.namespace", Equals("myapp-prod")),
+					Attribute("kubernetes.0.kubectl_version", IsNotEmpty()),
+					Attribute("kubernetes.0.kubernetes_workflow_tool", Equals("KUBERNETES")),
 					Attribute("ansible.#", Equals("0")),
 					Attribute("pulumi.#", Equals("0")),
 					Attribute("cloudformation.#", Equals("0")),

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -493,6 +493,7 @@ func TestStackResource(t *testing.T) {
 					Attribute("id", StartsWith("provider-test-stack")),
 					Attribute("kubernetes.0.namespace", Equals("")),
 					Attribute("kubernetes.0.kubectl_version", IsNotEmpty()),
+					Attribute("kubernetes.0.kubernetes_workflow_version", Equals("KUBERNETES")),
 					Attribute("ansible.#", Equals("0")),
 					Attribute("pulumi.#", Equals("0")),
 					Attribute("cloudformation.#", Equals("0")),
@@ -508,6 +509,7 @@ func TestStackResource(t *testing.T) {
 					Attribute("id", StartsWith("provider-test-stack")),
 					Attribute("kubernetes.0.namespace", Equals("myapp-prod")),
 					Attribute("kubernetes.0.kubectl_version", IsNotEmpty()),
+					Attribute("kubernetes.0.kubernetes_workflow_version", Equals("KUBERNETES")),
 					Attribute("ansible.#", Equals("0")),
 					Attribute("pulumi.#", Equals("0")),
 					Attribute("cloudformation.#", Equals("0")),
@@ -522,6 +524,22 @@ func TestStackResource(t *testing.T) {
 					Attribute("id", StartsWith("provider-test-stack")),
 					Attribute("kubernetes.0.namespace", Equals("")),
 					Attribute("kubernetes.0.kubectl_version", Equals("1.2.3")),
+					Attribute("kubernetes.0.kubernetes_workflow_version", Equals("KUBERNETES")),
+					Attribute("ansible.#", Equals("0")),
+					Attribute("pulumi.#", Equals("0")),
+					Attribute("cloudformation.#", Equals("0")),
+				),
+			},
+			{
+				Config: getConfig(`kubernetes {
+						kubernetes_workflow_version = "CUSTOM"
+					}`),
+				Check: Resource(
+					resourceName,
+					Attribute("id", StartsWith("provider-test-stack")),
+					Attribute("kubernetes.0.namespace", Equals("")),
+					Attribute("kubernetes.0.kubectl_version", IsNotEmpty()),
+					Attribute("kubernetes.0.kubernetes_workflow_version", Equals("CUSTOM")),
 					Attribute("ansible.#", Equals("0")),
 					Attribute("pulumi.#", Equals("0")),
 					Attribute("cloudformation.#", Equals("0")),


### PR DESCRIPTION
## Description of the change

Currently, users can only select custom workflow through the UI. A user has requested to be able to do it through the provider also. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

[Support custom workflow for kubernetes stack through terraform creation.](https://app.clickup.com/t/8694afyu7)

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
