### PR TITLE
fix: install TF on doc workflow

### DIFF
--- a/.github/workflows/check-documentation.yml
+++ b/.github/workflows/check-documentation.yml
@@ -21,6 +21,12 @@ jobs:
         uses: actions/setup-go@v5
         with: { go-version-file: go.mod }
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.10.5"
+          terraform_wrapper: false
+
       - name: Generate documentation
         run: cd tools && go generate ./...
 

--- a/.github/workflows/test-prod.yml
+++ b/.github/workflows/test-prod.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
         with:
+          terraform_version: "1.10.5"
           terraform_wrapper: false
 
       - name: Test with coverage (prod - just checking it will works, no env missing etc)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
         with:
+          terraform_version: "1.10.5"
           terraform_wrapper: false
 
       - name: Test with coverage


### PR DESCRIPTION
## Description of the change

Terraform binary has been removed from ubuntu-latest, so let's install
it in our pipeline.

I also pinned TF version used in all workflows to avoid surprises.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
