### PR TITLE
fix: error when updating an AWS integration attachment

### DIFF
--- a/spacelift/resource_aws_integration_attachment.go
+++ b/spacelift/resource_aws_integration_attachment.go
@@ -152,7 +152,7 @@ func resourceAWSIntegrationAttachmentRead(ctx context.Context, d *schema.Resourc
 
 func resourceAWSIntegrationAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var mutation struct {
-		awsIntegrationAttachmentUpdate structs.AWSIntegrationAttachment `graphql:"awsIntegrationAttachmentUpdate(id: $id, read: $read, write: $write)"`
+		AWSIntegrationAttachmentUpdate structs.AWSIntegrationAttachment `graphql:"awsIntegrationAttachmentUpdate(id: $id, read: $read, write: $write)"`
 	}
 
 	variables := map[string]interface{}{

--- a/spacelift/resource_aws_integration_attachment_test.go
+++ b/spacelift/resource_aws_integration_attachment_test.go
@@ -83,4 +83,63 @@ func TestAWSIntegrationAttachmentResource(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("update attachment", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "spacelift_stack" "test" {
+						branch     = "master"
+						repository = "demo"
+						name       = "Test stack %s"
+					}
+
+					resource "spacelift_aws_integration" "test" {
+						name                           = "test-aws-integration-%s"
+						role_arn                       = "arn:aws:iam::039653571618:role/empty-test-role"
+						generate_credentials_in_worker = false
+					}
+
+					resource "spacelift_aws_integration_attachment" "test" {
+						stack_id       = spacelift_stack.test.id
+						integration_id = spacelift_aws_integration.test.id
+						read           = true
+						write          = false
+					}
+				`, randomID, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("write", Equals("false")),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "spacelift_stack" "test" {
+						branch     = "master"
+						repository = "demo"
+						name       = "Test stack %s"
+					}
+
+					resource "spacelift_aws_integration" "test" {
+						name                           = "test-aws-integration-%s"
+						role_arn                       = "arn:aws:iam::039653571618:role/empty-test-role"
+						generate_credentials_in_worker = false
+					}
+
+					resource "spacelift_aws_integration_attachment" "test" {
+						stack_id       = spacelift_stack.test.id
+						integration_id = spacelift_aws_integration.test.id
+						read           = true
+						write          = true
+					}
+				`, randomID, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("write", Equals("true")),
+				),
+			},
+		})
+	})
 }


### PR DESCRIPTION
## Description of the change

The problem is that the field used to store the response from the mutation wasn't exported, causing the `struct field for "awsIntegrationAttachmentUpdate" doesn't exist in any of 1 places to unmarshal` error.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

Fixes #610

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
