### PR TITLE
fix: set terraform_version attribute only if it is specified

### DIFF
--- a/spacelift/internal/structs/stack.go
+++ b/spacelift/internal/structs/stack.go
@@ -307,7 +307,9 @@ func PopulateStack(d *schema.ResourceData, stack *Stack) error {
 
 	default:
 		d.Set("terraform_smart_sanitization", stack.VendorConfig.Terraform.UseSmartSanitization)
-		d.Set("terraform_version", stack.VendorConfig.Terraform.Version)
+		if stack.VendorConfig.Terraform.Version != nil {
+			d.Set("terraform_version", *stack.VendorConfig.Terraform.Version)
+		}
 		d.Set("terraform_workflow_tool", stack.VendorConfig.Terraform.WorkflowTool)
 		d.Set("terraform_workspace", stack.VendorConfig.Terraform.Workspace)
 		d.Set("terraform_external_state_access", stack.VendorConfig.Terraform.ExternalStateAccessEnabled)

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -888,6 +888,56 @@ func TestStackResource(t *testing.T) {
 		})
 	})
 
+	t.Run("with terraform_version", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "this" {
+					branch                  = "master"
+					name                    = "Provider test stack workflow_tool default %s"
+					project_root            = "root"
+					repository              = "demo"
+				}
+			`, randomID),
+				Check: Resource(
+					"spacelift_stack.this",
+					AttributeNotPresent("terraform_version"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "this" {
+					branch                  = "master"
+					name                    = "Provider test stack workflow_tool default %s"
+					project_root            = "root"
+					repository              = "demo"
+					terraform_version       = null
+				}
+			`, randomID),
+				Check: Resource(
+					"spacelift_stack.this",
+					AttributeNotPresent("terraform_version"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "this" {
+					branch                  = "master"
+					name                    = "Provider test stack workflow_tool default %s"
+					project_root            = "root"
+					repository              = "demo"
+					terraform_version       = "1.5.7"
+				}
+			`, randomID),
+				Check: Resource(
+					"spacelift_stack.this",
+					Attribute("terraform_version", Equals("1.5.7")),
+				),
+			},
+		})
+	})
 }
 
 func TestStackResourceSpace(t *testing.T) {


### PR DESCRIPTION
## Description of the change

If the `terraform_version` attribute was not specified, we would still set it to an empty string after applying, which could result in an inconsistent final plan.

Fixes #619

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
