### PR TITLE
fix: ignore not found error

### DIFF
--- a/spacelift/internal/client.go
+++ b/spacelift/internal/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -51,7 +52,11 @@ func (c *Client) Mutate(ctx context.Context, mutationName string, m interface{},
 func (c *Client) Query(ctx context.Context, queryName string, q interface{}, variables map[string]interface{}) error {
 	client := c.client()
 
-	return client.Query(ctx, q, variables, graphql.WithHeader("Spacelift-GraphQL-Query", queryName))
+	err := client.Query(ctx, q, variables, graphql.WithHeader("Spacelift-GraphQL-Query", queryName))
+	if err != nil && strings.Contains(err.Error(), "not found") {
+		return nil
+	}
+	return err
 }
 
 func (c *Client) client() *graphql.Client {


### PR DESCRIPTION
## Description of the change

Spacelict API returns somewhat inconsistent errors for not-found resources.

For some resources (like stacks), it returns null values in the results, but for other queries, it returns a "not found" error.

The problem is that we decide to recreate a resource if the response is null, but if it’s an error response, then we return an error to the end user.

This PR changes the error handling of the query method and returns an empty result on not found error.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
