### PR TITLE
feat: reset worker pools on csr update

### DIFF
--- a/docs/resources/worker_pool.md
+++ b/docs/resources/worker_pool.md
@@ -29,7 +29,7 @@ resource "spacelift_worker_pool" "k8s-core" {
 
 ### Optional
 
-- `csr` (String, Sensitive) certificate signing request in base64
+- `csr` (String, Sensitive) certificate signing request in base64. Changing this value will trigger a token reset.
 - `description` (String) description of the worker pool
 - `labels` (Set of String)
 - `space_id` (String) ID (slug) of the space the worker pool is in

--- a/spacelift/resource_worker_pool.go
+++ b/spacelift/resource_worker_pool.go
@@ -231,11 +231,9 @@ func resourceWorkerPoolUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			return diag.Errorf("could not reset worker pool token: %v", internal.FromSpaceliftError(err))
 		}
 
-		// Update the config with the new token info
 		d.Set("config", resetMutation.WorkerPool.Config)
 
-		// Return early if we only had a CSR change
-		if !d.HasChanges("name", "description", "labels", "space_id") {
+		if !d.HasChangeExcept("csr") {
 			return nil
 		}
 	}

--- a/spacelift/resource_worker_pool.go
+++ b/spacelift/resource_worker_pool.go
@@ -30,7 +30,7 @@ func resourceWorkerPool() *schema.Resource {
 		UpdateContext: resourceWorkerPoolUpdate,
 		DeleteContext: resourceWorkerPoolDelete,
 		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, _ any) error {
-			// Force the config to be recomputed if the CSR changes. Otherwise, it will ignore changes event if we `Set` new value.
+			// Force the config to be recomputed if the CSR changes. Otherwise, it will ignore changes even if we `Set` new value.
 			if diff.HasChange("csr") {
 				diff.SetNewComputed("config")
 			}

--- a/spacelift/resource_worker_pool.go
+++ b/spacelift/resource_worker_pool.go
@@ -228,7 +228,7 @@ func resourceWorkerPoolUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 
 		if err := meta.(*internal.Client).Mutate(ctx, "WorkerPoolReset", &resetMutation, resetVariables); err != nil {
-			return diag.Errorf("could not reset worker pool token: %v", internal.FromSpaceliftError(err))
+			return diag.Errorf("could not reset worker pool: %v", internal.FromSpaceliftError(err))
 		}
 
 		d.Set("config", resetMutation.WorkerPool.Config)

--- a/spacelift/resource_worker_pool.go
+++ b/spacelift/resource_worker_pool.go
@@ -234,7 +234,7 @@ func resourceWorkerPoolUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		d.Set("config", resetMutation.WorkerPool.Config)
 
 		if !d.HasChangeExcept("csr") {
-			return nil
+			return resourceWorkerPoolRead(ctx, d, meta)
 		}
 	}
 

--- a/spacelift/resource_worker_pool_test.go
+++ b/spacelift/resource_worker_pool_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	. "github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/testhelpers"
 )
 
@@ -33,6 +35,7 @@ func TestWorkerPoolResource(t *testing.T) {
 					Attribute("description", Equals("old description")),
 					Attribute("name", Equals(fmt.Sprintf("My first worker pool %s", randomID))),
 					Attribute("private_key", IsNotEmpty()),
+					Attribute("config", IsNotEmpty()),
 				),
 			},
 			{
@@ -47,6 +50,21 @@ func TestWorkerPoolResource(t *testing.T) {
 					resourceName,
 					Attribute("description", Equals("new description")),
 				),
+			},
+			{
+				Config: config("new description"),
+				Check: func(s *terraform.State) error {
+					rs, ok := s.RootModule().Resources[resourceName]
+					if !ok {
+						return fmt.Errorf("resource not found: %s", resourceName)
+					}
+
+					previousConfig := rs.Primary.Attributes["config"]
+					return Resource(
+						resourceName,
+						Attribute("config", Equals(previousConfig)),
+					)(s)
+				},
 			},
 		})
 	})

--- a/spacelift/resource_worker_pool_test.go
+++ b/spacelift/resource_worker_pool_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	. "github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/testhelpers"
 )
@@ -50,21 +49,6 @@ func TestWorkerPoolResource(t *testing.T) {
 					resourceName,
 					Attribute("description", Equals("new description")),
 				),
-			},
-			{
-				Config: config("new description"),
-				Check: func(s *terraform.State) error {
-					rs, ok := s.RootModule().Resources[resourceName]
-					if !ok {
-						return fmt.Errorf("resource not found: %s", resourceName)
-					}
-
-					previousConfig := rs.Primary.Attributes["config"]
-					return Resource(
-						resourceName,
-						Attribute("config", Equals(previousConfig)),
-					)(s)
-				},
 			},
 		})
 	})
@@ -270,8 +254,9 @@ func TestWorkerPoolResourceSpace(t *testing.T) {
 		})
 	})
 
-	t.Run("CSR changes force new resource", func(t *testing.T) {
+	t.Run("CSR changes reset worker pool", func(t *testing.T) {
 		var originalId string
+		var originalConfig string
 		csr := "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJRWtqQ0NBbm9DQVFBd1RURUxNQWtHQTFVRUJoTUNVRXd4RGpBTUJnTlZCQW9NQldKaFkyOXVNUTR3REFZRApWUVFEREFWaVlXTnZiakVlTUJ3R0NTcUdTSWIzRFFFSkFSWVBZbUZqYjI1QVltRmpiMjR1YjNKbk1JSUNJakFOCkJna3Foa2lHOXcwQkFRRUZBQU9DQWc4QU1JSUNDZ0tDQWdFQXdhand1UmlreTFkODF0TVpJZytJSXBHUHQxclUKV2t4UGhDOENKNzNUWmx3ZTdVcC9McFFiNnpYU0I2eStCWkludnptd1ZBNzNuM0dnVEdFeS9VbDF2VUthaXZmaQpna3lnd05vV0ExYzRTaUNnbjdYTnl1T2c2MktSWGxNb05TeCsrZmVINXZzVGRRVVd2TjZIZkJEQ2dGZ1VQa1JuClp1MDUwOWxBQ2ZrZ00ycnl0b3N3enplbUVUbWRrNlhsYXBnWE9Ebll5bGgvbnRrVFJqZU91VThOUUF1eGRmSUEKY2JFQ0lJZ1Vuak44WWJhWTlGL1RyRjBHUGlQRVZuTEh3Yi95REM2d0NiOXFITUFHRXJhZ0d0cHVzbis0eTBsRwo5S0IvTzZ1R2haRk5HK3FDYUM3MFFKZWI3TzRSdlI3VlA4aWxPOU8rQnE2OU4vY1B4cUFXRTY3WUplUzVxa1hNClFRVVBxVGVXMGs2NC9KZ2c0Nm5ZTmhueGJ5Rkp1MzZ5ME1xbndDN1FYVjZicjFDNldsM3gzTzlNZng4UGVaWGIKdjFqejhod2RWSGFIc0ZLTkgwemdrTk5ISkJ1ZTAyZWwxRkNnbCtMSGNTdWJKdHJnaXpLWkVFSGlFeWhUVURUOQpqeTlSWGpPSUUrNTQ3TkFNMHZvVlY1aTg1eDN0LzdFeFI5R0lraFpwejNQSlV3WUplbHE1M3JPakRvRXZhWTF1CmFUSm9VclYwUUUwK0hTN3ZyaWxXb0VXWlFjOUFiNFFmNnZicmpncCsvVzFEVU5WcGFtVjhQU2dTS3M4RUkwNW4Kek5hc3Q3cnA3b1A2WXBiR2VrbGVQRllWVUVqNTZOKzBxNnh3MFdtS1loNmtYOGRxTTVoNWlkVTFsdUlSU01xMgpkUmJZWStwRFQyeHAwaWtDQXdFQUFhQUFNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUNBUUNjZUM2VXRSbnZ3MkRmCkpsQ285NFdIZDRUTTdQYVBtYmdkeVlMSGpacTZKNGdMcGxrcFlnSno2TnA4OThhTExtRDluTlNEV1c0QkpieDkKdXNaaTA3eFl1cjZybjY0cFRUeUhOK1U4WHZsYVdCQjVoMmV3NytZeXVDNWh4RkU1Mjg0OEJ2WG9LNFdmSzRIegpsZ25vWW9qWERNWEpSRTBqR0drVk8rckt4ZW41ak9ZQW4rbkxQT25HNzRSR25kZ2xTYVFhbFFidjFZb095L1dSCll3QzNqM2JodzUrTG9BNVUvaXhZSytma09rZmZOR0VpaU91K0tZV1J6cTVUd2hOKzFHV1l1M3B4WGJ3ZHM3emgKcjlrdVRvdUhpbDg0OTdaZTJGY2t1VTF3OWVaSmY4WlBHWlNLamhmSUhMYWtwNE9UQUlDb1hDS0hhNEhtUVVzRApVdFBjS0E4ZUdkNmh3U0gyS0FndWU2VVdsMDhFZ2xnRlhkOC90Qy9wYzhNR3QxU2RtTzgzUlVEenJLREt3TCszClhNc0xYOWlic1VTZzk3ZzF5R1RxWE1JeUhXK0tiT3lOZS9JYVBYblJJKy9zdkJaTEY0OGQ4UTdKY2xQcHZ6SysKSnlhMXVLWkI4MFRlZnlpaW5oa21GcmcvWmNzdEI2MEI5VFVHaHNib3JmNW5hdnNCcWIxUkN6c2J5VUFvOVphUgpTUXQyNDlMOUc1bmlIcUNTUENxWXVqRktuMWxIVjVicGxwaDFzWHozOVU5RXVTanNxRlNlMlorM0duUVNSSHlNCkx1YTNPT2pmRXh6UUl3Zm5DUy8wMjVIZENjMDZXY3hNK3JUUlA1UW13eGRJNFBtTTNEU2dCRXE0L2RjeEZwTUYKWnp4VkNreU5PWUJPRklTTXRUWDNiQXI3K3JST2VBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUgUkVRVUVTVC0tLS0tCg=="
 		testSteps(t, []resource.TestStep{
 			{
@@ -290,6 +275,7 @@ func TestWorkerPoolResourceSpace(t *testing.T) {
 					// so we can use it later
 					func(attributes map[string]string) error {
 						originalId = attributes["id"]
+						originalConfig = attributes["config"]
 						return nil
 					},
 				),
@@ -303,10 +289,56 @@ func TestWorkerPoolResourceSpace(t *testing.T) {
 				`, csr),
 				Check: Resource(
 					resourceName,
-					// We validate the id has changed, which tells us the resource was recreated
-					Attribute("id", NotEquals(originalId)),
+					// We validate the id has not changed, which tells us the resource was not recreated
+					Attribute("id", func(v string) error { return Equals(originalId)(v) }),
+					// We validate the config has not changed
+					Attribute("config", func(v string) error { return NotEquals(originalConfig)(v) }),
 					// We also validate the CSR is the new one
 					Attribute("csr", Equals(csr)),
+				),
+			},
+		})
+	})
+
+	t.Run("Name and description change does not impact csr or config", func(t *testing.T) {
+		var originalId string
+		var originalConfig string
+		csr := "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJRWtqQ0NBbm9DQVFBd1RURUxNQWtHQTFVRUJoTUNVRXd4RGpBTUJnTlZCQW9NQldKaFkyOXVNUTR3REFZRApWUVFEREFWaVlXTnZiakVlTUJ3R0NTcUdTSWIzRFFFSkFSWVBZbUZqYjI1QVltRmpiMjR1YjNKbk1JSUNJakFOCkJna3Foa2lHOXcwQkFRRUZBQU9DQWc4QU1JSUNDZ0tDQWdFQXdhand1UmlreTFkODF0TVpJZytJSXBHUHQxclUKV2t4UGhDOENKNzNUWmx3ZTdVcC9McFFiNnpYU0I2eStCWkludnptd1ZBNzNuM0dnVEdFeS9VbDF2VUthaXZmaQpna3lnd05vV0ExYzRTaUNnbjdYTnl1T2c2MktSWGxNb05TeCsrZmVINXZzVGRRVVd2TjZIZkJEQ2dGZ1VQa1JuClp1MDUwOWxBQ2ZrZ00ycnl0b3N3enplbUVUbWRrNlhsYXBnWE9Ebll5bGgvbnRrVFJqZU91VThOUUF1eGRmSUEKY2JFQ0lJZ1Vuak44WWJhWTlGL1RyRjBHUGlQRVZuTEh3Yi95REM2d0NiOXFITUFHRXJhZ0d0cHVzbis0eTBsRwo5S0IvTzZ1R2haRk5HK3FDYUM3MFFKZWI3TzRSdlI3VlA4aWxPOU8rQnE2OU4vY1B4cUFXRTY3WUplUzVxa1hNClFRVVBxVGVXMGs2NC9KZ2c0Nm5ZTmhueGJ5Rkp1MzZ5ME1xbndDN1FYVjZicjFDNldsM3gzTzlNZng4UGVaWGIKdjFqejhod2RWSGFIc0ZLTkgwemdrTk5ISkJ1ZTAyZWwxRkNnbCtMSGNTdWJKdHJnaXpLWkVFSGlFeWhUVURUOQpqeTlSWGpPSUUrNTQ3TkFNMHZvVlY1aTg1eDN0LzdFeFI5R0lraFpwejNQSlV3WUplbHE1M3JPakRvRXZhWTF1CmFUSm9VclYwUUUwK0hTN3ZyaWxXb0VXWlFjOUFiNFFmNnZicmpncCsvVzFEVU5WcGFtVjhQU2dTS3M4RUkwNW4Kek5hc3Q3cnA3b1A2WXBiR2VrbGVQRllWVUVqNTZOKzBxNnh3MFdtS1loNmtYOGRxTTVoNWlkVTFsdUlSU01xMgpkUmJZWStwRFQyeHAwaWtDQXdFQUFhQUFNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUNBUUNjZUM2VXRSbnZ3MkRmCkpsQ285NFdIZDRUTTdQYVBtYmdkeVlMSGpacTZKNGdMcGxrcFlnSno2TnA4OThhTExtRDluTlNEV1c0QkpieDkKdXNaaTA3eFl1cjZybjY0cFRUeUhOK1U4WHZsYVdCQjVoMmV3NytZeXVDNWh4RkU1Mjg0OEJ2WG9LNFdmSzRIegpsZ25vWW9qWERNWEpSRTBqR0drVk8rckt4ZW41ak9ZQW4rbkxQT25HNzRSR25kZ2xTYVFhbFFidjFZb095L1dSCll3QzNqM2JodzUrTG9BNVUvaXhZSytma09rZmZOR0VpaU91K0tZV1J6cTVUd2hOKzFHV1l1M3B4WGJ3ZHM3emgKcjlrdVRvdUhpbDg0OTdaZTJGY2t1VTF3OWVaSmY4WlBHWlNLamhmSUhMYWtwNE9UQUlDb1hDS0hhNEhtUVVzRApVdFBjS0E4ZUdkNmh3U0gyS0FndWU2VVdsMDhFZ2xnRlhkOC90Qy9wYzhNR3QxU2RtTzgzUlVEenJLREt3TCszClhNc0xYOWlic1VTZzk3ZzF5R1RxWE1JeUhXK0tiT3lOZS9JYVBYblJJKy9zdkJaTEY0OGQ4UTdKY2xQcHZ6SysKSnlhMXVLWkI4MFRlZnlpaW5oa21GcmcvWmNzdEI2MEI5VFVHaHNib3JmNW5hdnNCcWIxUkN6c2J5VUFvOVphUgpTUXQyNDlMOUc1bmlIcUNTUENxWXVqRktuMWxIVjVicGxwaDFzWHozOVU5RXVTanNxRlNlMlorM0duUVNSSHlNCkx1YTNPT2pmRXh6UUl3Zm5DUy8wMjVIZENjMDZXY3hNK3JUUlA1UW13eGRJNFBtTTNEU2dCRXE0L2RjeEZwTUYKWnp4VkNreU5PWUJPRklTTXRUWDNiQXI3K3JST2VBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUgUkVRVUVTVC0tLS0tCg=="
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_worker_pool" "test" {
+					name = "My workerpool to update"
+					csr  = "%s"
+				}
+				`, csr),
+				Check: Resource(
+					resourceName,
+					Attribute("id", IsNotEmpty()),
+					Attribute("csr", Equals(csr)),
+					Attribute("name", Equals("My workerpool to update")),
+					func(attributes map[string]string) error {
+						originalId = attributes["id"]
+						originalConfig = attributes["config"]
+						return nil
+					},
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_worker_pool" "test" {
+					name        = "My workerpool to update - updated"
+					description = "My workerpool to update - updated"
+					csr  = "%s"
+				}
+				`, csr),
+				Check: Resource(
+					resourceName,
+					Attribute("id", func(v string) error { return Equals(originalId)(v) }),
+					Attribute("config", func(v string) error { return Equals(originalConfig)(v) }),
+					Attribute("csr", Equals(csr)),
+					Attribute("name", Equals("My workerpool to update - updated")),
+					Attribute("description", Equals("My workerpool to update - updated")),
 				),
 			},
 		})


### PR DESCRIPTION
## Description of the change

With this change we allow decoratively resetting worker pool credentials. If the CSR changes, the token is recreated.

It's based on [this](https://github.com/spacelift-io/terraform-provider-spacelift/pull/630) PR with small fix and tests adjustments.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
