### PR TITLE
Add region to AWS role resource and data source

### DIFF
--- a/docs/data-sources/aws_role.md
+++ b/docs/data-sources/aws_role.md
@@ -44,4 +44,5 @@ data "spacelift_aws_role" "k8s-core" {
 - `external_id` (String) Custom external ID (works only for private workers).
 - `generate_credentials_in_worker` (Boolean) Generate AWS credentials in the private worker
 - `id` (String) The ID of this resource.
+- `region` (String) AWS region to select a regional AWS STS endpoint.
 - `role_arn` (String) ARN of the AWS IAM role to attach

--- a/docs/data-sources/stack_aws_role.md
+++ b/docs/data-sources/stack_aws_role.md
@@ -47,4 +47,5 @@ data "spacelift_stack_aws_role" "k8s-core" {
 - `external_id` (String) Custom external ID (works only for private workers).
 - `generate_credentials_in_worker` (Boolean) Generate AWS credentials in the private worker
 - `id` (String) The ID of this resource.
+- `region` (String) AWS region to select a regional AWS STS endpoint.
 - `role_arn` (String) ARN of the AWS IAM role to attach

--- a/docs/resources/aws_role.md
+++ b/docs/resources/aws_role.md
@@ -77,6 +77,7 @@ resource "spacelift_aws_role" "k8s-core" {
 - `external_id` (String) Custom external ID (works only for private workers).
 - `generate_credentials_in_worker` (Boolean) Generate AWS credentials in the private worker. Defaults to `false`.
 - `module_id` (String) ID of the module which assumes the AWS IAM role
+- `region` (String) AWS region to select a regional AWS STS endpoint.
 - `stack_id` (String) ID of the stack which assumes the AWS IAM role
 
 ### Read-Only

--- a/docs/resources/stack_aws_role.md
+++ b/docs/resources/stack_aws_role.md
@@ -80,6 +80,7 @@ resource "spacelift_stack_aws_role" "k8s-core" {
 - `external_id` (String) Custom external ID (works only for private workers).
 - `generate_credentials_in_worker` (Boolean) Generate AWS credentials in the private worker. Defaults to `false`.
 - `module_id` (String) ID of the module which assumes the AWS IAM role
+- `region` (String) AWS region to select a regional AWS STS endpoint.
 - `stack_id` (String) ID of the stack which assumes the AWS IAM role
 
 ### Read-Only

--- a/spacelift/data_aws_role.go
+++ b/spacelift/data_aws_role.go
@@ -71,6 +71,11 @@ func dataAWSRole() *schema.Resource {
 				Description: "AWS IAM role session duration in seconds",
 				Computed:    true,
 			},
+			"region": {
+				Type:        schema.TypeString,
+				Description: "AWS region to select a regional AWS STS endpoint.",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -110,6 +115,7 @@ func dataModuleAWSRoleRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("generate_credentials_in_worker", query.Module.Integrations.AWS.GenerateCredentialsInWorker)
 	d.Set("external_id", module.Integrations.AWS.ExternalID)
 	d.Set("duration_seconds", module.Integrations.AWS.DurationSeconds)
+	d.Set("region", module.Integrations.AWS.Region)
 
 	return nil
 }
@@ -141,5 +147,6 @@ func dataStackAWSRoleRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("generate_credentials_in_worker", query.Stack.Integrations.AWS.GenerateCredentialsInWorker)
 	d.Set("external_id", stack.Integrations.AWS.ExternalID)
 	d.Set("duration_seconds", stack.Integrations.AWS.DurationSeconds)
+	d.Set("region", stack.Integrations.AWS.Region)
 	return nil
 }

--- a/spacelift/internal/structs/integrations.go
+++ b/spacelift/internal/structs/integrations.go
@@ -8,6 +8,7 @@ type Integrations struct {
 		ExternalID                  *string `graphql:"externalID"`
 		GenerateCredentialsInWorker bool    `graphql:"generateCredentialsInWorker"`
 		DurationSeconds             *int    `graphql:"durationSeconds"`
+		Region                      *string `graphql:"region"`
 	} `graphql:"aws"`
 	DriftDetection struct {
 		IgnoreState bool     `graphql:"ignoreState"`


### PR DESCRIPTION
## Description of the change

Adds region to `spacelift_aws_role` resource and data source.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
