### PR TITLE
add deprecation message for AWS role

### DIFF
--- a/spacelift/resource_aws_role.go
+++ b/spacelift/resource_aws_role.go
@@ -43,11 +43,11 @@ func resourceAWSRole() *schema.Resource {
 			"Note: when assuming credentials for **shared worker**, Spacelift will use `$accountName@$stackID` " +
 			"or `$accountName@$moduleID` as [external ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html) " +
 			"and `$runID@$stackID@$accountName` truncated to 64 characters as [session ID](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole).",
-
-		CreateContext: resourceAWSRoleCreate,
-		ReadContext:   resourceAWSRoleRead,
-		UpdateContext: resourceAWSRoleUpdate,
-		DeleteContext: resourceAWSRoleDelete,
+		DeprecationMessage: "Use `spacelift_aws_integration` in combination with `spacelift_aws_integration_attachment` instead.",
+		CreateContext:      resourceAWSRoleCreate,
+		ReadContext:        resourceAWSRoleRead,
+		UpdateContext:      resourceAWSRoleUpdate,
+		DeleteContext:      resourceAWSRoleDelete,
 
 		Importer: &schema.ResourceImporter{StateContext: importIntegration},
 


### PR DESCRIPTION
## Description of the change

The `spacelift_aws_integration` and `spacelift_aws_integration_attachment` have been introduced as a new way of attaching AWS integration to stack or modules.
The UI support for `spacelift_aws_role` has been confusing our users, so it's time that we deprecate this resource.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
