### PR TITLE
fix: allow to nullify `terraform_version` on the stack resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This involves the following steps:
 To build the provider, run the following command:
 
 ```shell
-goreleaser build --clean --snapshot
+goreleaser build --clean --snapshot --skip=sign
 ```
 
 This will produce a number of binaries in subfolders of the `dist` folder for each supported

--- a/spacelift/internal/structs/stack.go
+++ b/spacelift/internal/structs/stack.go
@@ -311,6 +311,8 @@ func PopulateStack(d *schema.ResourceData, stack *Stack) error {
 		d.Set("terraform_smart_sanitization", stack.VendorConfig.Terraform.UseSmartSanitization)
 		if stack.VendorConfig.Terraform.Version != nil {
 			d.Set("terraform_version", *stack.VendorConfig.Terraform.Version)
+		} else {
+			d.Set("terraform_version", nil)
 		}
 		d.Set("terraform_workflow_tool", stack.VendorConfig.Terraform.WorkflowTool)
 		d.Set("terraform_workspace", stack.VendorConfig.Terraform.Workspace)

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -606,10 +606,10 @@ func resourceStack() *schema.Resource {
 				Default:     false,
 			},
 			"terraform_version": {
-				Type:             schema.TypeString,
-				Description:      "Terraform version to use",
-				Optional:         true,
-				DiffSuppressFunc: onceTheVersionIsSetDoNotUnset,
+				Type:        schema.TypeString,
+				Description: "Terraform version to use",
+				Optional:    true,
+				Computed:    true,
 			},
 			"terraform_workflow_tool": {
 				Type:        schema.TypeString,
@@ -1032,6 +1032,10 @@ func getVendorConfig(d *schema.ResourceData) *structs.VendorConfigInput {
 		terraformConfig.Version = toOptionalString(terraformVersion)
 	}
 
+	if d.GetRawConfig().GetAttr("terraform_version").IsNull() {
+		terraformConfig.Version = nil
+	}
+
 	if terraformWorkflowTool, ok := d.GetOk("terraform_workflow_tool"); ok {
 		terraformConfig.WorkflowTool = toOptionalString(terraformWorkflowTool)
 		if shouldWeReComputeTerraformVersionForTerraformWorkflowTool(d) {
@@ -1128,10 +1132,6 @@ func uploadStateFile(ctx context.Context, content string, meta interface{}) (str
 	}
 
 	return mutation.StateUploadURL.ObjectID, nil
-}
-
-func onceTheVersionIsSetDoNotUnset(_, _, new string, _ *schema.ResourceData) bool {
-	return new == ""
 }
 
 func ignoreOnceCreated(_, _, _ string, d *schema.ResourceData) bool {

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -303,7 +303,7 @@ func TestStackResource(t *testing.T) {
 					Attribute("labels.#", Equals("0")),
 					Attribute("project_root", IsEmpty()),
 					Attribute("runner_image", IsEmpty()),
-					Attribute("terraform_version", Equals("1.0.1")),
+					Attribute("terraform_version", IsEmpty()),
 					Attribute("terraform_workspace", IsEmpty()),
 					Attribute("terraform_smart_sanitization", Equals("false")),
 				),
@@ -904,7 +904,7 @@ func TestStackResource(t *testing.T) {
 			`, randomID),
 				Check: Resource(
 					"spacelift_stack.this",
-					AttributeNotPresent("terraform_version"),
+					Attribute("terraform_version", IsEmpty()),
 				),
 			},
 			{
@@ -919,7 +919,7 @@ func TestStackResource(t *testing.T) {
 			`, randomID),
 				Check: Resource(
 					"spacelift_stack.this",
-					AttributeNotPresent("terraform_version"),
+					Attribute("terraform_version", IsEmpty()),
 				),
 			},
 			{
@@ -1530,7 +1530,7 @@ func TestStackResourceSpace(t *testing.T) {
 					Attribute("labels.#", Equals("0")),
 					Attribute("project_root", IsEmpty()),
 					Attribute("runner_image", IsEmpty()),
-					Attribute("terraform_version", Equals("0.12.5")),
+					Attribute("terraform_version", IsEmpty()),
 					Attribute("terraform_workspace", IsEmpty()),
 				),
 			},
@@ -1729,6 +1729,66 @@ func TestStackResourceSpace(t *testing.T) {
 				Check: Resource(
 					"spacelift_stack.terraform_workflow_tool_custom_with_run",
 					Attribute("terraform_workflow_tool", Equals("CUSTOM")),
+				),
+			},
+		})
+	})
+
+	t.Run("can change TERRAFORM_FOSS to CUSTOM and unset terraform_version", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "spacelift_stack" "terraform_workflow_tool_custom_unset_version" {
+						branch                  = "master"
+						name                    = "Provider test stack workflow_tool unset version %s"
+						project_root            = "root"
+						repository              = "demo"
+						terraform_workflow_tool = "TERRAFORM_FOSS"
+						terraform_version       = "1.5.7"
+						autodeploy              = true
+					}
+				`, randomID),
+				Check: Resource(
+					"spacelift_stack.terraform_workflow_tool_custom_unset_version",
+					Attribute("terraform_workflow_tool", Equals("TERRAFORM_FOSS")),
+					Attribute("terraform_version", Equals("1.5.7")),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "spacelift_stack" "terraform_workflow_tool_custom_unset_version" {
+						branch                  = "master"
+						name                    = "Provider test stack workflow_tool unset version %s"
+						project_root            = "root"
+						repository              = "demo"
+						terraform_workflow_tool = "CUSTOM"
+						autodeploy              = true
+					}
+				`, randomID),
+				Check: Resource(
+					"spacelift_stack.terraform_workflow_tool_custom_unset_version",
+					Attribute("terraform_workflow_tool", Equals("CUSTOM")),
+					Attribute("terraform_version", IsEmpty()),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "spacelift_stack" "terraform_workflow_tool_custom_unset_version" {
+						branch                  = "master"
+						name                    = "Provider test stack workflow_tool unset version %s"
+						project_root            = "root"
+						repository              = "demo"
+						terraform_workflow_tool = "CUSTOM"
+						labels                  = ["one", "two"]
+						autodeploy              = true
+					}
+				`, randomID),
+				Check: Resource(
+					"spacelift_stack.terraform_workflow_tool_custom_unset_version",
+					Attribute("terraform_workflow_tool", Equals("CUSTOM")),
+					Attribute("terraform_version", IsEmpty()),
+					SetEquals("labels", "one", "two"),
 				),
 			},
 		})


### PR DESCRIPTION
## Description of the change

Fixes https://github.com/spacelift-io/terraform-provider-spacelift/issues/647

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
