### PR TITLE
feat(aac): add ability to bind roles to IdP groups

### DIFF
--- a/docs/resources/idp_group_mapping.md
+++ b/docs/resources/idp_group_mapping.md
@@ -3,23 +3,46 @@
 page_title: "spacelift_idp_group_mapping Resource - terraform-provider-spacelift"
 subcategory: ""
 description: |-
-  spacelift_idp_group_mapping represents a mapping (binding) between a user group (as provided by IdP) and a Spacelift User Management Policy. If you assign permissions (a Policy) to a user group, all users in the group will have those permissions unless the user's permissions are higher than the group's permissions.
+  spacelift_idp_group_mapping represents a mapping between a group in an IdP and Spacelift.
+  Define the policy attribute to give permissions to user groups in a certain space.When the policy attribute is left empty, you can use the spacelift_role_attachment resource to bind roles to an IdP group.
 ---
 
 # spacelift_idp_group_mapping (Resource)
 
-`spacelift_idp_group_mapping` represents a mapping (binding) between a user group (as provided by IdP) and a Spacelift User Management Policy. If you assign permissions (a Policy) to a user group, all users in the group will have those permissions unless the user's permissions are higher than the group's permissions.
+`spacelift_idp_group_mapping` represents a mapping between a group in an IdP and Spacelift.
+
+- Define the `policy` attribute to give permissions to user groups in a certain space.
+- When the `policy` attribute is left empty, you can use the `spacelift_role_attachment` resource to bind roles to an IdP group.
 
 ## Example Usage
 
 ```terraform
-resource "spacelift_idp_group_mapping" "test" {
-  name = "test"
+# Via policy
+resource "spacelift_idp_group_mapping" "devops" {
+  name = "devops"
   policy {
     space_id = "root"
     role     = "ADMIN"
   }
-  description = "test description"
+  description = "Maps the devops IdP group to the root space with admin role"
+}
+
+# Via role attachment
+resource "spacelift_idp_group_mapping" "devops" {
+  name        = "devops"
+  description = "Creates a mapping for the devops IdP group"
+}
+
+resource "spacelift_role" "devops" {
+  name        = "SpaceAdmin"
+  description = "A role that provides full admin access to a space"
+  actions     = ["SPACE_ADMIN"]
+}
+
+resource "spacelift_role_attachment" "devops" {
+  idp_group_mapping = spacelift_idp_group_mapping.devops.id
+  role_id           = spacelift_role.devops.id
+  space_id          = "root"
 }
 ```
 
@@ -28,12 +51,12 @@ resource "spacelift_idp_group_mapping" "test" {
 
 ### Required
 
-- `name` (String) Name of the user group - should be unique in one account
-- `policy` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--policy))
+- `name` (String) Name of the IdP group as defined in the SSO provider - should be unique per account
 
 ### Optional
 
-- `description` (String) Description of the user group
+- `description` (String) Description of the IdP group mapping
+- `policy` (Block Set) List of access rules for the IdP group. (see [below for nested schema](#nestedblock--policy))
 
 ### Read-Only
 
@@ -45,4 +68,4 @@ resource "spacelift_idp_group_mapping" "test" {
 Required:
 
 - `role` (String) Type of access to the space. Possible values are: READ, WRITE, ADMIN
-- `space_id` (String) ID (slug) of the space the user group has access to
+- `space_id` (String) ID (slug) of the space the IdP group mapping has access to

--- a/docs/resources/role_attachment.md
+++ b/docs/resources/role_attachment.md
@@ -24,6 +24,10 @@ resource "spacelift_space" "devops" {
   parent_space_id = "root"
 }
 
+resource "spacelift_idp_group_mapping" "devops" {
+  name = "devops-group"
+}
+
 # Attach an API key to a role in a specific space
 resource "spacelift_role_attachment" "api_key_attachment" {
   api_key_id = "01K09KERE33P95V40YRWWRVAZT"
@@ -33,7 +37,7 @@ resource "spacelift_role_attachment" "api_key_attachment" {
 
 # Attach an IDP group mapping to a role in a specific space
 resource "spacelift_role_attachment" "idp_group_attachment" {
-  idp_group_mapping_id = "01K09KERE33P95V40YRWWRVAZT"
+  idp_group_mapping_id = spacelift_idp_group_mapping.devops.id
   role_id              = spacelift_role.devops.id
   space_id             = spacelift_space.devops.id
 }

--- a/examples/resources/spacelift_idp_group_mapping/resource.tf
+++ b/examples/resources/spacelift_idp_group_mapping/resource.tf
@@ -1,8 +1,27 @@
-resource "spacelift_idp_group_mapping" "test" {
-  name = "test"
+# Via policy
+resource "spacelift_idp_group_mapping" "devops" {
+  name = "devops"
   policy {
     space_id = "root"
     role     = "ADMIN"
   }
-  description = "test description"
+  description = "Maps the devops IdP group to the root space with admin role"
+}
+
+# Via role attachment
+resource "spacelift_idp_group_mapping" "devops" {
+  name        = "devops"
+  description = "Creates a mapping for the devops IdP group"
+}
+
+resource "spacelift_role" "devops" {
+  name        = "SpaceAdmin"
+  description = "A role that provides full admin access to a space"
+  actions     = ["SPACE_ADMIN"]
+}
+
+resource "spacelift_role_attachment" "devops" {
+  idp_group_mapping = spacelift_idp_group_mapping.devops.id
+  role_id           = spacelift_role.devops.id
+  space_id          = "root"
 }

--- a/examples/resources/spacelift_role_attachment/resource.tf
+++ b/examples/resources/spacelift_role_attachment/resource.tf
@@ -8,6 +8,10 @@ resource "spacelift_space" "devops" {
   parent_space_id = "root"
 }
 
+resource "spacelift_idp_group_mapping" "devops" {
+  name = "devops-group"
+}
+
 # Attach an API key to a role in a specific space
 resource "spacelift_role_attachment" "api_key_attachment" {
   api_key_id = "01K09KERE33P95V40YRWWRVAZT"
@@ -17,7 +21,7 @@ resource "spacelift_role_attachment" "api_key_attachment" {
 
 # Attach an IDP group mapping to a role in a specific space
 resource "spacelift_role_attachment" "idp_group_attachment" {
-  idp_group_mapping_id = "01K09KERE33P95V40YRWWRVAZT"
+  idp_group_mapping_id = spacelift_idp_group_mapping.devops.id
   role_id              = spacelift_role.devops.id
   space_id             = spacelift_space.devops.id
 }

--- a/spacelift/internal/structs/role_binding.go
+++ b/spacelift/internal/structs/role_binding.go
@@ -11,7 +11,7 @@ type APIKeyRoleBinding struct {
 
 type UserGroupRoleBinding struct {
 	ID        string    `graphql:"id"`
-	Role      Role      `graphql:"role"`
+	RoleID    string    `graphql:"roleID"`
 	SpaceID   string    `graphql:"spaceID"`
 	UserGroup UserGroup `graphql:"userGroup"`
 }

--- a/spacelift/internal/testhelpers/helpers.go
+++ b/spacelift/internal/testhelpers/helpers.go
@@ -301,6 +301,24 @@ func SetContains(name string, values ...string) AttributeCheck {
 	}
 }
 
+// SetEmpty checks if the given set is empty
+func SetEmpty(name string) AttributeCheck {
+	return func(attributes map[string]string) error {
+		countPrefix := fmt.Sprintf("%s.#", name)
+
+		count, ok := attributes[countPrefix]
+		if !ok {
+			return errors.Errorf("%q does not appear to be a set", name)
+		}
+
+		if count != "0" {
+			return errors.Errorf("expected %q to be empty, but it has %s elements", name, count)
+		}
+
+		return nil
+	}
+}
+
 // SetLengthGreaterThanZero ensures the given attribute is a set and has a length greater than zero
 func SetLengthGreaterThanZero(name string) AttributeCheck {
 	return func(attributes map[string]string) error {

--- a/spacelift/resource_idp_group_mapping_test.go
+++ b/spacelift/resource_idp_group_mapping_test.go
@@ -99,4 +99,27 @@ func TestIdpGroupMappingResource(t *testing.T) {
 		})
 	})
 
+	t.Run("create a group without policy", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "spacelift_idp_group_mapping" "test" {
+						name = "%s"
+					}
+				`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("name", Equals(randomID)),
+					SetEmpty("policy"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		})
+	})
 }

--- a/spacelift/resource_role_attachment.go
+++ b/spacelift/resource_role_attachment.go
@@ -179,7 +179,7 @@ func readIDPGroupMappingRoleBinding(ctx context.Context, d *schema.ResourceData,
 	roleBinding := query.UserGroupRoleBinding
 
 	d.Set("idp_group_mapping_id", roleBinding.UserGroup.ID)
-	d.Set("role_id", roleBinding.Role.ID)
+	d.Set("role_id", roleBinding.RoleID)
 	d.Set("space_id", roleBinding.SpaceID)
 
 	return nil


### PR DESCRIPTION
## Description of the change

In this PR I'm marking the old user group attachments legacy, and recommending the user to use the `spacelift_role_attachments` resource instead (which is user group bindings).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
