### PR TITLE
feat: add drift_detection_run_limit field to worker pool

### DIFF
--- a/docs/data-sources/worker_pool.md
+++ b/docs/data-sources/worker_pool.md
@@ -29,6 +29,7 @@ data "spacelift_worker_pool" "k8s-core" {
 
 - `config` (String, Sensitive) credentials necessary to connect WorkerPool's workers to the control plane
 - `description` (String) description of the worker pool
+- `drift_detection_run_limit` (Number) Limit of how many concurrent drift detection runs are allowed per worker pool
 - `id` (String) The ID of this resource.
 - `labels` (Set of String)
 - `name` (String) name of the worker pool

--- a/docs/data-sources/worker_pools.md
+++ b/docs/data-sources/worker_pools.md
@@ -31,6 +31,7 @@ Read-Only:
 
 - `config` (String)
 - `description` (String)
+- `drift_detection_run_limit` (Number)
 - `name` (String)
 - `space_id` (String)
 - `worker_pool_id` (String)

--- a/docs/resources/worker_pool.md
+++ b/docs/resources/worker_pool.md
@@ -14,9 +14,10 @@ description: |-
 
 ```terraform
 resource "spacelift_worker_pool" "k8s-core" {
-  name        = "Main worker"
-  csr         = filebase64("/path/to/csr")
-  description = "Used for all type jobs"
+  name                      = "Main worker"
+  csr                       = filebase64("/path/to/csr")
+  description               = "Used for all type jobs"
+  drift_detection_run_limit = 10
 }
 ```
 
@@ -31,6 +32,7 @@ resource "spacelift_worker_pool" "k8s-core" {
 
 - `csr` (String, Sensitive) certificate signing request in base64. Changing this value will trigger a token reset.
 - `description` (String) description of the worker pool
+- `drift_detection_run_limit` (Number) Limit of how many concurrent drift detection runs are allowed per worker pool
 - `labels` (Set of String)
 - `space_id` (String) ID (slug) of the space the worker pool is in
 

--- a/examples/resources/spacelift_worker_pool/resource.tf
+++ b/examples/resources/spacelift_worker_pool/resource.tf
@@ -1,5 +1,6 @@
 resource "spacelift_worker_pool" "k8s-core" {
-  name        = "Main worker"
-  csr         = filebase64("/path/to/csr")
-  description = "Used for all type jobs"
+  name                      = "Main worker"
+  csr                       = filebase64("/path/to/csr")
+  description               = "Used for all type jobs"
+  drift_detection_run_limit = 10
 }

--- a/spacelift/data_worker_pool.go
+++ b/spacelift/data_worker_pool.go
@@ -52,6 +52,11 @@ func dataWorkerPool() *schema.Resource {
 				Description: "ID (slug) of the space the worker pool is in",
 				Computed:    true,
 			},
+			"drift_detection_run_limit": {
+				Type:        schema.TypeInt,
+				Description: "Limit of how many concurrent drift detection runs are allowed per worker pool",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -89,6 +94,10 @@ func dataWorkerPoolRead(ctx context.Context, d *schema.ResourceData, meta interf
 		labels.Add(label)
 	}
 	d.Set("labels", labels)
+
+	if workerPool.DriftDetectionRunLimit != nil {
+		d.Set("drift_detection_run_limit", *workerPool.DriftDetectionRunLimit)
+	}
 
 	return nil
 }

--- a/spacelift/data_worker_pool_test.go
+++ b/spacelift/data_worker_pool_test.go
@@ -58,3 +58,43 @@ func TestWorkerPoolDataSpace(t *testing.T) {
 		),
 	}})
 }
+
+func TestWorkerPoolDataDriftDetection(t *testing.T) {
+	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	resourceName := "spacelift_worker_pool.test"
+	singleDataSourceName := "data.spacelift_worker_pool.test"
+	listDataSourceName := "data.spacelift_worker_pools.test"
+
+	testSteps(t, []resource.TestStep{{
+		Config: fmt.Sprintf(`
+			resource "spacelift_worker_pool" "test" {
+				name                      = "Worker pool with drift limit %s"
+				drift_detection_run_limit = 7
+				labels                    = ["test"]
+			}
+
+			data "spacelift_worker_pool" "test" {
+				worker_pool_id = spacelift_worker_pool.test.id
+			}
+
+			data "spacelift_worker_pools" "test" {
+				depends_on = [spacelift_worker_pool.test]
+			}
+		`, randomID),
+		Check: resource.ComposeTestCheckFunc(
+			// Test single data source
+			Resource(
+				singleDataSourceName,
+				Attribute("id", IsNotEmpty()),
+				Attribute("name", Equals(fmt.Sprintf("Worker pool with drift limit %s", randomID))),
+				Attribute("drift_detection_run_limit", Equals("7")),
+				SetEquals("labels", "test"),
+			),
+			// Test list data source
+			Resource(listDataSourceName, Attribute("id", IsNotEmpty())),
+			CheckIfResourceNestedAttributeContainsResourceAttribute(listDataSourceName, []string{"worker_pools", "worker_pool_id"}, resourceName, "id"),
+			CheckIfResourceNestedAttributeContainsResourceAttribute(listDataSourceName, []string{"worker_pools", "name"}, resourceName, "name"),
+			CheckIfResourceNestedAttributeContainsResourceAttribute(listDataSourceName, []string{"worker_pools", "drift_detection_run_limit"}, resourceName, "drift_detection_run_limit"),
+		),
+	}})
+}

--- a/spacelift/data_worker_pools.go
+++ b/spacelift/data_worker_pools.go
@@ -50,6 +50,11 @@ func dataWorkerPools() *schema.Resource {
 							Description: "ID (slug) of the space the worker pool is in",
 							Computed:    true,
 						},
+						"drift_detection_run_limit": {
+							Type:        schema.TypeInt,
+							Description: "Limit of how many concurrent drift detection runs are allowed per worker pool",
+							Computed:    true,
+						},
 					},
 				},
 			},
@@ -98,11 +103,12 @@ func flattenDataWorkerPoolsList(workerPools []*structs.WorkerPool) []map[string]
 		}
 
 		wps[index] = map[string]interface{}{
-			"worker_pool_id": wp.ID,
-			"name":           wp.Name,
-			"config":         wp.Config,
-			"description":    description,
-			"space_id":       wp.Space,
+			"worker_pool_id":            wp.ID,
+			"name":                      wp.Name,
+			"config":                    wp.Config,
+			"description":               description,
+			"space_id":                  wp.Space,
+			"drift_detection_run_limit": wp.DriftDetectionRunLimit,
 		}
 	}
 

--- a/spacelift/data_worker_pools_test.go
+++ b/spacelift/data_worker_pools_test.go
@@ -58,3 +58,4 @@ func TestWorkerPoolsDataSpace(t *testing.T) {
 		),
 	}})
 }
+

--- a/spacelift/internal/structs/worker_pool.go
+++ b/spacelift/internal/structs/worker_pool.go
@@ -2,10 +2,11 @@ package structs
 
 // WorkerPool represents the WorkerPool data relevant to the provider.
 type WorkerPool struct {
-	ID          string   `graphql:"id"`
-	Config      string   `graphql:"config"`
-	Name        string   `graphql:"name"`
-	Description *string  `graphql:"description"`
-	Labels      []string `graphql:"labels"`
-	Space       string   `graphql:"space"`
+	ID                     string   `graphql:"id"`
+	Config                 string   `graphql:"config"`
+	Name                   string   `graphql:"name"`
+	Description            *string  `graphql:"description"`
+	Labels                 []string `graphql:"labels"`
+	Space                  string   `graphql:"space"`
+	DriftDetectionRunLimit *int     `graphql:"driftDetectionRunLimit"`
 }

--- a/spacelift/resource_worker_pool_test.go
+++ b/spacelift/resource_worker_pool_test.go
@@ -41,7 +41,7 @@ func TestWorkerPoolResource(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"csr", "private_key"},
+				ImportStateVerifyIgnore: []string{"csr", "private_key", "drift_detection_run_limit"},
 			},
 			{
 				Config: config("new description"),
@@ -75,7 +75,7 @@ func TestWorkerPoolResource(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"csr", "private_key"},
+				ImportStateVerifyIgnore: []string{"csr", "private_key", "drift_detection_run_limit"},
 			},
 		})
 	})
@@ -130,6 +130,121 @@ func TestWorkerPoolResource(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("with drift detection run limit", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		config := func(limit int) string {
+			return fmt.Sprintf(`
+				resource "spacelift_worker_pool" "test" {
+					name                      = "Worker pool with drift limit %s"
+					description               = "Test drift detection run limit"
+					drift_detection_run_limit = %d
+				}
+			`, randomID, limit)
+		}
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: config(5),
+				Check: Resource(
+					resourceName,
+					Attribute("id", IsNotEmpty()),
+					Attribute("name", Equals(fmt.Sprintf("Worker pool with drift limit %s", randomID))),
+					Attribute("drift_detection_run_limit", Equals("5")),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"csr", "private_key"},
+			},
+			{
+				Config: config(10),
+				Check: Resource(
+					resourceName,
+					Attribute("drift_detection_run_limit", Equals("10")),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "spacelift_worker_pool" "test" {
+						name = "Worker pool with drift limit %s"
+						description = "Test drift detection run limit"
+					}
+				`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("drift_detection_run_limit", Equals("-1")),
+				),
+			},
+		})
+	})
+
+	t.Run("with drift detection default behavior", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "spacelift_worker_pool" "test" {
+						name        = "Worker pool default drift %s"
+						description = "Test default drift detection behavior"
+					}
+				`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("id", IsNotEmpty()),
+					Attribute("name", Equals(fmt.Sprintf("Worker pool default drift %s", randomID))),
+					Attribute("drift_detection_run_limit", Equals("-1")),
+				),
+			},
+		})
+	})
+
+	t.Run("with drift detection set to zero", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "spacelift_worker_pool" "test" {
+						name                      = "Worker pool zero drift %s"
+						description               = "Test zero drift detection limit"
+						drift_detection_run_limit = 0
+					}
+				`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("id", IsNotEmpty()),
+					Attribute("name", Equals(fmt.Sprintf("Worker pool zero drift %s", randomID))),
+					Attribute("drift_detection_run_limit", Equals("0")),
+				),
+			},
+		})
+	})
+
+	t.Run("with drift detection negative values", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "spacelift_worker_pool" "test" {
+						name                      = "Worker pool negative drift %s"
+						drift_detection_run_limit = -5
+					}
+				`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("id", IsNotEmpty()),
+					Attribute("name", Equals(fmt.Sprintf("Worker pool negative drift %s", randomID))),
+					Attribute("drift_detection_run_limit", Equals("-5")),
+				),
+			},
+		})
+	})
+
 }
 
 func TestWorkerPoolResourceSpace(t *testing.T) {
@@ -164,7 +279,7 @@ func TestWorkerPoolResourceSpace(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"csr", "private_key"},
+				ImportStateVerifyIgnore: []string{"csr", "private_key", "drift_detection_run_limit"},
 			},
 			{
 				Config: config("new description"),
@@ -198,7 +313,7 @@ func TestWorkerPoolResourceSpace(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"csr", "private_key"},
+				ImportStateVerifyIgnore: []string{"csr", "private_key", "drift_detection_run_limit"},
 			},
 		})
 	})


### PR DESCRIPTION
This change adds a new optional field to configure the maximum number of concurrent drift detection runs allowed per worker pool. The field uses -1 as a default value which the server interprets as "unset", allowing users to explicitly set limits including 0 to disable drift detection entirely.

* Add drift_detection_run_limit field to worker pool resource and data sources
* Set default value of -1 (interpreted as unset by server)
* Support explicit values including 0 to disable drift detection
* Add GraphQL integration with driftDetectionRunLimit parameter

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
