### PR TITLE
docs: clarify spacelift_stack_destructor `deactivated` attribute

### DIFF
--- a/docs/resources/stack_destructor.md
+++ b/docs/resources/stack_destructor.md
@@ -39,7 +39,7 @@ resource "spacelift_stack_destructor" "k8s-core" {
 
 ### Optional
 
-- `deactivated` (Boolean) If set to true, destruction won't delete the stack
+- `deactivated` (Boolean) If set to true, destruction won't delete the resources (e.g. AWS/Azure/GCP infrastructure) that the stack manages
 - `discard_runs` (Boolean) If set to true, destruction will also discard all runs on the stack that are eligible for discarding (e.g. not in progress runs)
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 


### PR DESCRIPTION
The current description of `If set to true, destruction won't delete the stack` is not really accurate, because what it actually does is preserve the resources taht the stack manages, as the description correctly specify. This confused me when reading the docs
<img width="1440" height="680" alt="image" src="https://github.com/user-attachments/assets/969595ca-0c1e-4676-bceb-6306ab22201f" />
