### PR TITLE
Allow to set the retry setting in all webhooks

### DIFF
--- a/docs/data-sources/named_webhook.md
+++ b/docs/data-sources/named_webhook.md
@@ -26,5 +26,6 @@ description: |-
 - `id` (String) The ID of this resource.
 - `labels` (Set of String) labels for the webhook to use when referring in policies or filtering them
 - `name` (String) the name for the webhook which will also be used to generate the id
+- `retry_on_failure` (Boolean) whether to retry the webhook in case of failure
 - `secret_header_keys` (Set of String) secret header keys which are currently set for this webhook
 - `space_id` (String) ID of the space the webhook is in

--- a/docs/data-sources/webhook.md
+++ b/docs/data-sources/webhook.md
@@ -35,3 +35,4 @@ data "spacelift_webhook" "webhook" {
 - `enabled` (Boolean) enables or disables sending webhooks
 - `endpoint` (String) endpoint to send the POST request to
 - `id` (String) The ID of this resource.
+- `retry_on_failure` (Boolean) whether to retry the webhook in case of failure

--- a/docs/resources/audit_trail_webhook.md
+++ b/docs/resources/audit_trail_webhook.md
@@ -33,6 +33,7 @@ resource "spacelift_audit_trail_webhook" "example" {
 
 - `custom_headers` (Map of String) `custom_headers` is a Map of key-value strings, that will be passed as headers with audit trail requests.
 - `include_runs` (Boolean) `include_runs` determines whether the webhook should include information about the run that triggered the event.
+- `retry_on_failure` (Boolean) whether to retry the webhook in case of failure. Defaults to `false`.
 
 ### Read-Only
 

--- a/docs/resources/named_webhook.md
+++ b/docs/resources/named_webhook.md
@@ -25,6 +25,7 @@ description: |-
 ### Optional
 
 - `labels` (Set of String) labels for the webhook to use when referring in policies or filtering them
+- `retry_on_failure` (Boolean) whether to retry the webhook in case of failure. Defaults to `false`.
 - `secret` (String, Sensitive) secret used to sign each request so you're able to verify that the request comes from us. Defaults to an empty value. Note that once it's created, it will be just an empty string in the state due to security reasons.
 
 ### Read-Only

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -30,6 +30,7 @@ resource "spacelift_webhook" "webhook" {
 
 - `enabled` (Boolean) enables or disables sending webhooks. Defaults to `true`.
 - `module_id` (String) ID of the module which triggers the webhooks
+- `retry_on_failure` (Boolean) whether to retry the webhook in case of failure. Defaults to `false`.
 - `secret` (String, Sensitive) secret used to sign each POST request so you're able to verify that the request comes from us. Defaults to an empty value. Note that once it's created, it will be just an empty string in the state due to security reasons.
 - `stack_id` (String) ID of the stack which triggers the webhooks
 

--- a/spacelift/data_named_webhook.go
+++ b/spacelift/data_named_webhook.go
@@ -63,6 +63,11 @@ func dataNamedWebhook() *schema.Resource {
 				Required:         true,
 				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
+			"retry_on_failure": {
+				Type:        schema.TypeBool,
+				Description: "whether to retry the webhook in case of failure",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -88,6 +93,7 @@ func dataNamedWebhookRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set("endpoint", wh.Endpoint)
 	d.Set("enabled", wh.Enabled)
 	d.Set("space_id", wh.Space.ID)
+	d.Set("retry_on_failure", wh.RetryOnFailure)
 
 	labels := schema.NewSet(schema.HashString, []interface{}{})
 	for _, label := range wh.Labels {

--- a/spacelift/data_named_webhook_test.go
+++ b/spacelift/data_named_webhook_test.go
@@ -15,12 +15,13 @@ func TestNamedWebhookData(t *testing.T) {
 	testSteps(t, []resource.TestStep{{
 		Config: fmt.Sprintf(`
 				resource "spacelift_named_webhook" "test" {
-					endpoint = "https://bacon.org"
-					space_id = "root"
-					name     = "%s"
-					labels   = ["1", "2"]
-					secret   = "super-secret"
-					enabled  = true
+					endpoint         = "https://bacon.org"
+					space_id         = "root"
+					name             = "%s"
+					labels           = ["1", "2"]
+					secret           = "super-secret"
+					enabled          = true
+					retry_on_failure = false
 				}
 
 				resource "spacelift_named_webhook_secret_header" "test-secret" {

--- a/spacelift/data_webhook.go
+++ b/spacelift/data_webhook.go
@@ -47,6 +47,11 @@ func dataWebhook() *schema.Resource {
 				Required:         true,
 				ValidateDiagFunc: validations.DisallowEmptyString,
 			},
+			"retry_on_failure": {
+				Type:        schema.TypeBool,
+				Description: "whether to retry the webhook in case of failure",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -91,6 +96,7 @@ func dataModuleWebhookRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.SetId(webhookID)
 	d.Set("enabled", module.Integrations.Webhooks[webhookIndex].Enabled)
 	d.Set("endpoint", module.Integrations.Webhooks[webhookIndex].Endpoint)
+	d.Set("retry_on_failure", module.Integrations.Webhooks[webhookIndex].RetryOnFailure)
 
 	return nil
 }
@@ -126,6 +132,7 @@ func dataStackWebhookRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.SetId(webhookID)
 	d.Set("enabled", stack.Integrations.Webhooks[webhookIndex].Enabled)
 	d.Set("endpoint", stack.Integrations.Webhooks[webhookIndex].Endpoint)
+	d.Set("retry_on_failure", stack.Integrations.Webhooks[webhookIndex].RetryOnFailure)
 
 	return nil
 }

--- a/spacelift/data_webhook_test.go
+++ b/spacelift/data_webhook_test.go
@@ -23,9 +23,10 @@ func TestWebhookData(t *testing.T) {
 				}
 
 				resource "spacelift_webhook" "test" {
-					stack_id = spacelift_stack.test.id
-					endpoint = "https://bacon.org"
-					secret   = "very-very-secret"
+					stack_id         = spacelift_stack.test.id
+					endpoint         = "https://bacon.org"
+					secret           = "very-very-secret"
+					retry_on_failure = false
 				}
 
 				data "spacelift_webhook" "test" {
@@ -56,9 +57,10 @@ func TestWebhookData(t *testing.T) {
 				}
 
 				resource "spacelift_webhook" "test" {
-					module_id = spacelift_module.test.id
-					endpoint  = "https://bacon.org"
-					secret    = "very-very-secret"
+					module_id        = spacelift_module.test.id
+					endpoint         = "https://bacon.org"
+					secret           = "very-very-secret"
+					retry_on_failure = false
 				}
 
 				data "spacelift_webhook" "test" {

--- a/spacelift/internal/structs/audit_trail_webhook.go
+++ b/spacelift/internal/structs/audit_trail_webhook.go
@@ -7,8 +7,9 @@ type AuditTrailWebhook struct {
 }
 
 type AuditTrailWebhookRead struct {
-	Enabled     bool   `graphql:"enabled"`
-	Endpoint    string `graphql:"endpoint"`
-	IncludeRuns bool   `graphql:"includeRuns"`
-	Secret      string `graphql:"secret"`
+	Enabled        bool   `graphql:"enabled"`
+	Endpoint       string `graphql:"endpoint"`
+	IncludeRuns    bool   `graphql:"includeRuns"`
+	Secret         string `graphql:"secret"`
+	RetryOnFailure *bool  `graphql:"retryOnFailure"`
 }

--- a/spacelift/internal/structs/audit_trail_webhook_input.go
+++ b/spacelift/internal/structs/audit_trail_webhook_input.go
@@ -3,11 +3,12 @@ package structs
 import "github.com/shurcooL/graphql"
 
 type AuditTrailWebhookInput struct {
-	Enabled       graphql.Boolean `json:"enabled"`
-	Endpoint      graphql.String  `json:"endpoint"`
-	IncludeRuns   graphql.Boolean `json:"includeRuns"`
-	Secret        graphql.String  `json:"secret"`
-	CustomHeaders *StringMap      `json:"customHeaders"`
+	Enabled        graphql.Boolean  `json:"enabled"`
+	Endpoint       graphql.String   `json:"endpoint"`
+	IncludeRuns    graphql.Boolean  `json:"includeRuns"`
+	Secret         graphql.String   `json:"secret"`
+	CustomHeaders  *StringMap       `json:"customHeaders"`
+	RetryOnFailure *graphql.Boolean `json:"retryOnFailure"`
 }
 
 type StringMap struct {

--- a/spacelift/internal/structs/integrations.go
+++ b/spacelift/internal/structs/integrations.go
@@ -21,9 +21,10 @@ type Integrations struct {
 		TokenScopes         []string `graphql:"tokenScopes"`
 	} `graphql:"gcp"`
 	Webhooks []struct {
-		ID       string `graphql:"id"`
-		Enabled  bool   `graphql:"enabled"`
-		Endpoint string `graphql:"endpoint"`
-		Secret   string `graphql:"secret"`
+		ID             string `graphql:"id"`
+		Enabled        bool   `graphql:"enabled"`
+		Endpoint       string `graphql:"endpoint"`
+		Secret         string `graphql:"secret"`
+		RetryOnFailure *bool  `graphql:"retryOnFailure"`
 	} `graphql:"webhooks"`
 }

--- a/spacelift/internal/structs/named_webhook_input.go
+++ b/spacelift/internal/structs/named_webhook_input.go
@@ -4,24 +4,26 @@ import "github.com/shurcooL/graphql"
 
 // WebhooksIntegration represents the input required to create or update a webhook.
 type NamedWebhooksIntegration struct {
-	ID            string   `graphql:"id" json:"id"`
-	Enabled       bool     `graphql:"enabled" json:"enabled"`
-	Endpoint      string   `graphql:"endpoint" json:"endpoint"`
-	Space         Space    `graphql:"space" json:"space"`
-	Name          string   `graphql:"name" json:"name"`
-	Secret        *string  `graphql:"secret" json:"secret"`
-	SecretHeaders []string `graphql:"secretHeaders" json:"secretHeaders"`
-	Labels        []string `graphql:"labels" json:"labels"`
+	ID             string   `graphql:"id" json:"id"`
+	Enabled        bool     `graphql:"enabled" json:"enabled"`
+	Endpoint       string   `graphql:"endpoint" json:"endpoint"`
+	Space          Space    `graphql:"space" json:"space"`
+	Name           string   `graphql:"name" json:"name"`
+	Secret         *string  `graphql:"secret" json:"secret"`
+	SecretHeaders  []string `graphql:"secretHeaders" json:"secretHeaders"`
+	Labels         []string `graphql:"labels" json:"labels"`
+	RetryOnFailure *bool    `graphql:"retryOnFailure" json:"retryOnFailure"`
 }
 
 // WebhooksIntegrationInput represents the input required to create or update a webhook.
 type NamedWebhooksIntegrationInput struct {
-	Enabled  graphql.Boolean  `json:"enabled"`
-	Endpoint graphql.String   `json:"endpoint"`
-	Space    graphql.ID       `json:"space"`
-	Name     graphql.String   `json:"name"`
-	Secret   *graphql.String  `json:"secret"`
-	Labels   []graphql.String `json:"labels"`
+	Enabled        graphql.Boolean  `json:"enabled"`
+	Endpoint       graphql.String   `json:"endpoint"`
+	Space          graphql.ID       `json:"space"`
+	Name           graphql.String   `json:"name"`
+	Secret         *graphql.String  `json:"secret"`
+	Labels         []graphql.String `json:"labels"`
+	RetryOnFailure *graphql.Boolean `json:"retryOnFailure"`
 }
 
 // NamedWebhookHeaderInput represents the input required to set a secret header.

--- a/spacelift/internal/structs/webhook_input.go
+++ b/spacelift/internal/structs/webhook_input.go
@@ -4,7 +4,8 @@ import "github.com/shurcooL/graphql"
 
 // WebhooksIntegrationInput represents the input required to create or update a webhook.
 type WebhooksIntegrationInput struct {
-	Enabled  graphql.Boolean `json:"enabled"`
-	Endpoint graphql.String  `json:"endpoint"`
-	Secret   graphql.String  `json:"secret"`
+	Enabled        graphql.Boolean  `json:"enabled"`
+	Endpoint       graphql.String   `json:"endpoint"`
+	Secret         graphql.String   `json:"secret"`
+	RetryOnFailure *graphql.Boolean `json:"retryOnFailure"`
 }

--- a/spacelift/resource_audit_trail_webhook.go
+++ b/spacelift/resource_audit_trail_webhook.go
@@ -79,8 +79,7 @@ func resourceAuditTrailWebhookCreate(ctx context.Context, data *schema.ResourceD
 	}
 
 	if retryOnFailure, ok := data.GetOk("retry_on_failure"); ok {
-		value := toBool(retryOnFailure)
-		input.RetryOnFailure = &value
+		input.RetryOnFailure = toOptionalBool(retryOnFailure)
 	}
 
 	variables := map[string]interface{}{
@@ -129,8 +128,7 @@ func resourceAuditTrailWebhookUpdate(ctx context.Context, data *schema.ResourceD
 	}
 
 	if retryOnFailure, ok := data.GetOk("retry_on_failure"); ok {
-		value := toBool(retryOnFailure)
-		input.RetryOnFailure = &value
+		input.RetryOnFailure = toOptionalBool(retryOnFailure)
 	}
 
 	variables := map[string]interface{}{

--- a/spacelift/resource_audit_trail_webhook_test.go
+++ b/spacelift/resource_audit_trail_webhook_test.go
@@ -16,6 +16,7 @@ resource "spacelift_audit_trail_webhook" "test" {
 	endpoint = "%s"
 	include_runs = true
 	secret = "secret"
+	retry_on_failure = false
 }
 `
 
@@ -25,6 +26,7 @@ resource "spacelift_audit_trail_webhook" "test" {
 	endpoint = "%s"
 	include_runs = true
 	secret = "secret"
+	retry_on_failure = false
 	custom_headers = {
 		"X-Some-Header" = "some-value"
 		"X-Some-Header-2" = "some-value-2"

--- a/spacelift/resource_named_webhook.go
+++ b/spacelift/resource_named_webhook.go
@@ -95,8 +95,7 @@ func resourceNamedWebhookCreate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if retryOnFailure, ok := d.GetOk("retry_on_failure"); ok {
-		value := graphql.Boolean(retryOnFailure.(bool))
-		input.RetryOnFailure = &value
+		input.RetryOnFailure = toOptionalBool(retryOnFailure)
 	}
 
 	if labelSet, ok := d.Get("labels").(*schema.Set); ok {
@@ -178,8 +177,7 @@ func resourceNamedWebhookUpdate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if retryOnFailure, ok := d.GetOk("retry_on_failure"); ok {
-		value := graphql.Boolean(retryOnFailure.(bool))
-		input.RetryOnFailure = &value
+		input.RetryOnFailure = toOptionalBool(retryOnFailure)
 	}
 
 	variables := map[string]interface{}{

--- a/spacelift/resource_named_webhook_test.go
+++ b/spacelift/resource_named_webhook_test.go
@@ -19,12 +19,13 @@ func TestNamedWebhookResource(t *testing.T) {
 		config := func(endpoint string) string {
 			return fmt.Sprintf(`
 				resource "spacelift_named_webhook" "test" {
-					endpoint = "%s"
-					space_id = "root"
-					name     = "testing-named-%s"
-					labels   = ["1", "2"]
-					secret   = "super-secret"
-					enabled  = true
+					endpoint         = "%s"
+					space_id         = "root"
+					name             = "testing-named-%s"
+					labels           = ["1", "2"]
+					secret           = "super-secret"
+					enabled          = true
+					retry_on_failure = false
 				}
 			`, endpoint, randomID)
 		}
@@ -61,10 +62,11 @@ func TestNamedWebhookResource(t *testing.T) {
 		config := func(endpoint string) string {
 			return fmt.Sprintf(`
 				resource "spacelift_named_webhook" "test" {
-					endpoint = "%s"
-					space_id = "root"
-					name     = "testing-named-%s"
-					enabled  = true
+					endpoint         = "%s"
+					space_id         = "root"
+					name             = "testing-named-%s"
+					enabled          = true
+					retry_on_failure = false
 				}
 			`, endpoint, randomID)
 		}

--- a/spacelift/resource_webhook.go
+++ b/spacelift/resource_webhook.go
@@ -110,8 +110,7 @@ func resourceWebhookCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if retryOnFailure, ok := d.GetOk("retry_on_failure"); ok {
-		value := graphql.Boolean(retryOnFailure.(bool))
-		input.RetryOnFailure = &value
+		input.RetryOnFailure = toOptionalBool(retryOnFailure)
 	}
 
 	variables := map[string]interface{}{
@@ -256,8 +255,7 @@ func resourceWebhookUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if retryOnFailure, ok := d.GetOk("retry_on_failure"); ok {
-		value := graphql.Boolean(retryOnFailure.(bool))
-		input.RetryOnFailure = &value
+		input.RetryOnFailure = toOptionalBool(retryOnFailure)
 	}
 
 	variables := map[string]interface{}{

--- a/spacelift/resource_webhook_test.go
+++ b/spacelift/resource_webhook_test.go
@@ -25,9 +25,10 @@ func TestWebhookResource(t *testing.T) {
 				}
 
 				resource "spacelift_webhook" "test" {
-					stack_id = spacelift_stack.test.id
-					endpoint = "%s"
-					secret   = "very-very-secret"
+					stack_id         = spacelift_stack.test.id
+					endpoint         = "%s"
+					secret           = "very-very-secret"
+					retry_on_failure = false
 				}
 			`, randomID, endpoint)
 		}
@@ -68,9 +69,10 @@ func TestWebhookResource(t *testing.T) {
 			}
 
 			resource "spacelift_webhook" "test" {
-				module_id = spacelift_module.test.id
-				endpoint  = "https://bacon.org"
-				secret    = "very-very-secret"
+				module_id        = spacelift_module.test.id
+				endpoint         = "https://bacon.org"
+				secret           = "very-very-secret"
+				retry_on_failure = false
 			}
 		`, randomID),
 				Check: Resource(


### PR DESCRIPTION
## Description of the change

We've recently added this as a setting to all webhooks, so I'm not also extending the provider.


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
