### PR TITLE
fix: test for new module sharing

### DIFF
--- a/spacelift/data_module_test.go
+++ b/spacelift/data_module_test.go
@@ -24,7 +24,7 @@ func TestModuleData(t *testing.T) {
 				labels          = ["one", "two"]
 				git_sparse_checkout_paths = ["module"]
 				repository      = "terraform-bacon-tasty"
-				shared_accounts = ["foo-subdomain", "bar-subdomain"]
+				shared_accounts = ["spacelift-io"]
 			}
 			data "spacelift_module" "test" {
 				module_id = spacelift_module.test.id
@@ -41,7 +41,7 @@ func TestModuleData(t *testing.T) {
 				Attribute("project_root", Equals("")),
 				SetEquals("git_sparse_checkout_paths", "module"),
 				Attribute("repository", Equals("terraform-bacon-tasty")),
-				SetEquals("shared_accounts", "bar-subdomain", "foo-subdomain"),
+				SetEquals("shared_accounts", "spacelift-io"),
 				Attribute("terraform_provider", Equals("default")),
 			),
 		}})
@@ -143,7 +143,7 @@ func TestModuleDataSpace(t *testing.T) {
 				description     = "description"
 				labels          = ["one", "two"]
 				repository      = "terraform-bacon-tasty"
-				shared_accounts = ["foo-subdomain", "bar-subdomain"]
+				shared_accounts = ["spacelift-io"]
 				space_id        = "root"
 			}
 
@@ -162,7 +162,7 @@ func TestModuleDataSpace(t *testing.T) {
 			Attribute("project_root", Equals("")),
 			Attribute("repository", Equals("terraform-bacon-tasty")),
 			Attribute("space_id", Equals("root")),
-			SetEquals("shared_accounts", "bar-subdomain", "foo-subdomain"),
+			SetEquals("shared_accounts", "spacelift-io"),
 			Attribute("terraform_provider", Equals("default")),
 		),
 	}})

--- a/spacelift/resource_module_test.go
+++ b/spacelift/resource_module_test.go
@@ -27,7 +27,7 @@ func TestModuleResource(t *testing.T) {
 					enable_local_preview  = %t
 					protect_from_deletion = %t
 					repository            = "terraform-bacon-tasty"
-					shared_accounts       = ["foo-subdomain", "bar-subdomain"]
+					shared_accounts       = ["spacelift-io"]
 				}
 			`, randomID, description, localPreview, protectFromDeletion)
 		}
@@ -51,7 +51,7 @@ func TestModuleResource(t *testing.T) {
 					Attribute("protect_from_deletion", Equals("true")),
 					Attribute("public", Equals("false")),
 					Attribute("repository", Equals("terraform-bacon-tasty")),
-					SetEquals("shared_accounts", "bar-subdomain", "foo-subdomain"),
+					SetEquals("shared_accounts", "spacelift-io"),
 					Attribute("terraform_provider", Equals("default")),
 				),
 			},
@@ -152,7 +152,7 @@ func TestModuleResource(t *testing.T) {
 					labels             = ["one", "two"]
                     project_root       = "%s"
 					repository         = "terraform-bacon-tasty"
-					shared_accounts    = ["foo-subdomain", "bar-subdomain"]
+					shared_accounts    = ["spacelift-io"]
                     terraform_provider = "papaya"
 				}
 			`, randomID, projectRoot)
@@ -173,7 +173,7 @@ func TestModuleResource(t *testing.T) {
 					Attribute("name", Equals(fmt.Sprintf("project-root-%s", randomID))),
 					Attribute("project_root", Equals("test-root/ab")),
 					Attribute("repository", Equals("terraform-bacon-tasty")),
-					SetEquals("shared_accounts", "bar-subdomain", "foo-subdomain"),
+					SetEquals("shared_accounts", "spacelift-io"),
 					Attribute("terraform_provider", Equals("papaya")),
 				),
 			},
@@ -344,7 +344,7 @@ func TestModuleResourceSpace(t *testing.T) {
 					protect_from_deletion = %t
 					repository            = "terraform-bacon-tasty"
 					space_id              = "root"
-					shared_accounts       = ["foo-subdomain", "bar-subdomain"]
+					shared_accounts       = ["spacelift-io"]
 				}
 			`, randomID, description, protectFromDeletion)
 		}
@@ -365,7 +365,7 @@ func TestModuleResourceSpace(t *testing.T) {
 					AttributeNotPresent("project_root"),
 					Attribute("protect_from_deletion", Equals("true")),
 					Attribute("repository", Equals("terraform-bacon-tasty")),
-					SetEquals("shared_accounts", "bar-subdomain", "foo-subdomain"),
+					SetEquals("shared_accounts", "spacelift-io"),
 					Attribute("terraform_provider", Equals("default")),
 					Attribute("space_id", Equals("root")),
 				),
@@ -399,7 +399,7 @@ func TestModuleResourceSpace(t *testing.T) {
 					labels             = ["one", "two"]
                     project_root       = "%s"
 					repository         = "terraform-bacon-tasty"
-					shared_accounts    = ["foo-subdomain", "bar-subdomain"]
+					shared_accounts    = ["spacelift-io"]
                     terraform_provider = "papaya"
 				}
 			`, randomID, projectRoot)
@@ -420,7 +420,7 @@ func TestModuleResourceSpace(t *testing.T) {
 					Attribute("name", Equals(fmt.Sprintf("project-root-%s", randomID))),
 					Attribute("project_root", Equals("test-root/ab")),
 					Attribute("repository", Equals("terraform-bacon-tasty")),
-					SetEquals("shared_accounts", "bar-subdomain", "foo-subdomain"),
+					SetEquals("shared_accounts", "spacelift-io"),
 					Attribute("terraform_provider", Equals("papaya")),
 				),
 			},


### PR DESCRIPTION
## Description of the change

Upcoming changes will validate for account names when saving module shares, so those tests will error soon if we do not change them to use an account that actually exist.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
