### PR TITLE
Add non-sensitive value attribute to environment variable resource

### DIFF
--- a/docs/resources/environment_variable.md
+++ b/docs/resources/environment_variable.md
@@ -55,6 +55,7 @@ resource "spacelift_environment_variable" "core-kubeconfig" {
 - `module_id` (String) ID of the module on which the environment variable is defined
 - `stack_id` (String) ID of the stack on which the environment variable is defined
 - `value` (String, Sensitive) Value of the environment variable. Defaults to an empty string.
+- `value_nonsensitive` (String) Value of the environment variable. Defaults to an empty string.
 - `write_only` (Boolean) Indicates whether the value is secret or not. Defaults to `true`.
 
 ### Read-Only

--- a/spacelift/resource_environment_variable_test.go
+++ b/spacelift/resource_environment_variable_test.go
@@ -2,6 +2,7 @@ package spacelift
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -137,6 +138,142 @@ func TestEnvironmentVariableResource(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		})
+	})
+}
+
+func TestEnvironmentVariableResourceNonsensitiveValue(t *testing.T) {
+	const resourceName = "spacelift_environment_variable.test"
+
+	t.Run("with a context", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		config := func(description string) string {
+			return fmt.Sprintf(`
+				resource "spacelift_context" "test" {
+					name = "My first context %s"
+				}
+
+				resource "spacelift_environment_variable" "test" {
+					context_id         = spacelift_context.test.id
+					name               = "BACON"
+					value_nonsensitive = "is tasty"
+					write_only         = false
+					description        = %s
+				}
+			`, randomID, description)
+		}
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: config(`"Bacon is tasty"`),
+				Check: Resource(
+					resourceName,
+					Attribute("id", IsNotEmpty()),
+					Attribute("checksum", Equals("4d5d01ea427b10dd483e8fce5b5149fb5a9814e9ee614176b756ca4a65c8f154")),
+					Attribute("context_id", Contains(randomID)),
+					Attribute("name", Equals("BACON")),
+					Attribute("value_nonsensitive", Equals("is tasty")),
+					Attribute("write_only", Equals("false")),
+					Attribute("description", Equals("Bacon is tasty")),
+					AttributeNotPresent("value"),
+					AttributeNotPresent("module_id"),
+					AttributeNotPresent("stack_id"),
+				),
+			},
+		})
+	})
+
+	t.Run("with a module", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_module" "test" {
+	          			name           = "test-module-%s"
+					branch         = "master"
+					repository     = "terraform-bacon-tasty"
+				}
+
+				resource "spacelift_environment_variable" "test" {
+					module_id          = spacelift_module.test.id
+					name               = "BACON"
+					value_nonsensitive = "is tasty"
+					write_only         = false
+					description        = "Bacon is tasty"
+				}
+				`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("module_id", Equals(fmt.Sprintf("terraform-default-test-module-%s", randomID))),
+					Attribute("value_nonsensitive", Equals("is tasty")),
+					Attribute("write_only", Equals("false")),
+					Attribute("description", Equals("Bacon is tasty")),
+					AttributeNotPresent("value"),
+					AttributeNotPresent("context_id"),
+					AttributeNotPresent("stack_id"),
+				),
+			},
+		})
+	})
+
+	t.Run("with a stack", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch     = "master"
+					repository = "demo"
+					name       = "Test stack %s"
+				}
+
+				resource "spacelift_environment_variable" "test" {
+					stack_id    	   = spacelift_stack.test.id
+					value_nonsensitive = "is tasty"
+					write_only         = false
+					name        	   = "BACON"
+					description   	   = "Bacon is tasty"
+				}
+				`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("stack_id", StartsWith("test-stack-")),
+					Attribute("stack_id", Contains(randomID)),
+					Attribute("value_nonsensitive", Equals("is tasty")),
+					Attribute("description", Equals("Bacon is tasty")),
+					AttributeNotPresent("value"),
+					AttributeNotPresent("context_id"),
+					AttributeNotPresent("module_id"),
+				),
+			},
+		})
+	})
+
+	t.Run("write only is not allowed", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch     = "master"
+					repository = "demo"
+					name       = "Test stack %s"
+				}
+
+				resource "spacelift_environment_variable" "test" {
+					stack_id    	   = spacelift_stack.test.id
+					value_nonsensitive = "is tasty"
+					write_only         = true
+					name        	   = "BACON"
+					description   	   = "Bacon is tasty"
+				}
+				`, randomID),
+				ExpectError: regexp.MustCompile("a non-sensitive environment variable cannot be write-only"),
 			},
 		})
 	})


### PR DESCRIPTION
## Description of the change

This change adds an alternative, non-sensitive `value` attribute to the environment variable resource.
This allows users to view the value of non-sensitive environment variables.

As I can't see the reason to have write-only, non-sensitive values, this combination is not allowed.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

Fixes #517

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
