### PR TITLE
feat(CU-869a73cqw): add space share to module

### DIFF
--- a/docs/data-sources/module.md
+++ b/docs/data-sources/module.md
@@ -51,6 +51,7 @@ data "spacelift_module" "k8s-module" {
 - `runner_image` (String) Name of the Docker image used to process Runs
 - `shared_accounts` (Set of String) List of the accounts (subdomains) which should have access to the Module
 - `space_id` (String) ID (slug) of the space the module is in
+- `space_shares` (Set of String) (Beta) List of the space IDs which should have access to the Module
 - `terraform_provider` (String) The module provider will by default be inferred from the repository name if it follows the terraform-provider-name naming convention. However, if the repository doesn't follow this convention, or you gave the module a custom name, you can provide the provider name here.
 - `worker_pool_id` (String) ID of the worker pool to use
 - `workflow_tool` (String) Defines the tool that will be used to execute the workflow. This can be one of `OPEN_TOFU`, `TERRAFORM_FOSS` or `CUSTOM`.

--- a/docs/resources/module.md
+++ b/docs/resources/module.md
@@ -61,6 +61,7 @@ resource "spacelift_module" "example-module" {
 - `runner_image` (String) Name of the Docker image used to process Runs
 - `shared_accounts` (Set of String) List of the accounts (subdomains) which should have access to the Module
 - `space_id` (String) ID (slug) of the space the module is in
+- `space_shares` (Set of String) (Beta) List of the space IDs which should have access to the Module
 - `terraform_provider` (String) The module provider will by default be inferred from the repository name if it follows the terraform-provider-name naming convention. However, if the repository doesn't follow this convention, or you gave the module a custom name, you can provide the provider name here.
 - `worker_pool_id` (String) ID of the worker pool to use. NOTE: worker_pool_id is required when using a self-hosted instance of Spacelift.
 - `workflow_tool` (String) Defines the tool that will be used to execute the workflow. This can be one of `OPEN_TOFU`, `TERRAFORM_FOSS` or `CUSTOM`. Defaults to `TERRAFORM_FOSS`.

--- a/spacelift/internal/structs/module.go
+++ b/spacelift/internal/structs/module.go
@@ -7,27 +7,27 @@ import (
 
 // Module represents the Module data relevant to the provider.
 type Module struct {
-	ID                     string       `graphql:"id"`
-	Administrative         bool         `graphql:"administrative"`
-	Branch                 string       `graphql:"branch"`
-	Description            *string      `graphql:"description"`
-	Integrations           Integrations `graphql:"integrations"`
-	Labels                 []string     `graphql:"labels"`
-	LocalPreviewEnabled    bool         `graphql:"localPreviewEnabled"`
-	Name                   string       `graphql:"name"`
-	Namespace              string       `graphql:"namespace"`
-	ProjectRoot            *string      `graphql:"projectRoot"`
-	GitSparseCheckoutPaths []string     `graphql:"gitSparseCheckoutPaths"`
-	ProtectFromDeletion    bool         `graphql:"protectFromDeletion"`
-	Provider               VCSProvider  `graphql:"provider"`
-	Public                 bool         `graphql:"public"`
-	Repository             string       `graphql:"repository"`
-	RepositoryURL          *string      `graphql:"repositoryURL"`
-	RunnerImage            *string      `graphql:"runnerImage"`
-	SharedAccounts         []string     `graphql:"sharedAccounts"`
-	Space                  string       `graphql:"space"`
-	SpaceDetails           Space        `graphql:"spaceDetails"`
-	TerraformProvider      string       `graphql:"terraformProvider"`
+	ID                     string        `graphql:"id"`
+	Administrative         bool          `graphql:"administrative"`
+	Branch                 string        `graphql:"branch"`
+	Description            *string       `graphql:"description"`
+	Integrations           Integrations  `graphql:"integrations"`
+	Labels                 []string      `graphql:"labels"`
+	LocalPreviewEnabled    bool          `graphql:"localPreviewEnabled"`
+	ModuleShares           []ModuleShare `graphql:"moduleShares"`
+	Name                   string        `graphql:"name"`
+	Namespace              string        `graphql:"namespace"`
+	ProjectRoot            *string       `graphql:"projectRoot"`
+	GitSparseCheckoutPaths []string      `graphql:"gitSparseCheckoutPaths"`
+	ProtectFromDeletion    bool          `graphql:"protectFromDeletion"`
+	Provider               VCSProvider   `graphql:"provider"`
+	Public                 bool          `graphql:"public"`
+	Repository             string        `graphql:"repository"`
+	RepositoryURL          *string       `graphql:"repositoryURL"`
+	RunnerImage            *string       `graphql:"runnerImage"`
+	Space                  string        `graphql:"space"`
+	SpaceDetails           Space         `graphql:"spaceDetails"`
+	TerraformProvider      string        `graphql:"terraformProvider"`
 	VCSIntegration         *struct {
 		ID        string `graphql:"id"`
 		IsDefault bool   `graphql:"isDefault"`
@@ -36,6 +36,36 @@ type Module struct {
 		ID string `graphql:"id"`
 	} `graphql:"workerPool"`
 	WorkflowTool *string `graphql:"workflowTool"`
+}
+
+// ModuleShare represents sharing information for a module.
+type ModuleShare struct {
+	ID     string            `graphql:"id"`
+	From   ModuleShareScope  `graphql:"from"`
+	To     ModuleShareScope  `graphql:"to"`
+	Module ModuleShareModule `graphql:"module"`
+}
+
+// ModuleShareScope represents the scope of a module share (account or space).
+type ModuleShareScope struct {
+	Account ModuleShareAccount `graphql:"account"`
+	Space   *ModuleShareSpace  `graphql:"space"`
+}
+
+// ModuleShareAccount represents account information in module shares.
+type ModuleShareAccount struct {
+	Subdomain string `graphql:"subdomain"`
+}
+
+type ModuleShareSpace struct {
+	ID string `graphql:"id"`
+}
+
+// ModuleShareModule represents module information in module shares.
+type ModuleShareModule struct {
+	Name        string   `graphql:"name"`
+	Description *string  `graphql:"description"`
+	Labels      []string `graphql:"labels"`
 }
 
 // ExportVCSSettings exports VCS settings into Terraform schema.


### PR DESCRIPTION
## Description of the change

This adds space_shares field to module resource and datasource. If specified, that will allow to configure cross space sharing for module.
This also use the new share endpoint to retrieve shared accounts.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
