### PR TITLE
docs(saved-filters): extend docs with a few more saved filter types

### DIFF
--- a/docs/resources/saved_filter.md
+++ b/docs/resources/saved_filter.md
@@ -75,9 +75,9 @@ resource "spacelift_saved_filter" "my_filter" {
 ### Required
 
 - `data` (String) Data is the JSON representation of the filter data
-- `is_public` (Boolean) Toggle whether the filter is public or not
+- `is_public` (Boolean) Toggle whether the filter is public or not. If set to true, everyone can use it in the account.
 - `name` (String) Name of the saved filter
-- `type` (String) Type describes the type of the filter. It is used to determine which view the filter is for. Possible values are `stacks`, `blueprints`, `contexts`, `webhooks`.
+- `type` (String) Type describes the type of the filter. It is used to determine which view the filter is for. Possible values are `stacks`, `modules`, `auditTrailEntries`, `vcsIntegrations`, `blueprints`, `contexts`, `workerPools`, `webhooks`, `notifications`, `resources`, `policies`.
 
 ### Read-Only
 

--- a/spacelift/resource_saved_filter.go
+++ b/spacelift/resource_saved_filter.go
@@ -48,7 +48,7 @@ func resourceSavedFilter() *schema.Resource {
 			},
 			"is_public": {
 				Type:        schema.TypeBool,
-				Description: "Toggle whether the filter is public or not",
+				Description: "Toggle whether the filter is public or not. If set to true, everyone can use it in the account.",
 				Required:    true,
 			},
 			"created_by": {
@@ -59,7 +59,7 @@ func resourceSavedFilter() *schema.Resource {
 			"type": {
 				Type: schema.TypeString,
 				Description: "Type describes the type of the filter. It is used to determine which view the filter is for. " +
-					"Possible values are `stacks`, `blueprints`, `contexts`, `webhooks`.",
+					"Possible values are `stacks`, `modules`, `auditTrailEntries`, `vcsIntegrations`, `blueprints`, `contexts`, `workerPools`, `webhooks`, `notifications`, `resources`, `policies`.",
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice(


### PR DESCRIPTION
## Description of the change

A few were missing from the list.

Fixes https://github.com/spacelift-io/terraform-provider-spacelift/issues/638

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
