### PR TITLE
chore(CU-8699htpkr): Remove beta mention for space sharing

### DIFF
--- a/docs/data-sources/module.md
+++ b/docs/data-sources/module.md
@@ -51,7 +51,7 @@ data "spacelift_module" "k8s-module" {
 - `runner_image` (String) Name of the Docker image used to process Runs
 - `shared_accounts` (Set of String) List of the accounts (subdomains) which should have access to the Module
 - `space_id` (String) ID (slug) of the space the module is in
-- `space_shares` (Set of String) (Beta) List of the space IDs which should have access to the Module
+- `space_shares` (Set of String) List of the space IDs which should have access to the Module
 - `terraform_provider` (String) The module provider will by default be inferred from the repository name if it follows the terraform-provider-name naming convention. However, if the repository doesn't follow this convention, or you gave the module a custom name, you can provide the provider name here.
 - `worker_pool_id` (String) ID of the worker pool to use
 - `workflow_tool` (String) Defines the tool that will be used to execute the workflow. This can be one of `OPEN_TOFU`, `TERRAFORM_FOSS` or `CUSTOM`.

--- a/docs/resources/module.md
+++ b/docs/resources/module.md
@@ -61,7 +61,7 @@ resource "spacelift_module" "example-module" {
 - `runner_image` (String) Name of the Docker image used to process Runs
 - `shared_accounts` (Set of String) List of the accounts (subdomains) which should have access to the Module
 - `space_id` (String) ID (slug) of the space the module is in
-- `space_shares` (Set of String) (Beta) List of the space IDs which should have access to the Module
+- `space_shares` (Set of String) List of the space IDs which should have access to the Module
 - `terraform_provider` (String) The module provider will by default be inferred from the repository name if it follows the terraform-provider-name naming convention. However, if the repository doesn't follow this convention, or you gave the module a custom name, you can provide the provider name here.
 - `worker_pool_id` (String) ID of the worker pool to use. NOTE: worker_pool_id is required when using a self-hosted instance of Spacelift.
 - `workflow_tool` (String) Defines the tool that will be used to execute the workflow. This can be one of `OPEN_TOFU`, `TERRAFORM_FOSS` or `CUSTOM`. Defaults to `TERRAFORM_FOSS`.

--- a/spacelift/data_module.go
+++ b/spacelift/data_module.go
@@ -234,7 +234,7 @@ func dataModule() *schema.Resource {
 			},
 			"space_shares": {
 				Type:        schema.TypeSet,
-				Description: "(Beta) List of the space IDs which should have access to the Module",
+				Description: "List of the space IDs which should have access to the Module",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Computed:    true,
 			},

--- a/spacelift/resource_module.go
+++ b/spacelift/resource_module.go
@@ -303,7 +303,7 @@ func resourceModule() *schema.Resource {
 			},
 			"space_shares": {
 				Type:        schema.TypeSet,
-				Description: "(Beta) List of the space IDs which should have access to the Module",
+				Description: "List of the space IDs which should have access to the Module",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
 			},


### PR DESCRIPTION
## Description of the change

Since module space sharing is GA, let's remove the Beta mention from here.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove the "(Beta)" label from the `space_shares` field across module docs and schemas.
> 
> - **Docs**:
>   - Remove "(Beta)" from `space_shares` in `docs/data-sources/module.md` and `docs/resources/module.md`.
> - **Provider schema**:
>   - Update `space_shares` description to remove "(Beta)" in `spacelift/data_module.go` and `spacelift/resource_module.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 858be6fab189814292980b651261e302cffa1e6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->