### PR TITLE
fix: expose proper Azure application's object ID

### DIFF
--- a/docs/data-sources/azure_integration.md
+++ b/docs/data-sources/azure_integration.md
@@ -41,6 +41,7 @@ data "spacelift_azure_integration" "example" {
 - `display_name` (String) The display name for the application in Azure. This is automatically generated when the integration is created, and cannot be changed without deleting and recreating the integration.
 - `id` (String) The ID of this resource.
 - `labels` (Set of String) Labels to set on the integration
-- `object_id` (String) The objectId of the Azure AD application used by the integration.
+- `object_id` (String, Deprecated) The objectId of the Azure AD application used by the integration.
+- `service_principal_object_id` (String) This is the unique ID of the service principal object associated with this application. This ID can be useful when performing management operations against this application using programmatic interfaces.
 - `space_id` (String) ID (slug) of the space the integration is in
 - `tenant_id` (String) The Azure AD tenant ID

--- a/docs/data-sources/azure_integrations.md
+++ b/docs/data-sources/azure_integrations.md
@@ -34,5 +34,6 @@ Read-Only:
 - `labels` (Set of String)
 - `name` (String)
 - `object_id` (String)
+- `service_principal_object_id` (String)
 - `space_id` (String)
 - `tenant_id` (String)

--- a/docs/resources/azure_integration.md
+++ b/docs/resources/azure_integration.md
@@ -42,7 +42,8 @@ resource "spacelift_azure_integration" "example" {
 - `application_id` (String) The applicationId of the Azure AD application used by the integration.
 - `display_name` (String) The display name for the application in Azure. This is automatically generated when the integration is created, and cannot be changed without deleting and recreating the integration.
 - `id` (String) The ID of this resource.
-- `object_id` (String) The objectId of the Azure AD application used by the integration.
+- `object_id` (String, Deprecated) The objectId of the Azure AD application used by the integration.
+- `service_principal_object_id` (String) This is the unique ID of the service principal object associated with this application. This ID can be useful when performing management operations against this application using programmatic interfaces.
 
 ## Import
 

--- a/spacelift/data_azure_integration.go
+++ b/spacelift/data_azure_integration.go
@@ -53,6 +53,13 @@ func dataAzureIntegration() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The objectId of the Azure AD application used by the integration.",
 				Computed:    true,
+				Deprecated:  "This field will be removed in a future version. Use `service_principal_object_id` instead.",
+			},
+			"service_principal_object_id": {
+				Type: schema.TypeString,
+				Description: "This is the unique ID of the service principal object associated with this application. " +
+					"This ID can be useful when performing management operations against this application using programmatic interfaces.",
+				Computed: true,
 			},
 			"default_subscription_id": {
 				Type: schema.TypeString,

--- a/spacelift/data_azure_integrations.go
+++ b/spacelift/data_azure_integrations.go
@@ -52,6 +52,13 @@ func dataAzureIntegrations() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: "The objectId of the Azure AD application used by the integration.",
 							Computed:    true,
+							Deprecated:  "This field will be removed in a future version. Use `service_principal_object_id` instead.",
+						},
+						"service_principal_object_id": {
+							Type: schema.TypeString,
+							Description: "This is the unique ID of the service principal object associated with this application. " +
+								"This ID can be useful when performing management operations against this application using programmatic interfaces.",
+							Computed: true,
 						},
 						"default_subscription_id": {
 							Type: schema.TypeString,

--- a/spacelift/internal/structs/azure_integration.go
+++ b/spacelift/internal/structs/azure_integration.go
@@ -5,17 +5,18 @@ import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 // AzureIntegration represents an Azure identity provided by the Spacelift
 // integration.
 type AzureIntegration struct {
-	ID                    string   `graphql:"id"`
-	AdminConsentProvided  bool     `graphql:"adminConsentProvided"`
-	AdminConsentURL       string   `graphql:"adminConsentURL"`
-	ApplicationID         string   `graphql:"applicationId"`
-	ObjectID              *string  `graphql:"objectId"`
-	DefaultSubscriptionID *string  `graphql:"defaultSubscriptionId"`
-	DisplayName           string   `graphql:"displayName"`
-	Labels                []string `graphql:"labels"`
-	Name                  string   `graphql:"name"`
-	TenantID              string   `graphql:"tenantId"`
-	Space                 string   `graphql:"space"`
+	ID                       string   `graphql:"id"`
+	AdminConsentProvided     bool     `graphql:"adminConsentProvided"`
+	AdminConsentURL          string   `graphql:"adminConsentURL"`
+	ApplicationID            string   `graphql:"applicationId"`
+	ObjectID                 *string  `graphql:"objectId"`
+	ServicePrincipalObjectID *string  `graphql:"servicePrincipalObjectId"`
+	DefaultSubscriptionID    *string  `graphql:"defaultSubscriptionId"`
+	DisplayName              string   `graphql:"displayName"`
+	Labels                   []string `graphql:"labels"`
+	Name                     string   `graphql:"name"`
+	TenantID                 string   `graphql:"tenantId"`
+	Space                    string   `graphql:"space"`
 }
 
 // PopulateResourceData populates Terraform resource data with the contents of
@@ -41,6 +42,11 @@ func (i *AzureIntegration) ToMap() map[string]interface{} {
 	}
 	if i.ObjectID != nil {
 		fields["object_id"] = *i.ObjectID
+	}
+
+	// service_principal_object_id is only available after going through the consent flow
+	if i.ServicePrincipalObjectID != nil {
+		fields["service_principal_object_id"] = *i.ServicePrincipalObjectID
 	}
 
 	fields["labels"] = i.getLabelsSet()

--- a/spacelift/resource_azure_integration.go
+++ b/spacelift/resource_azure_integration.go
@@ -86,6 +86,13 @@ func resourceAzureIntegration() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The objectId of the Azure AD application used by the integration.",
 				Computed:    true,
+				Deprecated:  "This field will be removed in a future version. Use `service_principal_object_id` instead.",
+			},
+			"service_principal_object_id": {
+				Type: schema.TypeString,
+				Description: "This is the unique ID of the service principal object associated with this application. " +
+					"This ID can be useful when performing management operations against this application using programmatic interfaces.",
+				Computed: true,
 			},
 			"display_name": {
 				Type: schema.TypeString,


### PR DESCRIPTION
## Description of the change

`servicePrincipalObjectId` replaces `objectId` as it correctly exposes a value that Azure refers to as "object ID".
This value is only available after the user completes the Azure integration creation process by going through the consent workflow.

The `objectId` endpoint will be removed from the API in the future.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

Fixes #693

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces computed `service_principal_object_id` to Azure integration resource/data sources and deprecates `object_id`, updating schemas, mappings, and docs.
> 
> - **Provider schemas**:
>   - Add computed `service_principal_object_id` to `spacelift_azure_integration` resource and data sources (`data_azure_integration`, `data_azure_integrations`).
>   - Deprecate `object_id` with notice to use `service_principal_object_id`.
> - **Internal**:
>   - Extend `AzureIntegration` struct with `ServicePrincipalObjectID` and surface it via `ToMap()`/population logic.
> - **Docs**:
>   - Update `docs/resources/azure_integration.md`, `docs/data-sources/azure_integration.md`, and `docs/data-sources/azure_integrations.md` to reflect new field and `object_id` deprecation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe144b36f1701de36ee45966be231aba12280d10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->