### PR TITLE
feat: human-readable stack dependency import format

### DIFF
--- a/docs/resources/stack_dependency.md
+++ b/docs/resources/stack_dependency.md
@@ -4,11 +4,14 @@ page_title: "spacelift_stack_dependency Resource - terraform-provider-spacelift"
 subcategory: ""
 description: |-
   spacelift_stack_dependency represents a Spacelift stack dependency - a dependency between two stacks. When one stack depends on another, the tracked runs of the stack will not start until the dependent stack is successfully finished. Additionally, changes to the dependency will trigger the dependent.
+  ~> Import format: Use terraform import spacelift_stack_dependency.example stack-id/depends-on-stack-id. The old format stack-id/dependency-ulid is deprecated but still supported for backward compatibility.
 ---
 
 # spacelift_stack_dependency (Resource)
 
 `spacelift_stack_dependency` represents a Spacelift **stack dependency** - a dependency between two stacks. When one stack depends on another, the tracked runs of the stack will not start until the dependent stack is successfully finished. Additionally, changes to the dependency will trigger the dependent.
+
+~> **Import format**: Use `terraform import spacelift_stack_dependency.example stack-id/depends-on-stack-id`. The old format `stack-id/dependency-ulid` is deprecated but still supported for backward compatibility.
 
 ## Example Usage
 

--- a/docs/resources/stack_dependency_reference.md
+++ b/docs/resources/stack_dependency_reference.md
@@ -4,11 +4,14 @@ page_title: "spacelift_stack_dependency_reference Resource - terraform-provider-
 subcategory: ""
 description: |-
   spacelift_stack_dependency_reference represents a Spacelift stack dependency reference - a reference matches a stack's output to another stack's input. It is similar to an environment variable (spacelift_environment_variable), except that value is provided by another stack's output.
+  ~> Import format: Use terraform import spacelift_stack_dependency_reference.example stack-id/depends-on-stack-id/input-name. The old format stack-id/dependency-ulid/reference-ulid is deprecated but still supported for backward compatibility.
 ---
 
 # spacelift_stack_dependency_reference (Resource)
 
 `spacelift_stack_dependency_reference` represents a Spacelift **stack dependency reference** - a reference matches a stack's output to another stack's input. It is similar to an environment variable (`spacelift_environment_variable`), except that value is provided by another stack's output.
+
+~> **Import format**: Use `terraform import spacelift_stack_dependency_reference.example stack-id/depends-on-stack-id/input-name`. The old format `stack-id/dependency-ulid/reference-ulid` is deprecated but still supported for backward compatibility.
 
 ## Example Usage
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466
 	golang.org/x/time v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,9 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
+github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
+github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
## Description of the change

Add support for importing stack dependencies and references using human-readable identifiers instead of obscure ULIDs:

- Stack dependency: stack-id/depends-on-stack-id (new) vs stack-id/dependency-ulid (old, deprecated)
- Stack dependency reference: stack-id/depends-on-stack-id/input-name (new) vs stack-id/dependency-ulid/reference-ulid (old, deprecated)

The old ULID-based format remains supported for backward compatibility but is now deprecated in favor of the more user-friendly format.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for importing stack dependencies and references using stack slugs (stack-id/depends-on-stack-id[/input-name]) while keeping ULID-based format for backward compatibility.
> 
> - **Resources**:
>   - `spacelift/resource_stack_dependency.go`: Add import via `stack-id/depends-on-stack-id`; support both new (by stack IDs) and old (by ULID) formats; refactor read/delete to parse IDs and fetch accordingly.
>   - `spacelift/resource_stack_dependency_reference.go`: Add import via `stack-id/depends-on-stack-id/input-name`; support both formats with fetch-by-ID or fetch-by-name; update importer and helpers.
> - **Docs**:
>   - `docs/resources/stack_dependency.md`, `docs/resources/stack_dependency_reference.md`: Document new human-readable import formats and deprecation of ULID-based formats.
> - **Tests**:
>   - `spacelift/resource_stack_dependency_test.go`, `spacelift/resource_stack_dependency_reference_test.go`: Add import tests for new human-readable formats.
> - **Dependencies**:
>   - `go.mod`, `go.sum`: Add `github.com/oklog/ulid/v2` for ULID parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e65aecd1da106032850d2058d93371a7d10b65e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->