### PR TITLE
fix: prevent secret erasure when updating named webhook

### DIFF
--- a/spacelift/resource_named_webhook.go
+++ b/spacelift/resource_named_webhook.go
@@ -152,7 +152,6 @@ func resourceNamedWebhookUpdate(ctx context.Context, d *schema.ResourceData, met
 
 	enabled := d.Get("enabled").(bool)
 	endpoint := d.Get("endpoint").(string)
-	secret := d.Get("secret").(string)
 	spaceID := d.Get("space_id").(string)
 	name := d.Get("name").(string)
 
@@ -170,7 +169,6 @@ func resourceNamedWebhookUpdate(ctx context.Context, d *schema.ResourceData, met
 	input := structs.NamedWebhooksIntegrationInput{
 		Enabled:  graphql.Boolean(enabled),
 		Endpoint: graphql.String(endpoint),
-		Secret:   toOptionalString(secret),
 		Name:     graphql.String(name),
 		Space:    graphql.String(spaceID),
 		Labels:   labels,


### PR DESCRIPTION
## Description of the change

This PR fixes a critical bug where the `secret` field of a `spacelift_named_webhook` resource was being erased when updating other attributes of the webhook without explicitly providing the secret in the Terraform configuration.

**Root Cause:** 
This:
```
  secret := d.Get("secret").(string) // secret := ""
  toOptionalString(secret) // &secret
```
produces a pointer to an empty string, which gets included in the update mutation (as `secret: ""`), resulting in erasing the secret from the DB. 

**Changes Made:**
- Removed `Secret` field from the update input struct (spacelift/resource_named_webhook.go:172)


```diff
{
    "query": "mutation($id:ID!$input:NamedWebhooksIntegrationInput!){namedWebhooksIntegrationUpdate(id: $id, input: $input){id,enabled,endpoint,space{id,description,name,inheritEntities,parentSpace,labels},name,secret,secretHeaders,labels,retryOnFailure}}",
    "variables": {
        "id": "test-webhook-1234",
        "input": {
            "enabled": false,
            "endpoint": "https://test.com2",
            "space": "root",
            "name": "test-webhook-1234",
-           "secret": "",
            "labels": [
                "test",
                "integration"
            ],
            "retryOnFailure": null
        }
    }
}
```


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> This fixes the issue described in issue.md where modifying a named webhook's attributes (like `retry_on_failure`) would inadvertently erase the secret value.

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to \`false\`.)
- [ ] If the action fails that checks the documentation: Run \`go generate\` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 52b511b31c8b522584439e32f666fe7273b12da0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->