### PR TITLE
chore: remove ForceNew flag from named_webhook secret field

### DIFF
--- a/spacelift/resource_named_webhook.go
+++ b/spacelift/resource_named_webhook.go
@@ -65,7 +65,6 @@ func resourceNamedWebhook() *schema.Resource {
 				Description:      "secret used to sign each request so you're able to verify that the request comes from us. Defaults to an empty value. Note that once it's created, it will be just an empty string in the state due to security reasons.",
 				Optional:         true,
 				Sensitive:        true,
-				ForceNew:         true,
 				DiffSuppressFunc: ignoreOnceCreated,
 			},
 			"retry_on_failure": {


### PR DESCRIPTION
## Description of the change

Removed the `ForceNew` flag from the `secret` field in the `named_webhook` resource. This flag was unnecessary because the secret value is not stored in the state after creation (it's always an empty string due to security reasons). The resource was being unnecessarily recreated when users attempted to update the secret, even though the state doesn't track the actual secret value.

The `ignoreOnceCreated` diff suppression function already handles the behavior correctly by ignoring changes to the secret after the resource is created.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> None

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to \`false\`.)
- [ ] If the action fails that checks the documentation: Run \`go generate\` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove `ForceNew` from the `secret` field of `spacelift_named_webhook` in `spacelift/resource_named_webhook.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96f0b3605612059581694e2ca57b4863503a3fd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->