### PR TITLE
fix(CU-869bhxufh): fix error message matching

### DIFF
--- a/spacelift/resource_module_test.go
+++ b/spacelift/resource_module_test.go
@@ -630,7 +630,7 @@ func TestModuleResourceSpace(t *testing.T) {
 					shared_accounts = ["spacelift-io"]
 				}
 			`, spaces, randomID, branch, repository),
-				ExpectError: regexp.MustCompile("you need to have admin or write permissions to be able to share a module with following spaces: foobar-space-that-does-not-exist"),
+				ExpectError: regexp.MustCompile("you do not have permissions to share a module with following spaces: foobar-space-that-does-not-exist"),
 			},
 		})
 	})


### PR DESCRIPTION
## Description of the change

I changed the error message returned by the backend and forgot to adjust it there.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates test expectation to align with revised backend error message.
> 
> - In `spacelift/resource_module_test.go`, changes `ExpectError` regex to match "you do not have permissions to share a module with following spaces: ..." for invalid `space_shares`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38ad2e2c43dec572f12cf4a774c79eac1a694d18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->