### PR TITLE
feat: Add `spacelift_template` datasource

### DIFF
--- a/spacelift/data_template.go
+++ b/spacelift/data_template.go
@@ -1,0 +1,105 @@
+package spacelift
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
+)
+
+func dataTemplate() *schema.Resource {
+	return &schema.Resource{
+		Description: "`spacelift_template` represents a Spacelift template (versioned blueprint), " +
+			"which is a collection of blueprint versions that can be used to create stacks.",
+
+		ReadContext: dataTemplateRead,
+
+		Schema: map[string]*schema.Schema{
+			"template_id": {
+				Type:             schema.TypeString,
+				Description:      "ID of the template",
+				Required:         true,
+				ValidateDiagFunc: validations.DisallowEmptyString,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Description: "Name of the template",
+				Computed:    true,
+			},
+			"space": {
+				Type:        schema.TypeString,
+				Description: "ID of the space the template is in",
+				Computed:    true,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "Description of the template",
+				Computed:    true,
+			},
+			"labels": {
+				Type:        schema.TypeSet,
+				Description: "Labels of the template",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+			},
+			"ulid": {
+				Type:        schema.TypeString,
+				Description: "Unique ULID of the template",
+				Computed:    true,
+			},
+			"created_at": {
+				Type:        schema.TypeInt,
+				Description: "Unix timestamp when the template was created",
+				Computed:    true,
+			},
+			"updated_at": {
+				Type:        schema.TypeInt,
+				Description: "Unix timestamp when the template was last updated",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataTemplateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var query struct {
+		BlueprintVersionedGroup *structs.BlueprintVersionedGroup `graphql:"blueprintVersionedGroup(id: $id)"`
+	}
+
+	templateID := d.Get("template_id")
+
+	variables := map[string]interface{}{"id": toID(templateID)}
+	if err := meta.(*internal.Client).Query(ctx, "TemplateRead", &query, variables); err != nil {
+		return diag.Errorf("could not query for template: %v", err)
+	}
+
+	template := query.BlueprintVersionedGroup
+	if template == nil {
+		return diag.Errorf("could not find template %s", templateID)
+	}
+
+	d.SetId(template.ID)
+	d.Set("name", template.Name)
+	d.Set("space", template.Space.ID)
+	d.Set("ulid", template.ULID)
+	d.Set("created_at", template.CreatedAt)
+	d.Set("updated_at", template.UpdatedAt)
+
+	if template.Description == nil {
+		d.Set("description", "")
+	} else {
+		d.Set("description", *template.Description)
+	}
+
+	labels := schema.NewSet(schema.HashString, []interface{}{})
+	for _, label := range template.Labels {
+		labels.Add(label)
+	}
+	d.Set("labels", labels)
+
+	return nil
+}

--- a/spacelift/data_template_test.go
+++ b/spacelift/data_template_test.go
@@ -1,0 +1,69 @@
+package spacelift
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	. "github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/testhelpers"
+)
+
+func TestTemplateData(t *testing.T) {
+	t.Run("creates and reads a template", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{{
+			Config: fmt.Sprintf(`
+				resource "spacelift_template" "test" {
+					name        = "test-template-%s"
+					space       = "root"
+					description = "test description"
+					labels      = ["label1", "label2"]
+				}
+
+				data "spacelift_template" "test" {
+					template_id = spacelift_template.test.id
+				}
+			`, randomID),
+			Check: Resource(
+				"data.spacelift_template.test",
+				Attribute("id", IsNotEmpty()),
+				Attribute("name", Equals("test-template-"+randomID)),
+				Attribute("space", Equals("root")),
+				Attribute("description", Equals("test description")),
+				SetEquals("labels", "label1", "label2"),
+				Attribute("ulid", IsNotEmpty()),
+				Attribute("created_at", IsNotEmpty()),
+				Attribute("updated_at", IsNotEmpty()),
+			),
+		}})
+	})
+
+	t.Run("reads a template without optional fields", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{{
+			Config: fmt.Sprintf(`
+				resource "spacelift_template" "test" {
+					name   = "test-template-%s"
+					space  = "root"
+					labels = []
+				}
+
+				data "spacelift_template" "test" {
+					template_id = spacelift_template.test.id
+				}
+			`, randomID),
+			Check: Resource(
+				"data.spacelift_template.test",
+				Attribute("id", IsNotEmpty()),
+				Attribute("name", Equals("test-template-"+randomID)),
+				Attribute("space", Equals("root")),
+				Attribute("description", Equals("")),
+				Attribute("labels.#", Equals("0")),
+			),
+		}})
+	})
+}

--- a/spacelift/provider.go
+++ b/spacelift/provider.go
@@ -97,6 +97,7 @@ func Provider(commit, version string) plugin.ProviderFunc {
 				"spacelift_stack":                                  dataStack(),
 				"spacelift_stack_outputs":                          dataStackOutputs(),
 				"spacelift_stacks":                                 dataStacks(),
+				"spacelift_template":                               dataTemplate(),
 				"spacelift_tool_versions":                          dataToolVersions(),
 				"spacelift_user":                                   dataUser(),
 				"spacelift_webhook":                                dataWebhook(),


### PR DESCRIPTION
## Description of the change

Depends on: https://github.com/spacelift-io/terraform-provider-spacelift/pull/722

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a read-only data source to fetch Spacelift template (versioned blueprint) metadata.
> 
> - New `data_template` with `template_id` input and computed fields: `name`, `space`, `description`, `labels`, `ulid`, `created_at`, `updated_at`
> - GraphQL query to `blueprintVersionedGroup(id: $id)`; handles missing `description` and sets label set
> - Registered `spacelift_template` in provider `DataSourcesMap`
> - Acceptance tests cover populated and minimal templates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb5052d1b39f8bc99f9d15caabbca0f7e1ac548d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->