### PR TITLE
fix: Install Terraform in dependabot workflow for docs generation

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -39,6 +39,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+
       - name: Regenerate docs
         run: cd tools && go generate ./...
 


### PR DESCRIPTION

## Description of the change

The docs regeneration step requires Terraform to be installed because `terraform-plugin-docs` invokes it during generation.

Fixes: `exec: "terraform": executable file not found in $PATH` https://github.com/spacelift-io/terraform-provider-spacelift/actions/runs/21513809590/job/61987122295?pr=728


- [x] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)