### PR TITLE
fix: template deployment with empty inputs

### DIFF
--- a/spacelift/resource_template_deployment.go
+++ b/spacelift/resource_template_deployment.go
@@ -346,9 +346,10 @@ func templateDeploymentCreateInput(d *schema.ResourceData) structs.BlueprintDepl
 }
 
 func templateDeploymentSchemaToInputs(d *schema.ResourceData) []structs.BlueprintDeploymentCreateInputPair {
+	inputs := make([]structs.BlueprintDeploymentCreateInputPair, 0)
 	if inputList, ok := d.GetOk("input"); ok {
 		stateInputs := inputList.([]any)
-		inputs := make([]structs.BlueprintDeploymentCreateInputPair, len(stateInputs))
+		inputs = make([]structs.BlueprintDeploymentCreateInputPair, len(stateInputs))
 		for i, v := range stateInputs {
 			item := v.(map[string]any)
 			inputs[i] = structs.BlueprintDeploymentCreateInputPair{
@@ -358,7 +359,7 @@ func templateDeploymentSchemaToInputs(d *schema.ResourceData) []structs.Blueprin
 		}
 		return inputs
 	}
-	return nil
+	return inputs
 }
 
 type waitInput struct {


### PR DESCRIPTION
## Description of the change

If no inputs are defined, we should send the empty slice instead of nothing.

<img width="811" height="154" alt="2026-02-11_14-42" src="https://github.com/user-attachments/assets/38256b51-0843-45e5-bd1d-374172b4683b" />

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to input serialization; primary risk is only potential behavior change if the API previously relied on omitted vs empty inputs.
> 
> **Overview**
> Fixes `spacelift_template_deployment` input handling so deployments with no `input` blocks send an explicit empty `Inputs` slice rather than `nil`.
> 
> This adjusts `templateDeploymentSchemaToInputs` to return an empty slice by default, avoiding API/GraphQL behavior differences between omitted vs empty inputs during create/update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 693425de254de1413baf755356f3cf108ff1cee4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->