### PR TITLE
fix: race condition in flaky test TestDestroyStackDestructor

### DIFF
--- a/spacelift/resource_stack_destructor_test.go
+++ b/spacelift/resource_stack_destructor_test.go
@@ -79,12 +79,15 @@ func TestDestroyStackDestructor(t *testing.T) {
 
 			resource "spacelift_run" "test" {
 				stack_id = spacelift_stack.test.id
-				keepers = {
-					"test": "value"
+				wait {
+					continue_on_state = ["unconfirmed"]
 				}
 			}
 
 			resource "spacelift_stack_destructor" "test" {
+				depends_on = [
+					spacelift_run.test,
+				]
 				stack_id     = spacelift_stack.test.id
 				discard_runs = true
 			}


### PR DESCRIPTION
## Description of the change

We have to wait for the run to be in unconfirmed run before doing executing  `spacelift_stack_destructor`. Otherwise we could end in a situation where the run has not been scheduled and we try to discard it, the state machine will refuse that and the test will fail with `Error: could not discard runs on stack stack-cpe6i:
[01KHNGR8GYA6QQMBWFG31CXJSV]`

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adjusts resource ordering/wait conditions to reduce flakiness; no production logic is modified.
> 
> **Overview**
> Fixes a race in `TestDestroyStackDestructor` by making the test `spacelift_run` wait until it reaches the `unconfirmed` state before proceeding.
> 
> The test now explicitly orders teardown by adding `depends_on` from `spacelift_stack_destructor` to the run resource, replacing the prior `keepers`-based run trigger so runs are reliably schedulable before discard-on-destroy is exercised.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d40084f5dc528ddfc15ab5bebd09e507e575dea2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->