### PR TITLE
revert: unpin goreleaser version back to ~> v2

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run GoReleaser to create draft release
         uses: goreleaser/goreleaser-action@v7
         with:
-          version: v2.14.3
+          version: ~> v2
           args: release --clean --snapshot
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run GoReleaser to create draft release
         uses: goreleaser/goreleaser-action@v7
         with:
-          version: v2.14.3
+          version: ~> v2
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION


## Description of the change

The GPG signing issue (goreleaser/goreleaser#6514) that required pinning to v2.14.3 has been fixed upstream. Reverting to the floating `~> v2` constraint so we automatically pick up future patch and minor releases without manual bumps.


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)