### PR TITLE
feat(spacelift_run): add runtime_config support for custom per-run configuration

### DIFF
--- a/docs/resources/run.md
+++ b/docs/resources/run.md
@@ -40,12 +40,43 @@ resource "spacelift_run" "this" {
 - `commit_sha` (String) The commit SHA for which to trigger a run.
 - `keepers` (Map of String) Arbitrary map of values that, when changed, will trigger recreation of the resource.
 - `proposed` (Boolean) Whether the run is a proposed run. Defaults to `false`.
+- `runtime_config` (Block List, Max: 1) Custom runtime configuration for this run. (see [below for nested schema](#nestedblock--runtime_config))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `wait` (Block List, Max: 1) Wait for the run to finish (see [below for nested schema](#nestedblock--wait))
 
 ### Read-Only
 
 - `id` (String) The ID of the triggered run.
+
+<a id="nestedblock--runtime_config"></a>
+### Nested Schema for `runtime_config`
+
+Optional:
+
+- `after_apply` (List of String) List of after-apply scripts.
+- `after_destroy` (List of String) List of after-destroy scripts.
+- `after_init` (List of String) List of after-init scripts.
+- `after_perform` (List of String) List of after-perform scripts.
+- `after_plan` (List of String) List of after-plan scripts.
+- `after_run` (List of String) List of after-run scripts.
+- `before_apply` (List of String) List of before-apply scripts.
+- `before_destroy` (List of String) List of before-destroy scripts.
+- `before_init` (List of String) List of before-init scripts.
+- `before_perform` (List of String) List of before-perform scripts.
+- `before_plan` (List of String) List of before-plan scripts.
+- `environment` (Block Set) Environment variables for the run. (see [below for nested schema](#nestedblock--runtime_config--environment))
+- `project_root` (String) Project root is the optional directory relative to the workspace root containing the entrypoint to the Stack.
+- `runner_image` (String) Name of the Docker image used to process Runs.
+
+<a id="nestedblock--runtime_config--environment"></a>
+### Nested Schema for `runtime_config.environment`
+
+Required:
+
+- `key` (String) Environment variable key.
+- `value` (String) Environment variable value.
+
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/spacelift/internal/structs/run.go
+++ b/spacelift/internal/structs/run.go
@@ -1,5 +1,12 @@
 package structs
 
+type RunType string
+
+const (
+	RunTypeProposed RunType = "PROPOSED"
+	RunTypeTracked  RunType = "TRACKED"
+)
+
 type Run struct {
 	ID string `graphql:"id"`
 }

--- a/spacelift/resource_run.go
+++ b/spacelift/resource_run.go
@@ -62,6 +62,112 @@ func resourceRun() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"runtime_config": {
+				Type:        schema.TypeList,
+				Description: "Custom runtime configuration for this run.",
+				Optional:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"project_root": {
+							Type:        schema.TypeString,
+							Description: "Project root is the optional directory relative to the workspace root containing the entrypoint to the Stack.",
+							Optional:    true,
+						},
+						"runner_image": {
+							Type:        schema.TypeString,
+							Description: "Name of the Docker image used to process Runs.",
+							Optional:    true,
+						},
+						"environment": {
+							Type:        schema.TypeSet,
+							Description: "Environment variables for the run.",
+							Optional:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Description: "Environment variable key.",
+										Required:    true,
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Description: "Environment variable value.",
+										Required:    true,
+									},
+								},
+							},
+						},
+						"after_apply": {
+							Type:        schema.TypeList,
+							Description: "List of after-apply scripts.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+						},
+						"after_destroy": {
+							Type:        schema.TypeList,
+							Description: "List of after-destroy scripts.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+						},
+						"after_init": {
+							Type:        schema.TypeList,
+							Description: "List of after-init scripts.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+						},
+						"after_perform": {
+							Type:        schema.TypeList,
+							Description: "List of after-perform scripts.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+						},
+						"after_plan": {
+							Type:        schema.TypeList,
+							Description: "List of after-plan scripts.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+						},
+						"after_run": {
+							Type:        schema.TypeList,
+							Description: "List of after-run scripts.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+						},
+						"before_apply": {
+							Type:        schema.TypeList,
+							Description: "List of before-apply scripts.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+						},
+						"before_destroy": {
+							Type:        schema.TypeList,
+							Description: "List of before-destroy scripts.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+						},
+						"before_init": {
+							Type:        schema.TypeList,
+							Description: "List of before-init scripts.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+						},
+						"before_perform": {
+							Type:        schema.TypeList,
+							Description: "List of before-perform scripts.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+						},
+						"before_plan": {
+							Type:        schema.TypeList,
+							Description: "List of before-plan scripts.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Optional:    true,
+						},
+					},
+				},
+			},
 			"wait": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -98,37 +204,80 @@ func resourceRun() *schema.Resource {
 
 func resourceRunCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var mutation struct {
-		ID string `graphql:"runResourceCreate(stack: $stack, commitSha: $sha, proposed: $proposed)"`
+		Run structs.Run `graphql:"runTrigger(stack: $stack, commitSha: $commitSha, runType: $runType, runtimeConfig: $runtimeConfig)"`
 	}
 
 	stackID := d.Get("stack_id").(string)
 
+	runType := structs.RunTypeTracked
+	if proposed, ok := d.GetOk("proposed"); ok && proposed.(bool) {
+		runType = structs.RunTypeProposed
+	}
+
 	variables := map[string]any{
-		"stack":    toID(stackID),
-		"sha":      (*graphql.String)(nil),
-		"proposed": (*graphql.Boolean)(nil),
+		"stack":         toID(stackID),
+		"commitSha":     (*graphql.String)(nil),
+		"runType":       &runType,
+		"runtimeConfig": (*structs.RuntimeConfigInput)(nil),
 	}
 
 	if sha, ok := d.GetOk("commit_sha"); ok {
-		variables["sha"] = new(graphql.String(sha.(string)))
+		variables["commitSha"] = toOptionalString(sha)
 	}
 
-	if proposed, ok := d.GetOk("proposed"); ok {
-		variables["proposed"] = new(graphql.Boolean(proposed.(bool)))
+	if runtimeConfig, ok := d.Get("runtime_config").([]any); ok && len(runtimeConfig) > 0 {
+		variables["runtimeConfig"] = parseRuntimeConfig(runtimeConfig)
 	}
 
 	client := meta.(*internal.Client)
-	if err := client.Mutate(ctx, "ResourceRunCreate", &mutation, variables); err != nil {
+	if err := client.Mutate(ctx, "RunTrigger", &mutation, variables); err != nil {
 		return diag.Errorf("could not trigger run for stack %s: %v", stackID, internal.FromSpaceliftError(err))
 	}
 
 	if waitRaw, ok := d.GetOk("wait"); ok {
 		wait := structs.NewWaitConfiguration(waitRaw.([]any))
-		if diag := wait.Wait(ctx, d, client, stackID, mutation.ID); len(diag) > 0 {
+		if diag := wait.Wait(ctx, d, client, stackID, mutation.Run.ID); len(diag) > 0 {
 			return diag
 		}
 	}
 
-	d.SetId(mutation.ID)
+	d.SetId(mutation.Run.ID)
 	return nil
+}
+
+func parseRuntimeConfig(runtimeConfig []any) *structs.RuntimeConfigInput {
+	mapped := runtimeConfig[0].(map[string]any)
+
+	environment := []structs.EnvVarInput{}
+	for _, e := range mapped["environment"].(*schema.Set).List() {
+		envMap := e.(map[string]any)
+		environment = append(environment, structs.EnvVarInput{
+			Key:   toString(envMap["key"]),
+			Value: toString(envMap["value"]),
+		})
+	}
+
+	cfg := &structs.RuntimeConfigInput{
+		AfterApply:    listToOptionalStringList(mapped["after_apply"]),
+		AfterDestroy:  listToOptionalStringList(mapped["after_destroy"]),
+		AfterInit:     listToOptionalStringList(mapped["after_init"]),
+		AfterPerform:  listToOptionalStringList(mapped["after_perform"]),
+		AfterPlan:     listToOptionalStringList(mapped["after_plan"]),
+		AfterRun:      listToOptionalStringList(mapped["after_run"]),
+		BeforeApply:   listToOptionalStringList(mapped["before_apply"]),
+		BeforeDestroy: listToOptionalStringList(mapped["before_destroy"]),
+		BeforeInit:    listToOptionalStringList(mapped["before_init"]),
+		BeforePerform: listToOptionalStringList(mapped["before_perform"]),
+		BeforePlan:    listToOptionalStringList(mapped["before_plan"]),
+		Environment:   &environment,
+	}
+
+	if projectRoot := mapped["project_root"]; len(projectRoot.(string)) > 0 {
+		cfg.ProjectRoot = toOptionalString(projectRoot)
+	}
+	if runnerImage := mapped["runner_image"]; len(runnerImage.(string)) > 0 {
+		cfg.RunnerImage = toOptionalString(runnerImage)
+	}
+
+	return cfg
 }

--- a/spacelift/resource_run_test.go
+++ b/spacelift/resource_run_test.go
@@ -49,6 +49,59 @@ func TestRunResource(t *testing.T) {
 	})
 }
 
+func TestRunResourceWithRuntimeConfig(t *testing.T) {
+
+	t.Run("on a new stack", func(t *testing.T) {
+		const resourceName = "spacelift_run.test"
+
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		randomIDwp := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_worker_pool" "test" {
+					name        = "Let's create a dummy worker pool to avoid running the job %s"
+				}
+
+				resource "spacelift_stack" "test" {
+					name           = "Test stack %s"
+					repository     = "demo"
+					branch         = "master"
+					worker_pool_id = spacelift_worker_pool.test.id
+				}
+
+				resource "spacelift_run" "test" {
+					stack_id = spacelift_stack.test.id
+
+					keepers = { "bacon" = "tasty" }
+
+					runtime_config {
+						project_root = "root"
+						runner_image = "image"
+						after_apply  = ["cmd1", "cmd2"]
+
+						environment {
+							key   = "ENV_1"
+							value = "ENV_1_VAL"
+						}
+						environment {
+							key   = "ENV_2"
+							value = "ENV_2_VAL"
+						}
+					}
+				}
+			`, randomIDwp, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("id", IsNotEmpty()),
+					Attribute("stack_id", Contains(randomID)),
+				),
+			},
+		})
+	})
+}
+
 func TestRunResourceWait(t *testing.T) {
 
 	t.Run("on a new stack", func(t *testing.T) {

--- a/spacelift/resource_scheduled_run.go
+++ b/spacelift/resource_scheduled_run.go
@@ -360,40 +360,8 @@ func parseScheduledRunInput(d *schema.ResourceData) (*structs.ScheduledRunInput,
 		cfg.Name = toString(name)
 	}
 
-	runtimeConfig, ok := d.Get("runtime_config").([]any)
-	if ok && len(runtimeConfig) > 0 {
-		mapped := runtimeConfig[0].(map[string]any)
-
-		environment := []structs.EnvVarInput{}
-		for _, e := range mapped["environment"].(*schema.Set).List() {
-			envMap := e.(map[string]any)
-			environment = append(environment, structs.EnvVarInput{
-				Key:   toString(envMap["key"]),
-				Value: toString(envMap["value"]),
-			})
-		}
-
-		cfg.RuntimeConfig = &structs.RuntimeConfigInput{
-			AfterApply:    listToOptionalStringList(mapped["after_apply"]),
-			AfterDestroy:  listToOptionalStringList(mapped["after_destroy"]),
-			AfterInit:     listToOptionalStringList(mapped["after_init"]),
-			AfterPerform:  listToOptionalStringList(mapped["after_perform"]),
-			AfterPlan:     listToOptionalStringList(mapped["after_plan"]),
-			AfterRun:      listToOptionalStringList(mapped["after_run"]),
-			BeforeApply:   listToOptionalStringList(mapped["before_apply"]),
-			BeforeDestroy: listToOptionalStringList(mapped["before_destroy"]),
-			BeforeInit:    listToOptionalStringList(mapped["before_init"]),
-			BeforePerform: listToOptionalStringList(mapped["before_perform"]),
-			BeforePlan:    listToOptionalStringList(mapped["before_plan"]),
-			Environment:   &environment,
-		}
-
-		if projectRoot := mapped["project_root"]; len(projectRoot.(string)) > 0 {
-			cfg.RuntimeConfig.ProjectRoot = toOptionalString(projectRoot)
-		}
-		if runnerImage := mapped["runner_image"]; len(runnerImage.(string)) > 0 {
-			cfg.RuntimeConfig.RunnerImage = toOptionalString(runnerImage)
-		}
+	if runtimeConfig, ok := d.Get("runtime_config").([]any); ok && len(runtimeConfig) > 0 {
+		cfg.RuntimeConfig = parseRuntimeConfig(runtimeConfig)
 	}
 
 	every, everyOk := d.GetOk("every")


### PR DESCRIPTION
## Summary

- Switch `spacelift_run` from `runResourceCreate` to `runTrigger` GraphQL mutation, enabling custom runtime configuration (environment variables, project root, runner image, and before/after hook scripts) scoped to a single run
- Matches the "Trigger with custom runtime config" capability already available in the Spacelift UI
- Deduplicate runtime config parsing by extracting shared `parseRuntimeConfig()` used by both `spacelift_run` and `spacelift_scheduled_run`
- The existing `proposed` field is preserved for backward compatibility, mapped internally to the `runType` enum

Tested locally with a dev_overrides provider build against a live Spacelift stack — confirmed runtime config environment variables are passed through and visible in the UI and GraphQL API.

Closes #775

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GraphQL mutation used to trigger runs and adds new runtime configuration inputs, which could affect run creation behavior and backward compatibility if the API differs. Scope is limited to run-triggering resources and includes test coverage and docs updates.
> 
> **Overview**
> **`spacelift_run` can now trigger runs with per-run `runtime_config`.** The resource schema and docs add a `runtime_config` block supporting env vars, `project_root`, `runner_image`, and before/after hook script lists.
> 
> Run creation is switched from the legacy `runResourceCreate` mutation to `runTrigger`, mapping the existing `proposed` boolean to a new `RunType` enum (`PROPOSED`/`TRACKED`) while preserving the old field. Runtime-config parsing is deduplicated into a shared `parseRuntimeConfig()` reused by `spacelift_scheduled_run`, and acceptance tests add coverage for the new `runtime_config` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4929f4c913b221bdb8f0559a2062de0f46578c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->