### PR TITLE
chore: drop administrative flag from tests, examples, and generated docs

### DIFF
--- a/docs/resources/module.md
+++ b/docs/resources/module.md
@@ -17,7 +17,6 @@ description: |-
 resource "spacelift_module" "k8s-module" {
   name               = "k8s-module"
   terraform_provider = "aws"
-  administrative     = true
   branch             = "master"
   description        = "Infra terraform module"
   repository         = "terraform-super-module"
@@ -25,11 +24,10 @@ resource "spacelift_module" "k8s-module" {
 
 # Unspecified module name and provider (repository naming scheme terraform-${provider}-${name})
 resource "spacelift_module" "example-module" {
-  administrative = true
-  branch         = "master"
-  description    = "Example terraform module"
-  repository     = "terraform-aws-example"
-  project_root   = "example"
+  branch       = "master"
+  description  = "Example terraform module"
+  repository   = "terraform-aws-example"
+  project_root = "example"
 }
 ```
 

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -15,7 +15,6 @@ description: |-
 ```terraform
 # Terraform stack using github.com as VCS
 resource "spacelift_stack" "k8s-cluster" {
-  administrative    = true
   autodeploy        = true
   branch            = "master"
   description       = "Provisions a Kubernetes cluster"
@@ -31,7 +30,6 @@ resource "spacelift_stack" "k8s-cluster-bitbucket-cloud" {
     namespace = "SPACELIFT" # The Bitbucket project containing the repository
   }
 
-  administrative    = true
   autodeploy        = true
   branch            = "master"
   description       = "Provisions a Kubernetes cluster"
@@ -47,7 +45,6 @@ resource "spacelift_stack" "k8s-cluster-bitbucket-datacenter" {
     namespace = "SPACELIFT" # The Bitbucket project containing the repository
   }
 
-  administrative    = true
   autodeploy        = true
   branch            = "master"
   description       = "Provisions a Kubernetes cluster"
@@ -63,7 +60,6 @@ resource "spacelift_stack" "k8s-cluster-github-enterprise" {
     namespace = "spacelift" # The GitHub organization / user the repository belongs to
   }
 
-  administrative    = true
   autodeploy        = true
   branch            = "master"
   description       = "Provisions a Kubernetes cluster"
@@ -79,7 +75,6 @@ resource "spacelift_stack" "k8s-cluster-gitlab" {
     namespace = "spacelift" # The GitLab namespace containing the repository
   }
 
-  administrative    = true
   autodeploy        = true
   branch            = "master"
   description       = "Provisions a Kubernetes cluster"
@@ -91,7 +86,6 @@ resource "spacelift_stack" "k8s-cluster-gitlab" {
 
 # Terraform stack using github.com as VCS and enabling smart sanitization
 resource "spacelift_stack" "k8s-cluster" {
-  administrative               = true
   autodeploy                   = true
   branch                       = "master"
   description                  = "Provisions a Kubernetes cluster"
@@ -104,7 +98,6 @@ resource "spacelift_stack" "k8s-cluster" {
 
 # Terraform stack using github.com as VCS and enabling external state access
 resource "spacelift_stack" "k8s-cluster" {
-  administrative                  = true
   autodeploy                      = true
   branch                          = "master"
   description                     = "Provisions a Kubernetes cluster"

--- a/docs/resources/version.md
+++ b/docs/resources/version.md
@@ -16,7 +16,6 @@ description: |-
 resource "spacelift_module" "k8s-module" {
   name               = "k8s-module"
   terraform_provider = "aws"
-  administrative     = true
   branch             = "master"
   description        = "Infra terraform module"
   repository         = "terraform-super-module"

--- a/examples/resources/spacelift_module/resource.tf
+++ b/examples/resources/spacelift_module/resource.tf
@@ -2,7 +2,6 @@
 resource "spacelift_module" "k8s-module" {
   name               = "k8s-module"
   terraform_provider = "aws"
-  administrative     = true
   branch             = "master"
   description        = "Infra terraform module"
   repository         = "terraform-super-module"
@@ -10,9 +9,8 @@ resource "spacelift_module" "k8s-module" {
 
 # Unspecified module name and provider (repository naming scheme terraform-${provider}-${name})
 resource "spacelift_module" "example-module" {
-  administrative = true
-  branch         = "master"
-  description    = "Example terraform module"
-  repository     = "terraform-aws-example"
-  project_root   = "example"
+  branch       = "master"
+  description  = "Example terraform module"
+  repository   = "terraform-aws-example"
+  project_root = "example"
 }

--- a/examples/resources/spacelift_stack/resource.tf
+++ b/examples/resources/spacelift_stack/resource.tf
@@ -1,6 +1,5 @@
 # Terraform stack using github.com as VCS
 resource "spacelift_stack" "k8s-cluster" {
-  administrative    = true
   autodeploy        = true
   branch            = "master"
   description       = "Provisions a Kubernetes cluster"
@@ -16,7 +15,6 @@ resource "spacelift_stack" "k8s-cluster-bitbucket-cloud" {
     namespace = "SPACELIFT" # The Bitbucket project containing the repository
   }
 
-  administrative    = true
   autodeploy        = true
   branch            = "master"
   description       = "Provisions a Kubernetes cluster"
@@ -32,7 +30,6 @@ resource "spacelift_stack" "k8s-cluster-bitbucket-datacenter" {
     namespace = "SPACELIFT" # The Bitbucket project containing the repository
   }
 
-  administrative    = true
   autodeploy        = true
   branch            = "master"
   description       = "Provisions a Kubernetes cluster"
@@ -48,7 +45,6 @@ resource "spacelift_stack" "k8s-cluster-github-enterprise" {
     namespace = "spacelift" # The GitHub organization / user the repository belongs to
   }
 
-  administrative    = true
   autodeploy        = true
   branch            = "master"
   description       = "Provisions a Kubernetes cluster"
@@ -64,7 +60,6 @@ resource "spacelift_stack" "k8s-cluster-gitlab" {
     namespace = "spacelift" # The GitLab namespace containing the repository
   }
 
-  administrative    = true
   autodeploy        = true
   branch            = "master"
   description       = "Provisions a Kubernetes cluster"
@@ -76,7 +71,6 @@ resource "spacelift_stack" "k8s-cluster-gitlab" {
 
 # Terraform stack using github.com as VCS and enabling smart sanitization
 resource "spacelift_stack" "k8s-cluster" {
-  administrative               = true
   autodeploy                   = true
   branch                       = "master"
   description                  = "Provisions a Kubernetes cluster"
@@ -89,7 +83,6 @@ resource "spacelift_stack" "k8s-cluster" {
 
 # Terraform stack using github.com as VCS and enabling external state access
 resource "spacelift_stack" "k8s-cluster" {
-  administrative                  = true
   autodeploy                      = true
   branch                          = "master"
   description                     = "Provisions a Kubernetes cluster"

--- a/examples/resources/spacelift_version/resource.tf
+++ b/examples/resources/spacelift_version/resource.tf
@@ -1,7 +1,6 @@
 resource "spacelift_module" "k8s-module" {
   name               = "k8s-module"
   terraform_provider = "aws"
-  administrative     = true
   branch             = "master"
   description        = "Infra terraform module"
   repository         = "terraform-super-module"

--- a/spacelift/data_module_test.go
+++ b/spacelift/data_module_test.go
@@ -18,7 +18,6 @@ func TestModuleData(t *testing.T) {
 			Config: fmt.Sprintf(`
 			resource "spacelift_module" "test" {
                 name            = "test-module-%s"
-				administrative  = true
 				branch          = "master"
 				description     = "description"
 				labels          = ["one", "two"]
@@ -33,7 +32,6 @@ func TestModuleData(t *testing.T) {
 			Check: Resource(
 				"data.spacelift_module.test",
 				Attribute("id", Equals(fmt.Sprintf("terraform-default-test-module-%s", randomID))),
-				Attribute("administrative", Equals("true")),
 				Attribute("branch", Equals("master")),
 				Attribute("description", Equals("description")),
 				SetEquals("labels", "one", "two"),
@@ -56,7 +54,6 @@ func TestModuleData(t *testing.T) {
 				Config: fmt.Sprintf(`
 				resource "spacelift_module" "test" {
 					name            = "test-module-%s"
-					administrative  = true
 					branch          = "master"
 					repository      = "terraform-bacon-tasty"
 				}
@@ -80,7 +77,6 @@ func TestModuleData(t *testing.T) {
 				Config: fmt.Sprintf(`
 				resource "spacelift_module" "test" {
 					name            = "test-module-%s"
-					administrative  = true
 					branch          = "master"
 					repository      = "terraform-bacon-tasty"
 					workflow_tool   = "CUSTOM"
@@ -105,7 +101,6 @@ func TestModuleData(t *testing.T) {
 				Config: fmt.Sprintf(`
 				resource "spacelift_module" "test" {
 					name            = "test-module-%s"
-					administrative  = false
 					branch          = "main"
 					repository      = "terraform-bacon-tasty"
 
@@ -139,7 +134,6 @@ func TestModuleDataSpace(t *testing.T) {
 		Config: fmt.Sprintf(`
 			resource "spacelift_module" "test" {
                 name            = "test-module-%s"
-				administrative  = true
 				branch          = "master"
 				description     = "description"
 				labels          = ["one", "two"]
@@ -155,7 +149,6 @@ func TestModuleDataSpace(t *testing.T) {
 		Check: Resource(
 			"data.spacelift_module.test",
 			Attribute("id", Equals(fmt.Sprintf("terraform-default-test-module-%s", randomID))),
-			Attribute("administrative", Equals("true")),
 			Attribute("branch", Equals("master")),
 			Attribute("description", Equals("description")),
 			SetEquals("labels", "one", "two"),

--- a/spacelift/data_modules_test.go
+++ b/spacelift/data_modules_test.go
@@ -33,7 +33,6 @@ func TestModulesData(t *testing.T) {
 				resource "spacelift_module" "test" {
 					name = "test-module-%s"
 
-					administrative = true
 					branch         = "master"
 					labels         = ["bacon", "cabbage"]
 					project_root   = "root"
@@ -44,8 +43,6 @@ func TestModulesData(t *testing.T) {
 
 				data "spacelift_modules" "test" {
 					depends_on = [spacelift_module.test]
-
-					administrative {}
 
 					branch {
 					  any_of = ["main", "master"]

--- a/spacelift/data_stack_test.go
+++ b/spacelift/data_stack_test.go
@@ -17,7 +17,6 @@ func TestStackData(t *testing.T) {
 		testSteps(t, []resource.TestStep{{
 			Config: fmt.Sprintf(`
 			resource "spacelift_stack" "test" {
-				administrative                  = true
 				after_apply                     = ["ls -la", "rm -rf /"]
 				after_destroy                   = ["echo 'after_destroy'"]
 				after_init                      = ["terraform fmt -check", "tflint"]
@@ -53,7 +52,6 @@ func TestStackData(t *testing.T) {
 			Check: Resource(
 				"data.spacelift_stack.test",
 				Attribute("id", StartsWith("test-stack-")),
-				Attribute("administrative", Equals("true")),
 				Attribute("after_apply.#", Equals("2")),
 				Attribute("after_apply.0", Equals("ls -la")),
 				Attribute("after_apply.1", Equals("rm -rf /")),
@@ -558,7 +556,6 @@ func TestStackDataSpace(t *testing.T) {
 		testSteps(t, []resource.TestStep{{
 			Config: fmt.Sprintf(`
 			resource "spacelift_stack" "test" {
-				administrative               = true
 				after_apply                  = ["ls -la", "rm -rf /"]
 				after_destroy                = ["echo 'after_destroy'"]
 				after_init                   = ["terraform fmt -check", "tflint"]
@@ -590,7 +587,6 @@ func TestStackDataSpace(t *testing.T) {
 			Check: Resource(
 				"data.spacelift_stack.test",
 				Attribute("id", StartsWith("test-stack-")),
-				Attribute("administrative", Equals("true")),
 				Attribute("after_apply.#", Equals("2")),
 				Attribute("after_apply.0", Equals("ls -la")),
 				Attribute("after_apply.1", Equals("rm -rf /")),

--- a/spacelift/data_stacks_test.go
+++ b/spacelift/data_stacks_test.go
@@ -22,17 +22,14 @@ func TestStacksData(t *testing.T) {
 				resource "spacelift_stack" "test" {
 					name = "My stack %s"
 
-					administrative = true
-					branch         = "master"
-					labels         = ["bacon", "cabbage"]
-					project_root   = "root"
-					repository     = "demo"
+					branch       = "master"
+					labels       = ["bacon", "cabbage"]
+					project_root = "root"
+					repository   = "demo"
 				}
 
 				data "spacelift_stacks" "test" {
 					depends_on = [spacelift_stack.test]
-
-					administrative {}
 
 					branch {
 					  any_of = ["main", "master"]

--- a/spacelift/resource_bitbucket_datacenter_integration_test.go
+++ b/spacelift/resource_bitbucket_datacenter_integration_test.go
@@ -55,7 +55,6 @@ func TestBitbucketDatacenterIntegrationResource(t *testing.T) {
 					repository      = "` + testConfig.SourceCode.BitbucketDatacenter.Repository.Name + `"
 					branch          = "` + testConfig.SourceCode.BitbucketDatacenter.Repository.Branch + `"
 					space_id        = "` + testConfig.SourceCode.BitbucketDatacenter.SpaceLevel.Space + `"
-					administrative  = false
 					worker_pool_id  = spacelift_worker_pool.test.id
 					bitbucket_datacenter {
 						namespace = "` + testConfig.SourceCode.BitbucketDatacenter.Repository.Namespace + `"

--- a/spacelift/resource_gitlab_integration_test.go
+++ b/spacelift/resource_gitlab_integration_test.go
@@ -54,7 +54,6 @@ func TestGitLabIntegrationResource(t *testing.T) {
 					repository      = "` + testConfig.SourceCode.Gitlab.Repository.Name + `"
 					branch          = "` + testConfig.SourceCode.Gitlab.Repository.Branch + `"
 					space_id        = "` + testConfig.SourceCode.Gitlab.SpaceLevel.Space + `"
-					administrative  = false
 					worker_pool_id  = spacelift_worker_pool.test.id
 					gitlab {
 						namespace = "` + testConfig.SourceCode.Gitlab.Repository.Namespace + `"

--- a/spacelift/resource_module_test.go
+++ b/spacelift/resource_module_test.go
@@ -19,7 +19,6 @@ func TestModuleResource(t *testing.T) {
 			return fmt.Sprintf(`
 				resource "spacelift_module" "test" {
 					name                  = "github-module-%s"
-					administrative        = true
 					branch                = "master"
 					description           = "%s"
 					labels                = ["one", "two"]
@@ -40,7 +39,6 @@ func TestModuleResource(t *testing.T) {
 				Check: Resource(
 					"spacelift_module.test",
 					Attribute("id", Equals(fmt.Sprintf("terraform-default-github-module-%s", randomID))),
-					Attribute("administrative", Equals("true")),
 					Attribute("branch", Equals("master")),
 					Attribute("description", Equals("old description")),
 					SetEquals("labels", "one", "two"),
@@ -80,7 +78,6 @@ func TestModuleResource(t *testing.T) {
 			return fmt.Sprintf(`
 				resource "spacelift_module" "test" {
 					name           = "raw-git-%s"
-					administrative = false
 					branch         = "main"
 					repository     = "terraform-bacon-tasty"
 
@@ -115,7 +112,6 @@ func TestModuleResource(t *testing.T) {
 			return fmt.Sprintf(`
 				resource "spacelift_module" "test" {
 					name           = "public-test-%s"
-					administrative = false
 					branch         = "main"
 					repository     = "terraform-bacon-tasty"
 					public         = true
@@ -146,7 +142,6 @@ func TestModuleResource(t *testing.T) {
 			return fmt.Sprintf(`
 				resource "spacelift_module" "test" {
                     name               = "project-root-%s"
-					administrative     = true
 					branch             = "master"
 					description        = "description"
 					labels             = ["one", "two"]
@@ -166,7 +161,6 @@ func TestModuleResource(t *testing.T) {
 				Check: Resource(
 					"spacelift_module.test",
 					Attribute("id", Equals(fmt.Sprintf("terraform-papaya-project-root-%s", randomID))),
-					Attribute("administrative", Equals("true")),
 					Attribute("branch", Equals("master")),
 					Attribute("description", Equals("description")),
 					SetEquals("labels", "one", "two"),
@@ -376,7 +370,6 @@ func TestModuleResourceSpace(t *testing.T) {
 			return fmt.Sprintf(`
 				resource "spacelift_module" "test" {
 					name                  = "github-module-%s"
-					administrative        = true
 					branch                = "master"
 					description           = "%s"
 					labels                = ["one", "two"]
@@ -396,7 +389,6 @@ func TestModuleResourceSpace(t *testing.T) {
 				Check: Resource(
 					"spacelift_module.test",
 					Attribute("id", Equals(fmt.Sprintf("terraform-default-github-module-%s", randomID))),
-					Attribute("administrative", Equals("true")),
 					Attribute("branch", Equals("master")),
 					Attribute("description", Equals("old description")),
 					SetEquals("labels", "one", "two"),
@@ -432,7 +424,6 @@ func TestModuleResourceSpace(t *testing.T) {
 			return fmt.Sprintf(`
 				resource "spacelift_module" "test" {
                     name               = "project-root-%s"
-					administrative     = true
 					branch             = "master"
 					description        = "description"
 					labels             = ["one", "two"]
@@ -452,7 +443,6 @@ func TestModuleResourceSpace(t *testing.T) {
 				Check: Resource(
 					"spacelift_module.test",
 					Attribute("id", Equals(fmt.Sprintf("terraform-papaya-project-root-%s", randomID))),
-					Attribute("administrative", Equals("true")),
 					Attribute("branch", Equals("master")),
 					Attribute("description", Equals("description")),
 					SetEquals("labels", "one", "two"),

--- a/spacelift/resource_stack_azure_devops_test.go
+++ b/spacelift/resource_stack_azure_devops_test.go
@@ -24,7 +24,6 @@ func TestVCSIntegrationAzureDevOps(t *testing.T) {
 				repository         = "%s"
 				branch             = "%s"
 				space_id           = "root"
-				administrative     = false
 				azure_devops {
 					project = "%s"
 				}
@@ -69,7 +68,6 @@ func TestVCSIntegrationAzureDevOps(t *testing.T) {
 				repository         = "%s"
 				branch             = "%s"
 				space_id           = "%s"
-				administrative     = false
 				azure_devops {
 					project = "%s"
 					id = "%s"

--- a/spacelift/resource_stack_bitbucket_cloud_test.go
+++ b/spacelift/resource_stack_bitbucket_cloud_test.go
@@ -23,7 +23,6 @@ func TestVCSIntegrationBitbucketCloud(t *testing.T) {
 				repository         = "%s"
 				branch             = "%s"
 				space_id           = "root"
-				administrative     = false
 				bitbucket_cloud {
 					namespace = "%s"
 				}
@@ -54,7 +53,6 @@ func TestVCSIntegrationBitbucketCloud(t *testing.T) {
 				repository         = "%s"
 				branch             = "%s"
 				space_id           = "%s"
-				administrative     = false
 				bitbucket_cloud {
 					namespace = "%s"
 					id = "%s"

--- a/spacelift/resource_stack_bitbucket_datacenter_test.go
+++ b/spacelift/resource_stack_bitbucket_datacenter_test.go
@@ -23,7 +23,6 @@ func TestVCSIntegrationBitbucketDatacenter(t *testing.T) {
 				repository         = "%s"
 				branch             = "%s"
 				space_id           = "root"
-				administrative     = false
 				bitbucket_datacenter {
 					namespace = "%s"
 				}
@@ -54,7 +53,6 @@ func TestVCSIntegrationBitbucketDatacenter(t *testing.T) {
 				repository         = "%s"
 				branch             = "%s"
 				space_id           = "%s"
-				administrative     = false
 				bitbucket_datacenter {
 					namespace = "%s"
 					id = "%s"

--- a/spacelift/resource_stack_github_enterprise_test.go
+++ b/spacelift/resource_stack_github_enterprise_test.go
@@ -23,7 +23,6 @@ func TestVCSIntegrationGithubEnterprise(t *testing.T) {
 				repository         = "%s"
 				branch             = "%s"
 				space_id           = "root"
-				administrative     = false
 				github_enterprise {
 					namespace = "%s"
 				}
@@ -54,7 +53,6 @@ func TestVCSIntegrationGithubEnterprise(t *testing.T) {
 				repository         = "%s"
 				branch             = "%s"
 				space_id           = "%s"
-				administrative     = false
 				github_enterprise {
 					namespace = "%s"
 					id = "%s"

--- a/spacelift/resource_stack_gitlab_test.go
+++ b/spacelift/resource_stack_gitlab_test.go
@@ -23,7 +23,6 @@ func TestVCSIntegrationGitlab(t *testing.T) {
 				repository         = "%s"
 				branch             = "%s"
 				space_id           = "root"
-				administrative     = false
 				gitlab {
 					namespace = "%s"
 				}
@@ -54,7 +53,6 @@ func TestVCSIntegrationGitlab(t *testing.T) {
 				repository         = "%s"
 				branch             = "%s"
 				space_id           = "%s"
-				administrative     = false
 				gitlab {
 					namespace = "%s"
 					id = "%s"

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -20,7 +20,6 @@ func TestStackResource(t *testing.T) {
 		config := func(description string, protectFromDeletion, enableWellKnownSecretMasking bool) string {
 			return fmt.Sprintf(`
 				resource "spacelift_stack" "test" {
-					administrative           = true
 					after_apply              = ["ls -la", "rm -rf /"]
 					after_destroy            = ["echo 'after_destroy'"]
 					after_init               = ["terraform fmt -check", "tflint"]
@@ -72,7 +71,6 @@ func TestStackResource(t *testing.T) {
 					Attribute("after_plan.0", Equals("echo 'after_plan'")),
 					Attribute("after_run.#", Equals("1")),
 					Attribute("after_run.0", Equals("echo 'after_run'")),
-					Attribute("administrative", Equals("true")),
 					Attribute("autodeploy", Equals("true")),
 					Attribute("autoretry", Equals("false")),
 					Attribute("before_apply.#", Equals("2")),
@@ -126,7 +124,6 @@ func TestStackResource(t *testing.T) {
 		config := func(description string) string {
 			return fmt.Sprintf(`
 				resource "spacelift_stack" "test" {
-					administrative       = true
 					after_apply          = ["ls -la", "rm -rf /"]
 					after_destroy        = ["echo 'after_destroy'"]
 					after_init           = ["terraform fmt -check", "tflint"]
@@ -164,7 +161,6 @@ func TestStackResource(t *testing.T) {
 				Check: Resource(
 					resourceName,
 					Attribute("id", StartsWith("custom-slug-")),
-					Attribute("administrative", Equals("true")),
 					Attribute("after_apply.#", Equals("2")),
 					Attribute("after_apply.0", Equals("ls -la")),
 					Attribute("after_apply.1", Equals("rm -rf /")),
@@ -221,7 +217,6 @@ func TestStackResource(t *testing.T) {
 
 		before := fmt.Sprintf(`
 			resource "spacelift_stack" "test" {
-				administrative               = true
 				after_apply                  = ["ls -la", "rm -rf /"]
 				after_destroy                = ["echo 'after_destroy'"]
 				after_init                   = ["terraform fmt -check", "tflint"]
@@ -259,7 +254,6 @@ func TestStackResource(t *testing.T) {
 				Config: before,
 				Check: Resource(
 					resourceName,
-					Attribute("administrative", Equals("true")),
 					Attribute("after_apply.#", Equals("2")),
 					Attribute("after_destroy.#", Equals("1")),
 					Attribute("after_init.#", Equals("2")),
@@ -289,7 +283,6 @@ func TestStackResource(t *testing.T) {
 				Config: after,
 				Check: Resource(
 					resourceName,
-					Attribute("administrative", Equals("false")),
 					Attribute("after_apply.#", Equals("0")),
 					Attribute("after_destroy.#", Equals("0")),
 					Attribute("after_init.#", Equals("0")),
@@ -350,7 +343,6 @@ func TestStackResource(t *testing.T) {
 		testSteps(t, []resource.TestStep{{
 			Config: fmt.Sprintf(`
 			resource "spacelift_stack" "test" {
-				administrative               = true
 				branch                       = "master"
 				description                  = "bacon"
 				name                         = "Provider test stack %s"
@@ -373,7 +365,6 @@ func TestStackResource(t *testing.T) {
 						project_root                    = "root"
 						repository                      = "demo"
 						branch                          = "master"
-						administrative                  = false
 						manage_state                    = true
 					 }`,
 				Check: Resource(
@@ -387,7 +378,6 @@ func TestStackResource(t *testing.T) {
 						project_root                    = "root"
 						repository                      = "demo"
 						branch                          = "master"
-						administrative                  = false
 						manage_state                    = true
 						terraform_external_state_access = true
 					 }`,
@@ -402,7 +392,6 @@ func TestStackResource(t *testing.T) {
 						project_root                    = "root"
 						repository                      = "demo"
 						branch                          = "master"
-						administrative                  = false
 						manage_state                    = true
 						terraform_external_state_access = true
 					 }`,
@@ -417,7 +406,6 @@ func TestStackResource(t *testing.T) {
 						project_root                    = "root"
 						repository                      = "demo"
 						branch                          = "master"
-						administrative                  = false
 						manage_state                    = false
 						terraform_external_state_access = true
 					 }`,
@@ -696,7 +684,6 @@ func TestStackResource(t *testing.T) {
 		config := func(body string) string {
 			return `
 				resource "spacelift_stack" "test" {
-					administrative = true
 					branch = "master"
 					name = "` + name + `"
 					project_root = "root"
@@ -879,7 +866,6 @@ func TestStackResource(t *testing.T) {
 				Check: Resource(
 					resourceName,
 					Attribute("id", StartsWith("provider-test-stack")),
-					Attribute("administrative", Equals("true")),
 					Attribute("after_apply.#", Equals("2")),
 					Attribute("after_apply.0", Equals("ls -la")),
 					Attribute("after_apply.1", Equals("rm -rf /")),
@@ -924,7 +910,6 @@ func TestStackResource(t *testing.T) {
 				Check: Resource(
 					resourceName,
 					Attribute("id", StartsWith("provider-test-stack")),
-					Attribute("administrative", Equals("true")),
 					Attribute("after_apply.#", Equals("2")),
 					Attribute("after_apply.0", Equals("ls -la")),
 					Attribute("after_apply.1", Equals("rm -rf /")),
@@ -1079,7 +1064,6 @@ func TestStackResourceSpace(t *testing.T) {
 		config := func(description string, protectFromDeletion bool) string {
 			return fmt.Sprintf(`
 				resource "spacelift_stack" "test" {
-					administrative        = true
 					after_apply           = ["ls -la", "rm -rf /"]
 					after_destroy         = ["echo 'after_destroy'"]
 					after_init            = ["terraform fmt -check", "tflint"]
@@ -1126,7 +1110,6 @@ func TestStackResourceSpace(t *testing.T) {
 					Attribute("after_perform.0", Equals("echo 'after_perform'")),
 					Attribute("after_plan.#", Equals("1")),
 					Attribute("after_plan.0", Equals("echo 'after_plan'")),
-					Attribute("administrative", Equals("true")),
 					Attribute("autodeploy", Equals("true")),
 					Attribute("autoretry", Equals("false")),
 					Attribute("before_apply.#", Equals("2")),
@@ -1176,7 +1159,6 @@ func TestStackResourceSpace(t *testing.T) {
 		config := func(description string) string {
 			return fmt.Sprintf(`
 				resource "spacelift_stack" "test" {
-					administrative       = true
 					after_apply          = ["ls -la", "rm -rf /"]
 					after_destroy        = ["echo 'after_destroy'"]
 					after_init           = ["terraform fmt -check", "tflint"]
@@ -1215,7 +1197,6 @@ func TestStackResourceSpace(t *testing.T) {
 				Check: Resource(
 					resourceName,
 					Attribute("id", StartsWith("custom-slug-")),
-					Attribute("administrative", Equals("true")),
 					Attribute("after_apply.#", Equals("2")),
 					Attribute("after_apply.0", Equals("ls -la")),
 					Attribute("after_apply.1", Equals("rm -rf /")),
@@ -1272,7 +1253,6 @@ func TestStackResourceSpace(t *testing.T) {
 		testSteps(t, []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "spacelift_stack" "test" {
-					administrative      = true
 					after_apply         = ["ls -la", "rm -rf /"]
 					after_destroy       = ["echo 'after_destroy'"]
 					after_init          = ["terraform fmt -check", "tflint"]
@@ -1300,7 +1280,6 @@ func TestStackResourceSpace(t *testing.T) {
 				Check: Resource(
 					resourceName,
 					Attribute("id", StartsWith("provider-test-stack")),
-					Attribute("administrative", Equals("true")),
 					Attribute("after_apply.#", Equals("2")),
 					Attribute("after_apply.0", Equals("ls -la")),
 					Attribute("after_apply.1", Equals("rm -rf /")),
@@ -1350,7 +1329,6 @@ func TestStackResourceSpace(t *testing.T) {
 		testSteps(t, []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "spacelift_stack" "test" {
-					administrative = true
 					after_apply    = ["ls -la", "rm -rf /"]
 					after_destroy  = ["echo 'after_destroy'"]
 					after_init     = ["terraform fmt -check", "tflint"]
@@ -1379,7 +1357,6 @@ func TestStackResourceSpace(t *testing.T) {
 				Check: Resource(
 					resourceName,
 					Attribute("id", StartsWith("provider-test-stack")),
-					Attribute("administrative", Equals("true")),
 					Attribute("after_apply.#", Equals("2")),
 					Attribute("after_apply.0", Equals("ls -la")),
 					Attribute("after_apply.1", Equals("rm -rf /")),
@@ -1430,7 +1407,6 @@ func TestStackResourceSpace(t *testing.T) {
 		testSteps(t, []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "spacelift_stack" "test" {
-					administrative = true
 					after_apply    = ["ls -la", "rm -rf /"]
 					after_destroy  = ["echo 'after_destroy'"]
 					after_init     = ["terraform fmt -check", "tflint"]
@@ -1456,7 +1432,6 @@ func TestStackResourceSpace(t *testing.T) {
 				Check: Resource(
 					resourceName,
 					Attribute("id", StartsWith("provider-test-stack")),
-					Attribute("administrative", Equals("true")),
 					Attribute("after_apply.#", Equals("2")),
 					Attribute("after_apply.0", Equals("ls -la")),
 					Attribute("after_apply.1", Equals("rm -rf /")),
@@ -1506,7 +1481,6 @@ func TestStackResourceSpace(t *testing.T) {
 		testSteps(t, []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`resource "spacelift_stack" "test" {
-					administrative = true
 					after_apply    = ["ls -la", "rm -rf /"]
 					after_destroy  = ["echo 'after_destroy'"]
 					after_init     = ["terraform fmt -check", "tflint"]
@@ -1532,7 +1506,6 @@ func TestStackResourceSpace(t *testing.T) {
 				Check: Resource(
 					resourceName,
 					Attribute("id", StartsWith("provider-test-stack")),
-					Attribute("administrative", Equals("true")),
 					Attribute("after_apply.#", Equals("2")),
 					Attribute("after_apply.0", Equals("ls -la")),
 					Attribute("after_apply.1", Equals("rm -rf /")),
@@ -1579,7 +1552,6 @@ func TestStackResourceSpace(t *testing.T) {
 
 		before := fmt.Sprintf(`
 			resource "spacelift_stack" "test" {
-				administrative      = true
 				after_apply         = ["ls -la", "rm -rf /"]
 				after_destroy       = ["echo 'after_destroy'"]
 				after_init          = ["terraform fmt -check", "tflint"]
@@ -1616,7 +1588,6 @@ func TestStackResourceSpace(t *testing.T) {
 				Config: before,
 				Check: Resource(
 					resourceName,
-					Attribute("administrative", Equals("true")),
 					Attribute("after_apply.#", Equals("2")),
 					Attribute("after_destroy.#", Equals("1")),
 					Attribute("after_init.#", Equals("2")),
@@ -1645,7 +1616,6 @@ func TestStackResourceSpace(t *testing.T) {
 				Config: after,
 				Check: Resource(
 					resourceName,
-					Attribute("administrative", Equals("false")),
 					Attribute("after_apply.#", Equals("0")),
 					Attribute("after_destroy.#", Equals("0")),
 					Attribute("after_init.#", Equals("0")),
@@ -1952,7 +1922,6 @@ func getConfig(vendorConfig string) string {
 	randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 	return fmt.Sprintf(`
 				resource "spacelift_stack" "test" {
-					administrative = true
 					after_apply    = ["ls -la", "rm -rf /"]
 					after_destroy  = ["echo 'after_destroy'"]
 					after_init     = ["terraform fmt -check", "tflint"]

--- a/spacelift/resource_version_test.go
+++ b/spacelift/resource_version_test.go
@@ -21,7 +21,6 @@ func TestVersionResource(t *testing.T) {
 				Config: fmt.Sprintf(`
 				resource "spacelift_module" "test" {
 					name           = "test-version-module-%s"
-					administrative = true
 					branch         = "module"
 					repository     = "terraform-bacon-tasty"
 					labels         = ["version-test"]


### PR DESCRIPTION

## Description of the change

The administrative field on stacks and modules is deprecated in favor of `spacelift_role_attachment`. Stop exercising it in tests and stop advertising it in examples so nobody copies the deprecated pattern. Regenerated docs pick up the cleaned-up examples.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)
