### PR TITLE
docs(resource_stack): fix 'tracked a run' typo in allow_run_promotion description

### DIFF
--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -361,7 +361,7 @@ func resourceStack() *schema.Resource {
 			},
 			"allow_run_promotion": {
 				Type:          schema.TypeBool,
-				Description:   "Indicates whether a proposed run can be promoted to a tracked a run. Defaults to `true`.",
+				Description:   "Indicates whether a proposed run can be promoted to a tracked run. Defaults to `true`.",
 				Optional:      true,
 				Default:       true,
 				ConflictsWith: []string{"github_action_deploy"},


### PR DESCRIPTION
Fixes #783.

```diff
- Description: "Indicates whether a proposed run can be promoted to a tracked a run. Defaults to \`true\`.",
+ Description: "Indicates whether a proposed run can be promoted to a tracked run. Defaults to \`true\`.",
```

Single-word fix in the Terraform schema description for `allow_run_promotion`. Shows up in `terraform providers schema` output and generated docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a one-word documentation string change in the Terraform schema with no behavior or API changes.
> 
> **Overview**
> Fixes a typo in the `spacelift_stack` schema docs by updating the `allow_run_promotion` field description from “tracked a run” to “tracked run”, affecting provider schema output and generated documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e7b4c4bfec72ff741e1e8750ebc52c5444f0f67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->