### PR TITLE
Add more information to error message when space is not found

### DIFF
--- a/spacelift/data_space_by_path.go
+++ b/spacelift/data_space_by_path.go
@@ -151,7 +151,7 @@ func findSpaceByPath(spaces []*structs.Space, path, startingSpace string) (*stru
 			}
 		}
 		if !found {
-			return nil, fmt.Errorf("space does not exist")
+			return nil, fmt.Errorf("space does not exist in path %s", strings.Join(pathSplit[:i+1], "/"))
 		}
 	}
 


### PR DESCRIPTION
## Description of the change

> Description here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes an error string to add context; no behavior, data, or control-flow changes.
> 
> **Overview**
> When resolving a space via `spacelift_space_by_path`, the not-found error now includes the specific path prefix where traversal failed (eg. `space does not exist in path root/foo/bar`) instead of the generic `space does not exist` message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8093d42f5cc86123e0984635edfb68a35332d1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->