### PR TITLE
feat: add skip_replan_when_run_all to terragrunt config

### DIFF
--- a/docs/data-sources/stack.md
+++ b/docs/data-sources/stack.md
@@ -191,6 +191,7 @@ Read-Only:
 
 Read-Only:
 
+- `skip_replan_when_run_all` (Boolean)
 - `terraform_version` (String)
 - `terragrunt_version` (String)
 - `tool` (String)

--- a/docs/data-sources/stacks.md
+++ b/docs/data-sources/stacks.md
@@ -288,6 +288,7 @@ Read-Only:
 
 Read-Only:
 
+- `skip_replan_when_run_all` (Boolean)
 - `terraform_version` (String)
 - `terragrunt_version` (String)
 - `tool` (String)

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -398,6 +398,7 @@ Required:
 
 Optional:
 
+- `skip_replan_when_run_all` (Boolean) Whether to skip re-planning during apply by reusing the saved plan. Only applies when `use_run_all` is true. WARNING: any `mocked_outputs` referenced during planning will be applied as-is — do not enable together with `mocked_outputs` unless you understand the implications. Defaults to `false`.
 - `terraform_version` (String) The Terraform version. Must not be provided when tool is set to MANUALLY_PROVISIONED. Defaults to the latest available OpenTofu/Terraform version.
 - `terragrunt_version` (String) The Terragrunt version. Defaults to the latest Terragrunt version.
 - `tool` (String) The IaC tool used by Terragrunt. Valid values are OPEN_TOFU, TERRAFORM_FOSS or MANUALLY_PROVISIONED. Defaults to TERRAFORM_FOSS if not specified.

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -398,7 +398,7 @@ Required:
 
 Optional:
 
-- `skip_replan_when_run_all` (Boolean) Whether to skip re-planning during apply by reusing the saved plan. Only applies when `use_run_all` is true. WARNING: any `mocked_outputs` referenced during planning will be applied as-is — do not enable together with `mocked_outputs` unless you understand the implications. Defaults to `false`.
+- `skip_replan_when_run_all` (Boolean) When using Run All, skip the second planning phase during the apply stage. This is an experimental feature. Runs with Run All disabled reuse the plan by default. Warning: this means any `mocked_outputs` referenced during planning will be applied as-is — do not enable this together with `mocked_outputs` unless you fully understand the implications, your apply may execute against mocked values rather than real ones.
 - `terraform_version` (String) The Terraform version. Must not be provided when tool is set to MANUALLY_PROVISIONED. Defaults to the latest available OpenTofu/Terraform version.
 - `terragrunt_version` (String) The Terragrunt version. Defaults to the latest Terragrunt version.
 - `tool` (String) The IaC tool used by Terragrunt. Valid values are OPEN_TOFU, TERRAFORM_FOSS or MANUALLY_PROVISIONED. Defaults to TERRAFORM_FOSS if not specified.

--- a/spacelift/data_stack.go
+++ b/spacelift/data_stack.go
@@ -502,6 +502,11 @@ func dataStack() *schema.Resource {
 							Description: "Determines if Spacelift should manage state for this Terragrunt stack. Takes precedence over `manage_state`. Defaults to `false`.",
 							Computed:    true,
 						},
+						"skip_replan_when_run_all": {
+							Type:        schema.TypeBool,
+							Description: "Whether the apply phase reuses the saved plan instead of re-planning. Only applies when `use_run_all` is true.",
+							Computed:    true,
+						},
 						"tool": {
 							Type:        schema.TypeString,
 							Description: "The IaC tool used by Terragrunt. Will be either OPEN_TOFU, TERRAFORM_FOSS or MANUALLY_PROVISIONED.",

--- a/spacelift/data_stack.go
+++ b/spacelift/data_stack.go
@@ -504,7 +504,7 @@ func dataStack() *schema.Resource {
 						},
 						"skip_replan_when_run_all": {
 							Type:        schema.TypeBool,
-							Description: "Whether the apply phase reuses the saved plan instead of re-planning. Only applies when `use_run_all` is true.",
+							Description: "When using Run All, skip the second planning phase during the apply stage. This is an experimental feature. Runs with Run All disabled reuse the plan by default. Warning: this means any `mocked_outputs` referenced during planning will be applied as-is — do not enable this together with `mocked_outputs` unless you fully understand the implications, your apply may execute against mocked values rather than real ones.",
 							Computed:    true,
 						},
 						"tool": {

--- a/spacelift/internal/structs/stack.go
+++ b/spacelift/internal/structs/stack.go
@@ -101,6 +101,7 @@ type Stack struct {
 			UseRunAll            bool    `graphql:"useRunAll"`
 			UseSmartSanitization bool    `graphql:"useSmartSanitization"`
 			UseStateManagement   bool    `graphql:"useStateManagement"`
+			SkipReplanWhenRunAll bool    `graphql:"skipReplanWhenRunAll"`
 			Tool                 string  `graphql:"tool"`
 		} `graphql:"... on StackConfigVendorTerragrunt"`
 	} `graphql:"vendorConfig"`
@@ -149,12 +150,13 @@ func (s *Stack) IaCSettings() (string, map[string]any) {
 		}
 	case StackConfigVendorTerragrunt:
 		return "terragrunt", map[string]any{
-			"terraform_version":      s.VendorConfig.Terragrunt.TerraformVersion,
-			"terragrunt_version":     s.VendorConfig.Terragrunt.TerragruntVersion,
-			"use_run_all":            s.VendorConfig.Terragrunt.UseRunAll,
-			"use_smart_sanitization": s.VendorConfig.Terragrunt.UseSmartSanitization,
-			"use_state_management":   s.VendorConfig.Terragrunt.UseStateManagement,
-			"tool":                   s.VendorConfig.Terragrunt.Tool,
+			"terraform_version":        s.VendorConfig.Terragrunt.TerraformVersion,
+			"terragrunt_version":       s.VendorConfig.Terragrunt.TerragruntVersion,
+			"use_run_all":              s.VendorConfig.Terragrunt.UseRunAll,
+			"use_smart_sanitization":   s.VendorConfig.Terragrunt.UseSmartSanitization,
+			"use_state_management":     s.VendorConfig.Terragrunt.UseStateManagement,
+			"skip_replan_when_run_all": s.VendorConfig.Terragrunt.SkipReplanWhenRunAll,
+			"tool":                     s.VendorConfig.Terragrunt.Tool,
 		}
 	}
 
@@ -308,12 +310,13 @@ func PopulateStack(d *schema.ResourceData, stack *Stack) error {
 		d.Set("pulumi", []any{m})
 	case StackConfigVendorTerragrunt:
 		m := map[string]any{
-			"terraform_version":      stack.VendorConfig.Terragrunt.TerraformVersion,
-			"terragrunt_version":     stack.VendorConfig.Terragrunt.TerragruntVersion,
-			"use_run_all":            stack.VendorConfig.Terragrunt.UseRunAll,
-			"use_smart_sanitization": stack.VendorConfig.Terragrunt.UseSmartSanitization,
-			"use_state_management":   stack.VendorConfig.Terragrunt.UseStateManagement,
-			"tool":                   stack.VendorConfig.Terragrunt.Tool,
+			"terraform_version":        stack.VendorConfig.Terragrunt.TerraformVersion,
+			"terragrunt_version":       stack.VendorConfig.Terragrunt.TerragruntVersion,
+			"use_run_all":              stack.VendorConfig.Terragrunt.UseRunAll,
+			"use_smart_sanitization":   stack.VendorConfig.Terragrunt.UseSmartSanitization,
+			"use_state_management":     stack.VendorConfig.Terragrunt.UseStateManagement,
+			"skip_replan_when_run_all": stack.VendorConfig.Terragrunt.SkipReplanWhenRunAll,
+			"tool":                     stack.VendorConfig.Terragrunt.Tool,
 		}
 
 		d.Set("terragrunt", []any{m})

--- a/spacelift/internal/structs/stack_input.go
+++ b/spacelift/internal/structs/stack_input.go
@@ -83,6 +83,7 @@ type TerragruntInput struct {
 	UseRunAll            graphql.Boolean  `json:"useRunAll"`
 	UseSmartSanitization graphql.Boolean  `json:"useSmartSanitization"`
 	UseStateManagement   *graphql.Boolean `json:"useStateManagement"`
+	SkipReplanWhenRunAll *graphql.Boolean `json:"skipReplanWhenRunAll"`
 	Tool                 *graphql.String  `json:"tool"`
 }
 

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -687,6 +687,12 @@ func resourceStack() *schema.Resource {
 							Default:     false,
 							ForceNew:    true,
 						},
+						"skip_replan_when_run_all": {
+							Type:        schema.TypeBool,
+							Description: "Whether to skip re-planning during apply by reusing the saved plan. Only applies when `use_run_all` is true. WARNING: any `mocked_outputs` referenced during planning will be applied as-is — do not enable together with `mocked_outputs` unless you understand the implications. Defaults to `false`.",
+							Optional:    true,
+							Default:     false,
+						},
 						"tool": {
 							Type:        schema.TypeString,
 							Description: "The IaC tool used by Terragrunt. Valid values are OPEN_TOFU, TERRAFORM_FOSS or MANUALLY_PROVISIONED. Defaults to TERRAFORM_FOSS if not specified.",
@@ -1071,6 +1077,10 @@ func getVendorConfig(d *schema.ResourceData) *structs.VendorConfigInput {
 
 		if useStateManagement, ok := terragrunt[0].(map[string]any)["use_state_management"]; ok {
 			terragruntConfig.UseStateManagement = toOptionalBool(useStateManagement)
+		}
+
+		if skipReplanWhenRunAll, ok := terragrunt[0].(map[string]any)["skip_replan_when_run_all"]; ok {
+			terragruntConfig.SkipReplanWhenRunAll = toOptionalBool(skipReplanWhenRunAll)
 		}
 
 		if shouldWeReComputeTerraformVersionForTerragrunt(d) {

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -689,7 +689,7 @@ func resourceStack() *schema.Resource {
 						},
 						"skip_replan_when_run_all": {
 							Type:        schema.TypeBool,
-							Description: "Whether to skip re-planning during apply by reusing the saved plan. Only applies when `use_run_all` is true. WARNING: any `mocked_outputs` referenced during planning will be applied as-is — do not enable together with `mocked_outputs` unless you understand the implications. Defaults to `false`.",
+							Description: "When using Run All, skip the second planning phase during the apply stage. This is an experimental feature. Runs with Run All disabled reuse the plan by default. Warning: this means any `mocked_outputs` referenced during planning will be applied as-is — do not enable this together with `mocked_outputs` unless you fully understand the implications, your apply may execute against mocked values rather than real ones.",
 							Optional:    true,
 							Default:     false,
 						},

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -859,6 +859,53 @@ func TestStackResource(t *testing.T) {
 		})
 	})
 
+	t.Run("with Terragrunt skip_replan_when_run_all", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch       = "master"
+					name         = "Provider test stack terragrunt skip replan %s"
+					project_root = "root"
+					repository   = "demo"
+					terragrunt {
+						terragrunt_version       = "0.45.0"
+						terraform_version        = "1.4.0"
+						use_run_all              = true
+						skip_replan_when_run_all = false
+					}
+				}
+			`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("terragrunt.0.skip_replan_when_run_all", Equals("false")),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch       = "master"
+					name         = "Provider test stack terragrunt skip replan %s"
+					project_root = "root"
+					repository   = "demo"
+					terragrunt {
+						terragrunt_version       = "0.45.0"
+						terraform_version        = "1.4.0"
+						use_run_all              = true
+						skip_replan_when_run_all = true
+					}
+				}
+			`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("terragrunt.0.skip_replan_when_run_all", Equals("true")),
+				),
+			},
+		})
+	})
+
 	t.Run("with GitHub and no vendor-specific configuration", func(t *testing.T) {
 		testSteps(t, []resource.TestStep{
 			{


### PR DESCRIPTION
## Summary
- Add `skip_replan_when_run_all` to the `spacelift_stack` resource and data source under the `terragrunt` block, wiring it through to the backend's `skipReplanWhenRunAll` field on `TerragruntInput` / `StackConfigVendorTerragrunt`.
- When enabled together with `use_run_all`, the apply phase reuses the saved plan instead of re-planning. Defaults to `false`.

## Test plan
- [ ] `go build ./...` passes
- [ ] `cd tools && go generate ./...` regenerated docs include the new field
- [ ] Acceptance test `TestStackResource/with_Terragrunt_skip_replan_when_run_all` passes against a backend that supports the field
- [ ] Roundtrip: create stack with `skip_replan_when_run_all = true`, read it back, flip to `false`, confirm plan reflects the change