### PR TITLE
chore: officially drop support for terraform < 1.x

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,9 @@ archives:
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
 
 signs:
   - artifacts: checksum
@@ -38,3 +41,6 @@ changelog:
 
 release:
   draft: false
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ You can browse the documentation on the following registries:
 
 ## Using the Provider
 
-### Terraform 0.13 and Above
+This provider requires **Terraform 1.0 or newer**.
+
+### From the Registry
 
 You can use the provider via the [Terraform provider registry](https://registry.terraform.io/providers/spacelift-io/spacelift/latest).
 
-### Terraform 0.12 or Manual Installation
+### Manual Installation
 
 You can download a pre-built binary from the [releases](https://github.com/spacelift-io/terraform-provider-spacelift/releases/) page, these are built using [goreleaser](https://goreleaser.com/) (the [configuration](.goreleaser.yml) is in the repo). You can verify the signature using [this key](https://keys.openpgp.org/vks/v1/by-fingerprint/175FD97AD2358EFE02832978E302FB5AA29D88F7).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,10 @@ description: |-
 
 The Spacelift Terraform provider is used to programmatically interact with its GraphQL API, allowing Spacelift to declaratively manage itself 🤯
 
+## Requirements
+
+- Terraform **1.0+**
+
 ## Running inside Spacelift
 
 When executed from inside a Spacelift run, this provider is designed to require no setup at all. All Spacelift jobs receive a temporary authentication token in the `SPACELIFT_API_TOKEN` environment variable, which is all the provider needs to run. 

--- a/templates/index.md
+++ b/templates/index.md
@@ -10,6 +10,10 @@ description: |-
 
 The Spacelift Terraform provider is used to programmatically interact with its GraphQL API, allowing Spacelift to declaratively manage itself 🤯
 
+## Requirements
+
+- Terraform **1.0+**
+
 ## Running inside Spacelift
 
 When executed from inside a Spacelift run, this provider is designed to require no setup at all. All Spacelift jobs receive a temporary authentication token in the `SPACELIFT_API_TOKEN` environment variable, which is all the provider needs to run. 

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "metadata": {
+    "protocol_versions": ["6.0"]
+  }
+}


### PR DESCRIPTION
## Description of the change

this pull request updates documentation and adds a manifest to indicate this provider can only be used with terraform >= 1.x

> note: the provider is verifiably broken for terraform < 1.x already, we're not changing this, just documenting it so users know they have to update terraform for using our provider

full context in [internal tracker](https://app.clickup.com/t/869crg2yh?comment=90120219361162)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (non-breaking change that adds documentation)

## Related issues

> closes CU-869crg2yh

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
