### PR TITLE
feat(resource_run): switch to run trigger API

### DIFF
--- a/docs/resources/run.md
+++ b/docs/resources/run.md
@@ -40,12 +40,43 @@ resource "spacelift_run" "this" {
 - `commit_sha` (String) The commit SHA for which to trigger a run.
 - `keepers` (Map of String) Arbitrary map of values that, when changed, will trigger recreation of the resource.
 - `proposed` (Boolean) Whether the run is a proposed run. Defaults to `false`.
+- `runtime_config` (Block List, Max: 1) Custom runtime configuration to apply to this run, overriding the stack's defaults. (see [below for nested schema](#nestedblock--runtime_config))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `wait` (Block List, Max: 1) Wait for the run to finish (see [below for nested schema](#nestedblock--wait))
 
 ### Read-Only
 
 - `id` (String) The ID of the triggered run.
+
+<a id="nestedblock--runtime_config"></a>
+### Nested Schema for `runtime_config`
+
+Optional:
+
+- `after_apply` (List of String) List of after-apply scripts
+- `after_destroy` (List of String) List of after-destroy scripts
+- `after_init` (List of String) List of after-init scripts
+- `after_perform` (List of String) List of after-perform scripts
+- `after_plan` (List of String) List of after-plan scripts
+- `after_run` (List of String) List of after-run scripts
+- `before_apply` (List of String) List of before-apply scripts
+- `before_destroy` (List of String) List of before-destroy scripts
+- `before_init` (List of String) List of before-init scripts
+- `before_perform` (List of String) List of before-perform scripts
+- `before_plan` (List of String) List of before-plan scripts
+- `environment` (Block Set) Environment variables for the run (see [below for nested schema](#nestedblock--runtime_config--environment))
+- `project_root` (String) Project root is the optional directory relative to the workspace root containing the entrypoint to the Stack.
+- `runner_image` (String) Name of the Docker image used to process Runs
+
+<a id="nestedblock--runtime_config--environment"></a>
+### Nested Schema for `runtime_config.environment`
+
+Required:
+
+- `key` (String) Environment variable key
+- `value` (String) Environment variable value
+
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/spacelift/internal/structs/run.go
+++ b/spacelift/internal/structs/run.go
@@ -1,5 +1,12 @@
 package structs
 
+type RunType string
+
+const (
+	RunTypeTracked  RunType = "TRACKED"
+	RunTypeProposed RunType = "PROPOSED"
+)
+
 type Run struct {
 	ID string `graphql:"id"`
 }

--- a/spacelift/resource_run.go
+++ b/spacelift/resource_run.go
@@ -106,28 +106,25 @@ func resourceRun() *schema.Resource {
 
 func resourceRunCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var mutation struct {
-		ID string `graphql:"runTrigger(stack: $stack, commitSha: $sha, runType: $runType, runtimeConfig: $runtimeConfig)"`
+		CreateRun structs.Run `graphql:"runTrigger(stack: $stack, commitSha: $sha, runType: $runType, runtimeConfig: $runtimeConfig)"`
 	}
 
 	stackID := d.Get("stack_id").(string)
 
+	runType := structs.RunTypeTracked
+	if d.Get("proposed").(bool) {
+		runType = structs.RunTypeProposed
+	}
+
 	variables := map[string]any{
 		"stack":         toID(stackID),
 		"sha":           (*graphql.String)(nil),
-		"run_type":      (*graphql.String)(nil),
+		"runType":       runType,
 		"runtimeConfig": (*structs.RuntimeConfigInput)(nil),
 	}
 
 	if sha, ok := d.GetOk("commit_sha"); ok {
 		variables["sha"] = new(graphql.String(sha.(string)))
-	}
-
-	if proposed, ok := d.GetOk("proposed"); ok {
-		if proposed.(bool) {
-			variables["run_type"] = "PROPOSED"
-		} else {
-			variables["run_type"] = "TRACKED"
-		}
 	}
 
 	if runtimeConfig := parseRuntimeConfigInput(d, "runtime_config"); runtimeConfig != nil {
@@ -141,11 +138,11 @@ func resourceRunCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 
 	if waitRaw, ok := d.GetOk("wait"); ok {
 		wait := structs.NewWaitConfiguration(waitRaw.([]any))
-		if diag := wait.Wait(ctx, d, client, stackID, mutation.ID); len(diag) > 0 {
+		if diag := wait.Wait(ctx, d, client, stackID, mutation.CreateRun.ID); len(diag) > 0 {
 			return diag
 		}
 	}
 
-	d.SetId(mutation.ID)
+	d.SetId(mutation.CreateRun.ID)
 	return nil
 }

--- a/spacelift/resource_run.go
+++ b/spacelift/resource_run.go
@@ -92,21 +92,30 @@ func resourceRun() *schema.Resource {
 					},
 				},
 			},
+			"runtime_config": {
+				Type:        schema.TypeList,
+				Description: "Custom runtime configuration to apply to this run, overriding the stack's defaults.",
+				Optional:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Elem:        &schema.Resource{Schema: runtimeConfigInputSchema(true)},
+			},
 		},
 	}
 }
 
 func resourceRunCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var mutation struct {
-		ID string `graphql:"runResourceCreate(stack: $stack, commitSha: $sha, proposed: $proposed)"`
+		ID string `graphql:"runTrigger(stack: $stack, commitSha: $sha, runType: $runType, runtimeConfig: $runtimeConfig)"`
 	}
 
 	stackID := d.Get("stack_id").(string)
 
 	variables := map[string]any{
-		"stack":    toID(stackID),
-		"sha":      (*graphql.String)(nil),
-		"proposed": (*graphql.Boolean)(nil),
+		"stack":         toID(stackID),
+		"sha":           (*graphql.String)(nil),
+		"run_type":      (*graphql.String)(nil),
+		"runtimeConfig": (*structs.RuntimeConfigInput)(nil),
 	}
 
 	if sha, ok := d.GetOk("commit_sha"); ok {
@@ -114,11 +123,19 @@ func resourceRunCreate(ctx context.Context, d *schema.ResourceData, meta any) di
 	}
 
 	if proposed, ok := d.GetOk("proposed"); ok {
-		variables["proposed"] = new(graphql.Boolean(proposed.(bool)))
+		if proposed.(bool) {
+			variables["run_type"] = "PROPOSED"
+		} else {
+			variables["run_type"] = "TRACKED"
+		}
+	}
+
+	if runtimeConfig := parseRuntimeConfigInput(d, "runtime_config"); runtimeConfig != nil {
+		variables["runtimeConfig"] = runtimeConfig
 	}
 
 	client := meta.(*internal.Client)
-	if err := client.Mutate(ctx, "ResourceRunCreate", &mutation, variables); err != nil {
+	if err := client.Mutate(ctx, "RunTrigger", &mutation, variables); err != nil {
 		return diag.Errorf("could not trigger run for stack %s: %v", stackID, internal.FromSpaceliftError(err))
 	}
 

--- a/spacelift/resource_scheduled_run.go
+++ b/spacelift/resource_scheduled_run.go
@@ -79,137 +79,7 @@ func resourceScheduledRun() *schema.Resource {
 				Description: "Customer provided runtime configuration for this scheduled run.",
 				Optional:    true,
 				MaxItems:    1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"project_root": {
-							Type:        schema.TypeString,
-							Description: "Project root is the optional directory relative to the workspace root containing the entrypoint to the Stack.",
-							Optional:    true,
-						},
-						"runner_image": {
-							Type:        schema.TypeString,
-							Description: "Name of the Docker image used to process Runs",
-							Optional:    true,
-						},
-						"terraform_version": {
-							Type:        schema.TypeString,
-							Description: "Terraform version to use",
-							Computed:    true,
-						},
-						"terraform_workflow_tool": {
-							Type:        schema.TypeString,
-							Description: "Defines the tool that will be used to execute the workflow. This can be one of `OPEN_TOFU`, `TERRAFORM_FOSS` or `CUSTOM`. Defaults to `TERRAFORM_FOSS`.",
-							Computed:    true,
-						},
-						"environment": {
-							Type:        schema.TypeSet,
-							Description: "Environment variables for the run",
-							Optional:    true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"key": {
-										Type:        schema.TypeString,
-										Description: "Environment variable key",
-										Required:    true,
-									},
-									"value": {
-										Type:        schema.TypeString,
-										Description: "Environment variable value",
-										Required:    true,
-									},
-								},
-							},
-						},
-						"after_apply": {
-							Type:        schema.TypeList,
-							Description: "List of after-apply scripts",
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Optional: true,
-						},
-						"after_destroy": {
-							Type:        schema.TypeList,
-							Description: "List of after-destroy scripts",
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Optional: true,
-						},
-						"after_init": {
-							Type:        schema.TypeList,
-							Description: "List of after-init scripts",
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Optional: true,
-						},
-						"after_perform": {
-							Type:        schema.TypeList,
-							Description: "List of after-perform scripts",
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Optional: true,
-						},
-						"after_plan": {
-							Type:        schema.TypeList,
-							Description: "List of after-plan scripts",
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Optional: true,
-						},
-						"after_run": {
-							Type:        schema.TypeList,
-							Description: "List of after-run scripts",
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Optional: true,
-						},
-						"before_apply": {
-							Type:        schema.TypeList,
-							Description: "List of before-apply scripts",
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Optional: true,
-						},
-						"before_destroy": {
-							Type:        schema.TypeList,
-							Description: "List of before-destroy scripts",
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Optional: true,
-						},
-						"before_init": {
-							Type:        schema.TypeList,
-							Description: "List of before-init scripts",
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Optional: true,
-						},
-						"before_perform": {
-							Type:        schema.TypeList,
-							Description: "List of before-perform scripts",
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Optional: true,
-						},
-						"before_plan": {
-							Type:        schema.TypeList,
-							Description: "List of before-plan scripts",
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-							Optional: true,
-						},
-					},
-				},
+				Elem:        &schema.Resource{Schema: scheduledRunRuntimeConfigSchema()},
 			},
 		},
 	}
@@ -352,48 +222,33 @@ func resourceScheduledRunDelete(ctx context.Context, d *schema.ResourceData, met
 	return nil
 }
 
+// scheduledRunRuntimeConfigSchema returns the runtime_config schema for the
+// spacelift_scheduled_run resource: the shared input fields plus the
+// read-only terraform_version and terraform_workflow_tool fields populated
+// from the server.
+func scheduledRunRuntimeConfigSchema() map[string]*schema.Schema {
+	s := runtimeConfigInputSchema(false)
+	s["terraform_version"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "Terraform version to use",
+		Computed:    true,
+	}
+	s["terraform_workflow_tool"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "Defines the tool that will be used to execute the workflow. This can be one of `OPEN_TOFU`, `TERRAFORM_FOSS` or `CUSTOM`. Defaults to `TERRAFORM_FOSS`.",
+		Computed:    true,
+	}
+	return s
+}
+
 func parseScheduledRunInput(d *schema.ResourceData) (*structs.ScheduledRunInput, error) {
-	cfg := &structs.ScheduledRunInput{}
+	cfg := &structs.ScheduledRunInput{
+		RuntimeConfig: parseRuntimeConfigInput(d, "runtime_config"),
+	}
 
 	name, ok := d.GetOk("name")
 	if ok && name != nil {
 		cfg.Name = toString(name)
-	}
-
-	runtimeConfig, ok := d.Get("runtime_config").([]any)
-	if ok && len(runtimeConfig) > 0 {
-		mapped := runtimeConfig[0].(map[string]any)
-
-		environment := []structs.EnvVarInput{}
-		for _, e := range mapped["environment"].(*schema.Set).List() {
-			envMap := e.(map[string]any)
-			environment = append(environment, structs.EnvVarInput{
-				Key:   toString(envMap["key"]),
-				Value: toString(envMap["value"]),
-			})
-		}
-
-		cfg.RuntimeConfig = &structs.RuntimeConfigInput{
-			AfterApply:    listToOptionalStringList(mapped["after_apply"]),
-			AfterDestroy:  listToOptionalStringList(mapped["after_destroy"]),
-			AfterInit:     listToOptionalStringList(mapped["after_init"]),
-			AfterPerform:  listToOptionalStringList(mapped["after_perform"]),
-			AfterPlan:     listToOptionalStringList(mapped["after_plan"]),
-			AfterRun:      listToOptionalStringList(mapped["after_run"]),
-			BeforeApply:   listToOptionalStringList(mapped["before_apply"]),
-			BeforeDestroy: listToOptionalStringList(mapped["before_destroy"]),
-			BeforeInit:    listToOptionalStringList(mapped["before_init"]),
-			BeforePerform: listToOptionalStringList(mapped["before_perform"]),
-			BeforePlan:    listToOptionalStringList(mapped["before_plan"]),
-			Environment:   &environment,
-		}
-
-		if projectRoot := mapped["project_root"]; len(projectRoot.(string)) > 0 {
-			cfg.RuntimeConfig.ProjectRoot = toOptionalString(projectRoot)
-		}
-		if runnerImage := mapped["runner_image"]; len(runnerImage.(string)) > 0 {
-			cfg.RuntimeConfig.RunnerImage = toOptionalString(runnerImage)
-		}
 	}
 
 	every, everyOk := d.GetOk("every")

--- a/spacelift/runtime_config.go
+++ b/spacelift/runtime_config.go
@@ -1,0 +1,116 @@
+package spacelift
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
+)
+
+// runtimeConfigInputSchema returns the nested-block schema for the user-
+// configurable fields of a runtime_config. When forceNew is true (e.g., for
+// immutable resources like spacelift_run), every field is marked ForceNew.
+func runtimeConfigInputSchema(forceNew bool) map[string]*schema.Schema {
+	stringList := func(description string) *schema.Schema {
+		return &schema.Schema{
+			Type:        schema.TypeList,
+			Description: description,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Optional:    true,
+			ForceNew:    forceNew,
+		}
+	}
+
+	return map[string]*schema.Schema{
+		"project_root": {
+			Type:        schema.TypeString,
+			Description: "Project root is the optional directory relative to the workspace root containing the entrypoint to the Stack.",
+			Optional:    true,
+			ForceNew:    forceNew,
+		},
+		"runner_image": {
+			Type:        schema.TypeString,
+			Description: "Name of the Docker image used to process Runs",
+			Optional:    true,
+			ForceNew:    forceNew,
+		},
+		"environment": {
+			Type:        schema.TypeSet,
+			Description: "Environment variables for the run",
+			Optional:    true,
+			ForceNew:    forceNew,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"key": {
+						Type:        schema.TypeString,
+						Description: "Environment variable key",
+						Required:    true,
+					},
+					"value": {
+						Type:        schema.TypeString,
+						Description: "Environment variable value",
+						Required:    true,
+					},
+				},
+			},
+		},
+		"after_apply":    stringList("List of after-apply scripts"),
+		"after_destroy":  stringList("List of after-destroy scripts"),
+		"after_init":     stringList("List of after-init scripts"),
+		"after_perform":  stringList("List of after-perform scripts"),
+		"after_plan":     stringList("List of after-plan scripts"),
+		"after_run":      stringList("List of after-run scripts"),
+		"before_apply":   stringList("List of before-apply scripts"),
+		"before_destroy": stringList("List of before-destroy scripts"),
+		"before_init":    stringList("List of before-init scripts"),
+		"before_perform": stringList("List of before-perform scripts"),
+		"before_plan":    stringList("List of before-plan scripts"),
+	}
+}
+
+// parseRuntimeConfigInput reads the runtime_config nested block from the
+// given ResourceData and returns the corresponding GraphQL input, or nil if
+// the block is not set.
+func parseRuntimeConfigInput(d *schema.ResourceData, key string) *structs.RuntimeConfigInput {
+	raw, ok := d.Get(key).([]any)
+	if !ok || len(raw) == 0 || raw[0] == nil {
+		return nil
+	}
+
+	mapped := raw[0].(map[string]any)
+
+	cfg := &structs.RuntimeConfigInput{
+		AfterApply:    listToOptionalStringList(mapped["after_apply"]),
+		AfterDestroy:  listToOptionalStringList(mapped["after_destroy"]),
+		AfterInit:     listToOptionalStringList(mapped["after_init"]),
+		AfterPerform:  listToOptionalStringList(mapped["after_perform"]),
+		AfterPlan:     listToOptionalStringList(mapped["after_plan"]),
+		AfterRun:      listToOptionalStringList(mapped["after_run"]),
+		BeforeApply:   listToOptionalStringList(mapped["before_apply"]),
+		BeforeDestroy: listToOptionalStringList(mapped["before_destroy"]),
+		BeforeInit:    listToOptionalStringList(mapped["before_init"]),
+		BeforePerform: listToOptionalStringList(mapped["before_perform"]),
+		BeforePlan:    listToOptionalStringList(mapped["before_plan"]),
+	}
+
+	if envSet, ok := mapped["environment"].(*schema.Set); ok && envSet.Len() > 0 {
+		environment := make([]structs.EnvVarInput, 0, envSet.Len())
+		for _, e := range envSet.List() {
+			envMap := e.(map[string]any)
+			environment = append(environment, structs.EnvVarInput{
+				Key:   toString(envMap["key"]),
+				Value: toString(envMap["value"]),
+			})
+		}
+		cfg.Environment = &environment
+	}
+
+	if projectRoot, ok := mapped["project_root"].(string); ok && projectRoot != "" {
+		cfg.ProjectRoot = toOptionalString(projectRoot)
+	}
+
+	if runnerImage, ok := mapped["runner_image"].(string); ok && runnerImage != "" {
+		cfg.RunnerImage = toOptionalString(runnerImage)
+	}
+
+	return cfg
+}


### PR DESCRIPTION
## Description of the change

Swap API from run resource create to run trigger.

Adds a `runtime_config` nested block to `spacelift_run` so users can override the stack's runtime configuration when triggering a run (runner image, project root, environment variables, before/after hook scripts). The underlying `runTrigger` GraphQL mutation already accepts a `runtimeConfig` input; this wires it through the provider.

All `runtime_config` fields on `spacelift_run` are marked `ForceNew` because the resource is immutable; changing the config should trigger a new run rather than silently no-op.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer