### PR TITLE
feat: support vendor migration between Terraform and Terragrunt stacks

### DIFF
--- a/spacelift/internal/rate_limiting_round_tripper.go
+++ b/spacelift/internal/rate_limiting_round_tripper.go
@@ -27,5 +27,5 @@ func (r *rateLimitingRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 		return nil, errors.Wrap(err, "could not get request token from limiter")
 	}
 
-	return r.client.Do(req)
+	return r.client.Do(req) //nolint:gosec // G704: req is constructed internally, not from user input
 }

--- a/spacelift/internal/structs/stack_input.go
+++ b/spacelift/internal/structs/stack_input.go
@@ -96,3 +96,22 @@ type TerraformInput struct {
 	Workspace                  *graphql.String  `json:"workspace"`
 	ExternalStateAccessEnabled *graphql.Boolean `json:"externalStateAccessEnabled"`
 }
+
+// StackVendor represents the vendor type for stack migration.
+type StackVendor string
+
+const (
+	StackVendorTerragrunt StackVendor = "Terragrunt"
+	StackVendorTerraform  StackVendor = "Terraform"
+)
+
+// TerragruntMigrationInput represents Terragrunt-specific migration configuration.
+type TerragruntMigrationInput struct {
+	TerragruntVersion *graphql.String `json:"terragruntVersion"`
+}
+
+// StackVendorMigrationInput represents the input for vendor migration.
+type StackVendorMigrationInput struct {
+	Labels     *[]graphql.String         `json:"labels"`
+	Terragrunt *TerragruntMigrationInput `json:"terragrunt"`
+}

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -822,6 +822,25 @@ func resourceStackRead(ctx context.Context, d *schema.ResourceData, meta any) di
 }
 
 func resourceStackUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	var ret diag.Diagnostics
+
+	// Check if vendor migration is needed (terraform <-> terragrunt).
+	if targetVendor := vendorMigrationDirection(d); targetVendor != "" {
+		var migrateMutation struct {
+			MigrateVendor structs.Stack `graphql:"stackMigrateVendor(id: $id, targetVendor: $targetVendor, config: $config)"`
+		}
+
+		migrateVariables := map[string]any{
+			"id":           toID(d.Id()),
+			"targetVendor": targetVendor,
+			"config":       buildMigrationConfig(d, targetVendor),
+		}
+
+		if err := meta.(*internal.Client).Mutate(ctx, "StackMigrateVendor", &migrateMutation, migrateVariables); err != nil {
+			return diag.Errorf("could not migrate stack vendor: %v", internal.FromSpaceliftError(err))
+		}
+	}
+
 	var mutation struct {
 		UpdateStack structs.Stack `graphql:"stackUpdate(id: $id, input: $input)"`
 	}
@@ -830,8 +849,6 @@ func resourceStackUpdate(ctx context.Context, d *schema.ResourceData, meta any) 
 		"id":    toID(d.Id()),
 		"input": stackInput(d),
 	}
-
-	var ret diag.Diagnostics
 
 	if err := meta.(*internal.Client).Mutate(ctx, "StackUpdate", &mutation, variables); err != nil {
 		ret = diag.Errorf("could not update stack: %v", internal.FromSpaceliftError(err))
@@ -1168,6 +1185,51 @@ func shouldWeReComputeTerraformVersionForTerraformWorkflowTool(d *schema.Resourc
 	}
 
 	return false
+}
+
+// vendorMigrationDirection detects if the vendor type is changing between
+// terraform and terragrunt, and returns the target vendor. Returns empty
+// string if no migration is happening.
+func vendorMigrationDirection(d *schema.ResourceData) structs.StackVendor {
+	oldTerragrunt, _ := d.GetChange("terragrunt")
+	oldTgList, _ := oldTerragrunt.([]any)
+	wasTerragrunt := len(oldTgList) > 0
+
+	newVendorConfig := getVendorConfig(d)
+	isTerragrunt := newVendorConfig.TerragruntInput != nil
+
+	if !wasTerragrunt && isTerragrunt {
+		return structs.StackVendorTerragrunt
+	}
+
+	if wasTerragrunt && !isTerragrunt {
+		return structs.StackVendorTerraform
+	}
+
+	return ""
+}
+
+// buildMigrationConfig builds the StackVendorMigrationInput for the given
+// migration direction.
+func buildMigrationConfig(d *schema.ResourceData, targetVendor structs.StackVendor) *structs.StackVendorMigrationInput {
+	config := &structs.StackVendorMigrationInput{}
+
+	switch targetVendor {
+	case structs.StackVendorTerragrunt:
+		if terragrunt, ok := d.Get("terragrunt").([]any); ok && len(terragrunt) > 0 {
+			settings := terragrunt[0].(map[string]any)
+			if version, ok := settings["terragrunt_version"]; ok && version.(string) != "" {
+				config.Terragrunt = &structs.TerragruntMigrationInput{
+					TerragruntVersion: toOptionalString(version),
+				}
+			}
+		}
+	case structs.StackVendorTerraform:
+		labels := []graphql.String{graphql.String("terragrunt")}
+		config.Labels = &labels
+	}
+
+	return config
 }
 
 func getStrings(d *schema.ResourceData, fieldName string) []graphql.String {

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	. "github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/testhelpers"
 )
@@ -2021,6 +2022,90 @@ func TestStackResourceSpace(t *testing.T) {
 				Check: Resource(
 					"spacelift_stack.state_import",
 					Attribute("import_state", Equals("")),
+				),
+			},
+		})
+	})
+
+	t.Run("vendor migration roundtrip Terraform to Terragrunt and back", func(t *testing.T) {
+		name := "vendor-migration-roundtrip-" + acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		config := func(vendorConfig string) string {
+			return fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch         = "master"
+					name           = "%s"
+					project_root   = "root"
+					repository     = "demo"
+					manage_state   = false
+					%s
+				}
+			`, name, vendorConfig)
+		}
+
+		var stackID string
+
+		testSteps(t, []resource.TestStep{
+			{
+				// Step 1: Create as Terraform stack with "terragrunt" label
+				Config: config(`
+					labels            = ["terragrunt"]
+					terraform_version = "1.5.7"
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					Resource(
+						resourceName,
+						Attribute("terraform_version", Equals("1.5.7")),
+						SetContains("labels", "terragrunt"),
+						Attribute("terragrunt.#", Equals("0")),
+					),
+					func(s *terraform.State) error {
+						stackID = s.RootModule().Resources[resourceName].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Step 2: Migrate to Terragrunt — must be update, not recreate
+				Config: config(`
+					terragrunt {
+						terragrunt_version = "0.67.16"
+						tool               = "TERRAFORM_FOSS"
+					}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					Resource(
+						resourceName,
+						Attribute("terragrunt.#", Equals("1")),
+						Attribute("terragrunt.0.terragrunt_version", Equals("0.67.16")),
+						Attribute("terragrunt.0.tool", Equals("TERRAFORM_FOSS")),
+					),
+					func(s *terraform.State) error {
+						if id := s.RootModule().Resources[resourceName].Primary.ID; id != stackID {
+							return fmt.Errorf("stack was recreated (ID changed from %s to %s), expected in-place update", stackID, id)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				// Step 3: Migrate back to Terraform — must be update, not recreate
+				Config: config(`
+					labels            = ["terragrunt"]
+					terraform_version = "1.5.7"
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					Resource(
+						resourceName,
+						Attribute("terraform_version", Equals("1.5.7")),
+						SetContains("labels", "terragrunt"),
+						Attribute("terragrunt.#", Equals("0")),
+					),
+					func(s *terraform.State) error {
+						if id := s.RootModule().Resources[resourceName].Primary.ID; id != stackID {
+							return fmt.Errorf("stack was recreated (ID changed from %s to %s), expected in-place update", stackID, id)
+						}
+						return nil
+					},
 				),
 			},
 		})


### PR DESCRIPTION
## Description of the change

Support in-place vendor migration between Terraform stacks (with `terragrunt` label) and Spacelift-native Terragrunt stacks using the `stackMigrateVendor` GraphQL mutation.

When the user changes a `spacelift_stack` resource from top-level Terraform fields to a `terragrunt {}` block (or vice versa), the provider now calls `stackMigrateVendor` before `stackUpdate`, enabling the transition without destroy+create.

For example:
```diff
--- terraform
+++ terragrunt
@@ -2,7 +2,9 @@
   name       = "vendor-migration-test"
   repository = "terragrunt-example"
   branch     = "main"
-  labels = ["terragrunt"]
-  terraform_version = "1.11.0"
-  terraform_workflow_tool = "OPEN_TOFU"
+  terragrunt {
+    use_state_management = true
+    terraform_version = "1.11.0"
+    tool = "OPEN_TOFU"
+  }
 }
```


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer