### PR TITLE
feat: deprecate usage of STACK_MANAGE on the side of provider-terraform

### DIFF
--- a/spacelift/data_role_actions.go
+++ b/spacelift/data_role_actions.go
@@ -32,7 +32,7 @@ func dataRoleActions() *schema.Resource {
 func dataRoleActionsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	introspectionClient := internal.NewIntrospectionClient(meta.(*internal.Client))
 
-	enumValues, err := introspectionClient.GetEnumValues(ctx, "Action")
+	enumValues, err := introspectionClient.GetEnumValues(ctx, "Action", internal.WithIncludeDeprecated(true))
 	if err != nil {
 		return diag.Errorf("could not fetch role actions: %v", err)
 	}

--- a/spacelift/internal/introspection.go
+++ b/spacelift/internal/introspection.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/shurcooL/graphql"
 )
 
 const enumKind string = "ENUM"
@@ -29,7 +30,7 @@ type Schema struct {
 		Name        string      `json:"name"`
 		Kind        string      `json:"kind"`
 		Description string      `json:"description"`
-		EnumValues  []EnumValue `json:"enumValues"`
+		EnumValues  []EnumValue `graphql:"enumValues(includeDeprecated: $includeDeprecated)" json:"enumValues"`
 	} `json:"types"`
 }
 
@@ -37,8 +38,8 @@ type IntrospectionQuery struct {
 	Schema Schema `graphql:"__schema"`
 }
 
-func (c *IntrospectionClient) GetEnumValues(ctx context.Context, enumName string) ([]string, error) {
-	resp, err := c.Introspect(ctx)
+func (c *IntrospectionClient) GetEnumValues(ctx context.Context, enumName string, introspectionOpts ...IntrospectionOption) ([]string, error) {
+	resp, err := c.Introspect(ctx, introspectionOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to introspect schema: %w", err)
 	}
@@ -60,11 +61,32 @@ func (c *IntrospectionClient) GetEnumValues(ctx context.Context, enumName string
 	return nil, fmt.Errorf("enum type %s not found in schema", enumName)
 }
 
-func (c *IntrospectionClient) Introspect(ctx context.Context) (*IntrospectionQuery, error) {
-	tflog.Debug(ctx, "Introspecting GraphQL endpoint")
+type introspectOpts struct {
+	includeDeprecated bool
+}
 
+type IntrospectionOption func(*introspectOpts)
+
+func WithIncludeDeprecated(include bool) IntrospectionOption {
+	return func(io *introspectOpts) {
+		io.includeDeprecated = include
+	}
+}
+
+func (c *IntrospectionClient) Introspect(ctx context.Context, opts ...IntrospectionOption) (*IntrospectionQuery, error) {
 	var query IntrospectionQuery
-	if err := c.client.Query(ctx, "Introspection", &query, nil); err != nil {
+	introOpts := &introspectOpts{}
+	for i := range opts {
+		opts[i](introOpts)
+	}
+
+	tflog.Debug(ctx, "Introspecting GraphQL endpoint", map[string]any{
+		"includeDeprecated": introOpts.includeDeprecated,
+	})
+	if err := c.client.Query(ctx, "Introspection", &query, map[string]any{
+		// https://github.com/graphql/graphql-spec/blob/September2025/spec/Section%204%20--%20Introspection.md
+		"includeDeprecated": graphql.Boolean(introOpts.includeDeprecated),
+	}); err != nil {
 		return nil, fmt.Errorf("failed to perform GraphQL introspection: %w", err)
 	}
 

--- a/spacelift/resource_role.go
+++ b/spacelift/resource_role.go
@@ -2,6 +2,7 @@ package spacelift
 
 import (
 	"context"
+	"fmt"
 	"slices"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -12,6 +13,8 @@ import (
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/structs"
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
+
+var deprecatedActions = []string{"STACK_MANAGE"}
 
 func resourceRole() *schema.Resource {
 	return &schema.Resource{
@@ -116,13 +119,20 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 	d.Set("slug", role.Slug)
 	d.Set("description", role.Description)
 
+	var diags diag.Diagnostics
 	actions := schema.NewSet(schema.HashString, []any{})
 	for _, action := range role.Actions {
 		actions.Add(string(action))
+		if slices.Contains(deprecatedActions, string(action)) {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("Action %q is deprecated", string(action)),
+			})
+		}
 	}
 	d.Set("actions", actions)
 
-	return nil
+	return diags
 }
 
 func resourceRoleUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -194,7 +204,7 @@ func validateActions(ctx context.Context, client *internal.Client, actions []gra
 
 	introspectionClient := internal.NewIntrospectionClient(client)
 
-	enumValues, err := introspectionClient.GetEnumValues(ctx, "Action")
+	enumValues, err := introspectionClient.GetEnumValues(ctx, "Action", internal.WithIncludeDeprecated(true))
 	if err != nil {
 		return nil, diag.Errorf("could not fetch action enum values: %v", err)
 	}


### PR DESCRIPTION
## Description of the change

> Description here

~The incoming deprecation of STACK_MANAGE in Spacelift's GraphQL API (https://github.com/spacelift-io/backend/pull/14336)~ (Not happening anymore to not break users stuck on older spacelift-provider versions) causes a function that lists valid Actions to return a list without this value, which breaks existing users. This PR fixes this situation by improving GQL introspection of Action enum to also return deprecated values, which allows using STACK_MANAGE for now, but later it adds a diagnostic that causes opentofu/tf to print a warning that such a deprecated value was used. See:

```hcl
resource "spacelift_role" "stack_webhook_creator" {
  name    = "stack-webhook-creator"
  actions = ["STACK_WEBHOOK_CREATE", "STACK_AZURE_INTEGRATION_ATTACH", "STACK_MANAGE"]
}

```
output: 
<img width="727" height="234" alt="image" src="https://github.com/user-attachments/assets/ab4747c3-90d3-4962-b3fd-4d10460d1b50" />

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [x] Changes have been reviewed by at least one other engineer
