### PR TITLE
feat: add prefix_resource_names_with_module_name to terragrunt config

### DIFF
--- a/docs/data-sources/stack.md
+++ b/docs/data-sources/stack.md
@@ -191,6 +191,7 @@ Read-Only:
 
 Read-Only:
 
+- `prefix_resource_names_with_module_name` (Boolean)
 - `skip_replan_when_run_all` (Boolean)
 - `terraform_version` (String)
 - `terragrunt_version` (String)

--- a/docs/data-sources/stacks.md
+++ b/docs/data-sources/stacks.md
@@ -288,6 +288,7 @@ Read-Only:
 
 Read-Only:
 
+- `prefix_resource_names_with_module_name` (Boolean)
 - `skip_replan_when_run_all` (Boolean)
 - `terraform_version` (String)
 - `terragrunt_version` (String)

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -398,6 +398,7 @@ Required:
 
 Optional:
 
+- `prefix_resource_names_with_module_name` (Boolean) Controls whether resource and output names are prefixed with the module path. Has no effect when use_run_all is enabled (always prefixes in that case).
 - `skip_replan_when_run_all` (Boolean) When using Run All, skip the second planning phase during the apply stage. This is an experimental feature. Runs with Run All disabled reuse the plan by default. Warning: this means any `mocked_outputs` referenced during planning will be applied as-is — do not enable this together with `mocked_outputs` unless you fully understand the implications, your apply may execute against mocked values rather than real ones.
 - `terraform_version` (String) The Terraform version. Must not be provided when tool is set to MANUALLY_PROVISIONED. Defaults to the latest available OpenTofu/Terraform version.
 - `terragrunt_version` (String) The Terragrunt version. Defaults to the latest Terragrunt version.

--- a/spacelift/data_stack.go
+++ b/spacelift/data_stack.go
@@ -507,6 +507,11 @@ func dataStack() *schema.Resource {
 							Description: "When using Run All, skip the second planning phase during the apply stage. This is an experimental feature. Runs with Run All disabled reuse the plan by default. Warning: this means any `mocked_outputs` referenced during planning will be applied as-is — do not enable this together with `mocked_outputs` unless you fully understand the implications, your apply may execute against mocked values rather than real ones.",
 							Computed:    true,
 						},
+						"prefix_resource_names_with_module_name": {
+							Type:        schema.TypeBool,
+							Description: "Controls whether resource and output names are prefixed with the module path. Has no effect when use_run_all is enabled (always prefixes in that case).",
+							Computed:    true,
+						},
 						"tool": {
 							Type:        schema.TypeString,
 							Description: "The IaC tool used by Terragrunt. Will be either OPEN_TOFU, TERRAFORM_FOSS or MANUALLY_PROVISIONED.",

--- a/spacelift/internal/structs/stack.go
+++ b/spacelift/internal/structs/stack.go
@@ -96,13 +96,14 @@ type Stack struct {
 			ExternalStateAccessEnabled bool    `graphql:"externalStateAccessEnabled"`
 		} `graphql:"... on StackConfigVendorTerraform"`
 		Terragrunt struct {
-			TerraformVersion     *string `graphql:"terraformVersion"`
-			TerragruntVersion    *string `graphql:"terragruntVersion"`
-			UseRunAll            bool    `graphql:"useRunAll"`
-			UseSmartSanitization bool    `graphql:"useSmartSanitization"`
-			UseStateManagement   bool    `graphql:"useStateManagement"`
-			SkipReplanWhenRunAll bool    `graphql:"skipReplanWhenRunAll"`
-			Tool                 string  `graphql:"tool"`
+			TerraformVersion                  *string `graphql:"terraformVersion"`
+			TerragruntVersion                 *string `graphql:"terragruntVersion"`
+			UseRunAll                         bool    `graphql:"useRunAll"`
+			UseSmartSanitization              bool    `graphql:"useSmartSanitization"`
+			UseStateManagement                bool    `graphql:"useStateManagement"`
+			PrefixResourceNamesWithModuleName bool    `graphql:"prefixResourceNamesWithModuleName"`
+			SkipReplanWhenRunAll              bool    `graphql:"skipReplanWhenRunAll"`
+			Tool                              string  `graphql:"tool"`
 		} `graphql:"... on StackConfigVendorTerragrunt"`
 	} `graphql:"vendorConfig"`
 	WorkerPool *struct {
@@ -150,13 +151,14 @@ func (s *Stack) IaCSettings() (string, map[string]any) {
 		}
 	case StackConfigVendorTerragrunt:
 		return "terragrunt", map[string]any{
-			"terraform_version":        s.VendorConfig.Terragrunt.TerraformVersion,
-			"terragrunt_version":       s.VendorConfig.Terragrunt.TerragruntVersion,
-			"use_run_all":              s.VendorConfig.Terragrunt.UseRunAll,
-			"use_smart_sanitization":   s.VendorConfig.Terragrunt.UseSmartSanitization,
-			"use_state_management":     s.VendorConfig.Terragrunt.UseStateManagement,
-			"skip_replan_when_run_all": s.VendorConfig.Terragrunt.SkipReplanWhenRunAll,
-			"tool":                     s.VendorConfig.Terragrunt.Tool,
+			"terraform_version":                      s.VendorConfig.Terragrunt.TerraformVersion,
+			"terragrunt_version":                     s.VendorConfig.Terragrunt.TerragruntVersion,
+			"use_run_all":                            s.VendorConfig.Terragrunt.UseRunAll,
+			"use_smart_sanitization":                 s.VendorConfig.Terragrunt.UseSmartSanitization,
+			"use_state_management":                   s.VendorConfig.Terragrunt.UseStateManagement,
+			"skip_replan_when_run_all":               s.VendorConfig.Terragrunt.SkipReplanWhenRunAll,
+			"prefix_resource_names_with_module_name": s.VendorConfig.Terragrunt.PrefixResourceNamesWithModuleName,
+			"tool":                                   s.VendorConfig.Terragrunt.Tool,
 		}
 	}
 
@@ -310,13 +312,14 @@ func PopulateStack(d *schema.ResourceData, stack *Stack) error {
 		d.Set("pulumi", []any{m})
 	case StackConfigVendorTerragrunt:
 		m := map[string]any{
-			"terraform_version":        stack.VendorConfig.Terragrunt.TerraformVersion,
-			"terragrunt_version":       stack.VendorConfig.Terragrunt.TerragruntVersion,
-			"use_run_all":              stack.VendorConfig.Terragrunt.UseRunAll,
-			"use_smart_sanitization":   stack.VendorConfig.Terragrunt.UseSmartSanitization,
-			"use_state_management":     stack.VendorConfig.Terragrunt.UseStateManagement,
-			"skip_replan_when_run_all": stack.VendorConfig.Terragrunt.SkipReplanWhenRunAll,
-			"tool":                     stack.VendorConfig.Terragrunt.Tool,
+			"terraform_version":                      stack.VendorConfig.Terragrunt.TerraformVersion,
+			"terragrunt_version":                     stack.VendorConfig.Terragrunt.TerragruntVersion,
+			"use_run_all":                            stack.VendorConfig.Terragrunt.UseRunAll,
+			"use_smart_sanitization":                 stack.VendorConfig.Terragrunt.UseSmartSanitization,
+			"use_state_management":                   stack.VendorConfig.Terragrunt.UseStateManagement,
+			"skip_replan_when_run_all":               stack.VendorConfig.Terragrunt.SkipReplanWhenRunAll,
+			"prefix_resource_names_with_module_name": stack.VendorConfig.Terragrunt.PrefixResourceNamesWithModuleName,
+			"tool":                                   stack.VendorConfig.Terragrunt.Tool,
 		}
 
 		d.Set("terragrunt", []any{m})

--- a/spacelift/internal/structs/stack_input.go
+++ b/spacelift/internal/structs/stack_input.go
@@ -78,13 +78,14 @@ type PulumiInput struct {
 }
 
 type TerragruntInput struct {
-	TerraformVersion     *graphql.String  `json:"terraformVersion"`
-	TerragruntVersion    *graphql.String  `json:"terragruntVersion"`
-	UseRunAll            graphql.Boolean  `json:"useRunAll"`
-	UseSmartSanitization graphql.Boolean  `json:"useSmartSanitization"`
-	UseStateManagement   *graphql.Boolean `json:"useStateManagement"`
-	SkipReplanWhenRunAll *graphql.Boolean `json:"skipReplanWhenRunAll"`
-	Tool                 *graphql.String  `json:"tool"`
+	TerraformVersion                  *graphql.String  `json:"terraformVersion"`
+	TerragruntVersion                 *graphql.String  `json:"terragruntVersion"`
+	UseRunAll                         graphql.Boolean  `json:"useRunAll"`
+	UseSmartSanitization              graphql.Boolean  `json:"useSmartSanitization"`
+	UseStateManagement                *graphql.Boolean `json:"useStateManagement"`
+	SkipReplanWhenRunAll              *graphql.Boolean `json:"skipReplanWhenRunAll"`
+	PrefixResourceNamesWithModuleName *graphql.Boolean `json:"prefixResourceNamesWithModuleName"`
+	Tool                              *graphql.String  `json:"tool"`
 }
 
 // TerraformInput represents Terraform-specific configuration.

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -699,6 +699,12 @@ func resourceStack() *schema.Resource {
 							Optional:    true,
 							Computed:    true,
 						},
+						"prefix_resource_names_with_module_name": {
+							Type:        schema.TypeBool,
+							Description: "Controls whether resource and output names are prefixed with the module path. Has no effect when use_run_all is enabled (always prefixes in that case).",
+							Optional:    true,
+							Computed:    true,
+						},
 					},
 				},
 			},
@@ -1081,6 +1087,10 @@ func getVendorConfig(d *schema.ResourceData) *structs.VendorConfigInput {
 
 		if skipReplanWhenRunAll, ok := terragrunt[0].(map[string]any)["skip_replan_when_run_all"]; ok {
 			terragruntConfig.SkipReplanWhenRunAll = toOptionalBool(skipReplanWhenRunAll)
+		}
+
+		if prefixResourceNamesWithModuleName, ok := terragrunt[0].(map[string]any)["prefix_resource_names_with_module_name"]; ok {
+			terragruntConfig.PrefixResourceNamesWithModuleName = toOptionalBool(prefixResourceNamesWithModuleName)
 		}
 
 		if shouldWeReComputeTerraformVersionForTerragrunt(d) {

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -906,6 +906,69 @@ func TestStackResource(t *testing.T) {
 		})
 	})
 
+	t.Run("with Terragrunt prefix_resource_names_with_module_name", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch       = "master"
+					name         = "Provider test stack terragrunt prefix resource names %s"
+					project_root = "root"
+					repository   = "demo"
+					terragrunt {
+						terragrunt_version = "0.45.0"
+						terraform_version  = "1.4.0"
+					}
+				}
+			`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("terragrunt.0.prefix_resource_names_with_module_name", Equals("false")),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch       = "master"
+					name         = "Provider test stack terragrunt prefix resource names %s"
+					project_root = "root"
+					repository   = "demo"
+					terragrunt {
+						terragrunt_version                     = "0.45.0"
+						terraform_version                      = "1.4.0"
+						prefix_resource_names_with_module_name = true
+					}
+				}
+			`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("terragrunt.0.prefix_resource_names_with_module_name", Equals("true")),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch       = "master"
+					name         = "Provider test stack terragrunt prefix resource names %s"
+					project_root = "root"
+					repository   = "demo"
+					terragrunt {
+						terragrunt_version                     = "0.45.0"
+						terraform_version                      = "1.4.0"
+						prefix_resource_names_with_module_name = false
+					}
+				}
+			`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("terragrunt.0.prefix_resource_names_with_module_name", Equals("false")),
+				),
+			},
+		})
+	})
+
 	t.Run("with GitHub and no vendor-specific configuration", func(t *testing.T) {
 		testSteps(t, []resource.TestStep{
 			{


### PR DESCRIPTION
## Description of the change

Adds `prefix_resource_names_with_module_name` attribute to the `terragrunt` block in `spacelift_stack` resource and data source. This allows users to control whether resource and output names are prefixed with the module path when `use_run_all` is disabled. Previously this setting was only configurable via the UI.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

Fix [#799](https://github.com/spacelift-io/terraform-provider-spacelift/issues/799)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer