### PR TITLE
feat(resource_policy): warn on deprecated ACCESS policy types

### DIFF
--- a/spacelift/resource_policy.go
+++ b/spacelift/resource_policy.go
@@ -201,6 +201,13 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta any) d
 		}}
 	}
 
+	if policy.Type == "ACCESS" || policy.Type == "STACK_ACCESS" {
+		return diag.Diagnostics{{
+			Severity: diag.Warning,
+			Summary:  "Access policies are deprecated and should no longer be used",
+		}}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Emit a Terraform `Warning` diagnostic in `resourcePolicyRead` when a policy's type is `ACCESS` or `STACK_ACCESS`.
- Mirrors the existing pattern used for `TASK` / `INITIALIZATION` policies.
- Warning automatically surfaces on create/update because both delegate to `resourcePolicyRead`.

## Test plan
- [ ] `go build ./...` passes
- [ ] Manual: `terraform apply` on a policy with `type = "ACCESS"` shows the deprecation warning
- [ ] Manual: `terraform apply` on a policy with `type = "STACK_ACCESS"` shows the deprecation warning
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)