### PR TITLE
feat: undeprecate STACK_MANAGE action

### DIFF
--- a/spacelift/resource_role.go
+++ b/spacelift/resource_role.go
@@ -14,7 +14,9 @@ import (
 	"github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/validations"
 )
 
-var deprecatedActions = []string{"STACK_MANAGE"}
+var deprecatedActions = []string{
+	// "STACK_MANAGE", // Undeprecated
+}
 
 func resourceRole() *schema.Resource {
 	return &schema.Resource{
@@ -141,7 +143,6 @@ func resourceRoleUpdate(ctx context.Context, d *schema.ResourceData, meta any) d
 	}
 
 	input := structs.RoleUpdateInput{}
-
 	if d.HasChange("name") {
 		input.Name = toOptionalString(d.Get("name"))
 	}


### PR DESCRIPTION
## Description of the change

> Description here

See https://app.notion.com/p/spacelift/Stack-creation-wizard-StackCreate-StackUpdate-alignment-2026-06-08-379251e5616a81fa8d47e7e4627c8aea?pvs=25 and https://app.notion.com/p/spacelift/StackManage-action-decomposition-reversal-plan-e46251e5616a828e906f01644b144817. Reverses deprecation of STACK_MANAGE action.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
