### PR TITLE
feat(stack): add native OpenTofu vendor support

### DIFF
--- a/docs/data-sources/stack.md
+++ b/docs/data-sources/stack.md
@@ -166,12 +166,20 @@ Read-Only:
 
 Read-Only:
 
-- `concise` (Boolean)
 - `external_state_access` (Boolean)
+- `logging` (List of Object) (see [below for nested schema](#nestedobjatt--opentofu--logging))
 - `use_smart_sanitization` (Boolean)
 - `version` (String)
 - `workflow_tool` (String)
 - `workspace` (String)
+
+<a id="nestedobjatt--opentofu--logging"></a>
+### Nested Schema for `opentofu.logging`
+
+Read-Only:
+
+- `concise` (Boolean)
+
 
 
 <a id="nestedatt--pulumi"></a>

--- a/docs/data-sources/stack.md
+++ b/docs/data-sources/stack.md
@@ -65,6 +65,7 @@ data "spacelift_stack" "k8s-core" {
 - `labels` (Set of String)
 - `manage_state` (Boolean) Determines if Spacelift should manage state for this stack
 - `name` (String) Name of the stack - should be unique in one account
+- `opentofu` (List of Object) OpenTofu-specific configuration. Presence means this Stack is a native OpenTofu Stack. (see [below for nested schema](#nestedatt--opentofu))
 - `project_root` (String) Project root is the optional directory relative to the workspace root containing the entrypoint to the Stack.
 - `protect_from_deletion` (Boolean) Protect this stack from accidental deletion. If set, attempts to delete this stack will fail.
 - `pulumi` (List of Object) Pulumi-specific configuration. Presence means this Stack is a Pulumi Stack. (see [below for nested schema](#nestedatt--pulumi))
@@ -158,6 +159,19 @@ Read-Only:
 - `kubectl_version` (String)
 - `kubernetes_workflow_tool` (String)
 - `namespace` (String)
+
+
+<a id="nestedatt--opentofu"></a>
+### Nested Schema for `opentofu`
+
+Read-Only:
+
+- `concise` (Boolean)
+- `external_state_access` (Boolean)
+- `use_smart_sanitization` (Boolean)
+- `version` (String)
+- `workflow_tool` (String)
+- `workspace` (String)
 
 
 <a id="nestedatt--pulumi"></a>

--- a/docs/data-sources/stacks.md
+++ b/docs/data-sources/stacks.md
@@ -161,6 +161,7 @@ Read-Only:
 - `labels` (Set of String)
 - `manage_state` (Boolean)
 - `name` (String)
+- `opentofu` (List of Object) (see [below for nested schema](#nestedobjatt--stacks--opentofu))
 - `project_root` (String)
 - `protect_from_deletion` (Boolean)
 - `pulumi` (List of Object) (see [below for nested schema](#nestedobjatt--stacks--pulumi))
@@ -255,6 +256,27 @@ Read-Only:
 - `kubectl_version` (String)
 - `kubernetes_workflow_tool` (String)
 - `namespace` (String)
+
+
+<a id="nestedobjatt--stacks--opentofu"></a>
+### Nested Schema for `stacks.opentofu`
+
+Read-Only:
+
+- `external_state_access` (Boolean)
+- `logging` (List of Object) (see [below for nested schema](#nestedobjatt--stacks--opentofu--logging))
+- `use_smart_sanitization` (Boolean)
+- `version` (String)
+- `workflow_tool` (String)
+- `workspace` (String)
+
+<a id="nestedobjatt--stacks--opentofu--logging"></a>
+### Nested Schema for `stacks.opentofu.logging`
+
+Read-Only:
+
+- `concise` (Boolean)
+
 
 
 <a id="nestedobjatt--stacks--pulumi"></a>

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -396,12 +396,20 @@ Optional:
 
 Optional:
 
-- `concise` (Boolean) Enables the -concise flag for OpenTofu plan/apply/refresh commands. Requires OpenTofu 1.7+. Defaults to `true`.
 - `external_state_access` (Boolean) Indicates whether you can access the Stack state file from other stacks or outside of Spacelift. Defaults to `false`.
+- `logging` (Block List, Max: 1) Logging configuration for OpenTofu commands. (see [below for nested schema](#nestedblock--opentofu--logging))
 - `use_smart_sanitization` (Boolean) Indicates whether runs on this will use OpenTofu's sensitive value system to sanitize the outputs of state and plans in Spacelift instead of sanitizing all fields. Defaults to `true`.
 - `version` (String) OpenTofu version to use.
 - `workflow_tool` (String) Defines the tool that will be used to execute the workflow. This can be one of `OPENTOFU` or `CUSTOM`. Defaults to `OPENTOFU`.
 - `workspace` (String) OpenTofu workspace to select.
+
+<a id="nestedblock--opentofu--logging"></a>
+### Nested Schema for `opentofu.logging`
+
+Optional:
+
+- `concise` (Boolean) Enables the -concise flag for OpenTofu plan/apply/refresh commands. Requires OpenTofu 1.7+. Defaults to `true`.
+
 
 
 <a id="nestedblock--pulumi"></a>

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -260,6 +260,7 @@ resource "spacelift_role_attachment" "spacelift-admin-operator" {
 - `kubernetes` (Block List, Max: 1) Kubernetes-specific configuration. Presence means this Stack is a Kubernetes Stack. (see [below for nested schema](#nestedblock--kubernetes))
 - `labels` (Set of String)
 - `manage_state` (Boolean) Determines if Spacelift should manage state for this stack. Defaults to `true`.
+- `opentofu` (Block List, Max: 1) OpenTofu-specific configuration. Presence means this Stack is a native OpenTofu Stack. (see [below for nested schema](#nestedblock--opentofu))
 - `project_root` (String) Project root is the optional directory relative to the workspace root containing the entrypoint to the Stack.
 - `protect_from_deletion` (Boolean) Protect this stack from accidental deletion. If set, attempts to delete this stack will fail. Defaults to `false`.
 - `pulumi` (Block List, Max: 1) Pulumi-specific configuration. Presence means this Stack is a Pulumi Stack. (see [below for nested schema](#nestedblock--pulumi))
@@ -388,6 +389,19 @@ Optional:
 - `kubectl_version` (String) Kubectl version.
 - `kubernetes_workflow_tool` (String) Defines the tool that will be used to execute the workflow. This can be one of `KUBERNETES` or `CUSTOM`. Defaults to `KUBERNETES`.
 - `namespace` (String) Namespace of the Kubernetes cluster to run commands on. Leave empty for multi-namespace Stacks.
+
+
+<a id="nestedblock--opentofu"></a>
+### Nested Schema for `opentofu`
+
+Optional:
+
+- `concise` (Boolean) Enables the -concise flag for OpenTofu plan/apply/refresh commands. Requires OpenTofu 1.7+. Defaults to `true`.
+- `external_state_access` (Boolean) Indicates whether you can access the Stack state file from other stacks or outside of Spacelift. Defaults to `false`.
+- `use_smart_sanitization` (Boolean) Indicates whether runs on this will use OpenTofu's sensitive value system to sanitize the outputs of state and plans in Spacelift instead of sanitizing all fields. Defaults to `true`.
+- `version` (String) OpenTofu version to use.
+- `workflow_tool` (String) Defines the tool that will be used to execute the workflow. This can be one of `OPENTOFU` or `CUSTOM`. Defaults to `OPENTOFU`.
+- `workspace` (String) OpenTofu workspace to select.
 
 
 <a id="nestedblock--pulumi"></a>

--- a/spacelift/data_stack.go
+++ b/spacelift/data_stack.go
@@ -341,6 +341,45 @@ func dataStack() *schema.Resource {
 					},
 				},
 			},
+			"opentofu": {
+				Type:        schema.TypeList,
+				Description: "OpenTofu-specific configuration. Presence means this Stack is a native OpenTofu Stack.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"concise": {
+							Type:        schema.TypeBool,
+							Description: "Indicates whether the -concise flag is enabled for OpenTofu plan/apply/refresh commands.",
+							Computed:    true,
+						},
+						"external_state_access": {
+							Type:        schema.TypeBool,
+							Description: "Indicates whether you can access the Stack state file from other stacks or outside of Spacelift.",
+							Computed:    true,
+						},
+						"use_smart_sanitization": {
+							Type:        schema.TypeBool,
+							Description: "Indicates whether runs on this will use OpenTofu's sensitive value system to sanitize the outputs of state and plans in Spacelift instead of sanitizing all fields.",
+							Computed:    true,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Description: "OpenTofu version to use.",
+							Computed:    true,
+						},
+						"workflow_tool": {
+							Type:        schema.TypeString,
+							Description: "Defines the tool that will be used to execute the workflow. This can be one of `OPENTOFU` or `CUSTOM`.",
+							Computed:    true,
+						},
+						"workspace": {
+							Type:        schema.TypeString,
+							Description: "OpenTofu workspace to select.",
+							Computed:    true,
+						},
+					},
+				},
+			},
 			"manage_state": {
 				Type:        schema.TypeBool,
 				Description: "Determines if Spacelift should manage state for this stack",

--- a/spacelift/data_stack.go
+++ b/spacelift/data_stack.go
@@ -347,10 +347,19 @@ func dataStack() *schema.Resource {
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"concise": {
-							Type:        schema.TypeBool,
-							Description: "Indicates whether the -concise flag is enabled for OpenTofu plan/apply/refresh commands.",
+						"logging": {
+							Type:        schema.TypeList,
+							Description: "Logging configuration for OpenTofu commands.",
 							Computed:    true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"concise": {
+										Type:        schema.TypeBool,
+										Description: "Indicates whether the -concise flag is enabled for OpenTofu plan/apply/refresh commands.",
+										Computed:    true,
+									},
+								},
+							},
 						},
 						"external_state_access": {
 							Type:        schema.TypeBool,

--- a/spacelift/internal/structs/stack.go
+++ b/spacelift/internal/structs/stack.go
@@ -159,7 +159,9 @@ func (s *Stack) IaCSettings() (string, map[string]any) {
 		}
 	case StackConfigVendorOpenTofu:
 		return "opentofu", map[string]any{
-			"concise":                s.VendorConfig.OpenTofu.Concise,
+			"logging": []any{map[string]any{
+				"concise": s.VendorConfig.OpenTofu.Concise,
+			}},
 			"external_state_access":  s.VendorConfig.OpenTofu.ExternalStateAccessEnabled,
 			"use_smart_sanitization": s.VendorConfig.OpenTofu.UseSmartSanitization,
 			"version":                s.VendorConfig.OpenTofu.Version,
@@ -343,7 +345,9 @@ func PopulateStack(d *schema.ResourceData, stack *Stack) diag.Diagnostics {
 
 		if userHasOpenTofuBlock {
 			m := map[string]any{
-				"concise":                stack.VendorConfig.OpenTofu.Concise,
+				"logging": []any{map[string]any{
+					"concise": stack.VendorConfig.OpenTofu.Concise,
+				}},
 				"external_state_access":  stack.VendorConfig.OpenTofu.ExternalStateAccessEnabled,
 				"use_smart_sanitization": stack.VendorConfig.OpenTofu.UseSmartSanitization,
 				"version":                stack.VendorConfig.OpenTofu.Version,

--- a/spacelift/internal/structs/stack.go
+++ b/spacelift/internal/structs/stack.go
@@ -1,6 +1,7 @@
 package structs
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 )
@@ -19,6 +20,9 @@ const StackConfigVendorTerraform = "StackConfigVendorTerraform"
 
 // StackConfigVendorKubernetes is a graphql union typename.
 const StackConfigVendorKubernetes = "StackConfigVendorKubernetes"
+
+// StackConfigVendorOpenTofu is a graphql union typename.
+const StackConfigVendorOpenTofu = "StackConfigVendorOpenTofu"
 
 // StackConfigVendorTerragrunt is a graphql union typename.
 const StackConfigVendorTerragrunt = "StackConfigVendorTerragrunt"
@@ -84,6 +88,14 @@ type Stack struct {
 			KubectlVersion         *string `graphql:"kubectlVersion"`
 			KubernetesWorkflowTool *string `graphql:"kubernetesWorkflowTool"`
 		} `graphql:"... on StackConfigVendorKubernetes"`
+		OpenTofu struct {
+			Concise                    bool    `graphql:"concise"`
+			ExternalStateAccessEnabled bool    `graphql:"externalStateAccessEnabled"`
+			UseSmartSanitization       bool    `graphql:"useSmartSanitization"`
+			Version                    *string `graphql:"version"`
+			WorkflowTool               *string `graphql:"openTofuWorkflowTool:workflowTool"`
+			Workspace                  *string `graphql:"workspace"`
+		} `graphql:"... on StackConfigVendorOpenTofu"`
 		Pulumi struct {
 			LoginURL  string `graphql:"loginURL"`
 			StackName string `graphql:"stackName"`
@@ -144,6 +156,15 @@ func (s *Stack) IaCSettings() (string, map[string]any) {
 			"namespace":                s.VendorConfig.Kubernetes.Namespace,
 			"kubectl_version":          s.VendorConfig.Kubernetes.KubectlVersion,
 			"kubernetes_workflow_tool": s.VendorConfig.Kubernetes.KubernetesWorkflowTool,
+		}
+	case StackConfigVendorOpenTofu:
+		return "opentofu", map[string]any{
+			"concise":                s.VendorConfig.OpenTofu.Concise,
+			"external_state_access":  s.VendorConfig.OpenTofu.ExternalStateAccessEnabled,
+			"use_smart_sanitization": s.VendorConfig.OpenTofu.UseSmartSanitization,
+			"version":                s.VendorConfig.OpenTofu.Version,
+			"workflow_tool":          s.VendorConfig.OpenTofu.WorkflowTool,
+			"workspace":              s.VendorConfig.OpenTofu.Workspace,
 		}
 	case StackConfigVendorPulumi:
 		return "pulumi", map[string]any{
@@ -227,7 +248,8 @@ func (s *Stack) VCSSettings() (string, map[string]any) {
 	return "", nil
 }
 
-func PopulateStack(d *schema.ResourceData, stack *Stack) error {
+func PopulateStack(d *schema.ResourceData, stack *Stack) diag.Diagnostics {
+	var diags diag.Diagnostics
 	d.Set("administrative", stack.Administrative)
 	d.Set("after_apply", stack.AfterApply)
 	d.Set("after_destroy", stack.AfterDestroy)
@@ -260,7 +282,7 @@ func PopulateStack(d *schema.ResourceData, stack *Stack) error {
 	d.Set("slug", stack.ID)
 
 	if err := stack.ExportVCSSettings(d); err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	labels := schema.NewSet(schema.HashString, []any{})
@@ -305,6 +327,48 @@ func PopulateStack(d *schema.ResourceData, stack *Stack) error {
 		}
 
 		d.Set("kubernetes", []any{m})
+	case StackConfigVendorOpenTofu:
+		// Check whether the user's .tf config uses the opentofu block.
+		// During Read, GetRawConfig() may be null, so we also check whether
+		// the opentofu block is already present in state (set by a prior Create/Update).
+		rawConfig := d.GetRawConfig()
+		userHasOpenTofuBlock := !rawConfig.IsNull() && !rawConfig.GetAttr("opentofu").IsNull()
+		if !userHasOpenTofuBlock {
+			if otState, ok := d.GetOk("opentofu"); ok {
+				if otList, ok := otState.([]any); ok && len(otList) > 0 {
+					userHasOpenTofuBlock = true
+				}
+			}
+		}
+
+		if userHasOpenTofuBlock {
+			m := map[string]any{
+				"concise":                stack.VendorConfig.OpenTofu.Concise,
+				"external_state_access":  stack.VendorConfig.OpenTofu.ExternalStateAccessEnabled,
+				"use_smart_sanitization": stack.VendorConfig.OpenTofu.UseSmartSanitization,
+				"version":                stack.VendorConfig.OpenTofu.Version,
+				"workflow_tool":          stack.VendorConfig.OpenTofu.WorkflowTool,
+				"workspace":              stack.VendorConfig.OpenTofu.Workspace,
+			}
+			d.Set("opentofu", []any{m})
+		} else {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "Stack uses native OpenTofu vendor but config has no `opentofu` block",
+				Detail:   "This stack has been migrated to the native OpenTofu vendor. Consider replacing `terraform_workflow_tool = \"OPEN_TOFU\"` with an `opentofu` block for full access to OpenTofu-specific features.",
+			})
+			// Backward compatibility: map native OpenTofu vendor config to terraform_*
+			// fields so stacks migrated server-side from Terraform+OPEN_TOFU show no drift.
+			d.Set("terraform_smart_sanitization", stack.VendorConfig.OpenTofu.UseSmartSanitization)
+			if stack.VendorConfig.OpenTofu.Version != nil {
+				d.Set("terraform_version", *stack.VendorConfig.OpenTofu.Version)
+			} else {
+				d.Set("terraform_version", nil)
+			}
+			d.Set("terraform_workflow_tool", "OPEN_TOFU")
+			d.Set("terraform_workspace", stack.VendorConfig.OpenTofu.Workspace)
+			d.Set("terraform_external_state_access", stack.VendorConfig.OpenTofu.ExternalStateAccessEnabled)
+		}
 	case StackConfigVendorPulumi:
 		m := map[string]any{
 			"login_url":  stack.VendorConfig.Pulumi.LoginURL,
@@ -345,7 +409,7 @@ func PopulateStack(d *schema.ResourceData, stack *Stack) error {
 		d.Set("worker_pool_id", nil)
 	}
 
-	return nil
+	return diags
 }
 
 func singleKeyMap(key, val string) map[string]any {

--- a/spacelift/internal/structs/stack_input.go
+++ b/spacelift/internal/structs/stack_input.go
@@ -46,6 +46,7 @@ type VendorConfigInput struct {
 	AnsibleInput        *AnsibleInput        `json:"ansible"`
 	CloudFormationInput *CloudFormationInput `json:"cloudFormation"`
 	Kubernetes          *KubernetesInput     `json:"kubernetes"`
+	OpenTofuInput       *OpenTofuInput       `json:"opentofu"`
 	Pulumi              *PulumiInput         `json:"pulumi"`
 	Terraform           *TerraformInput      `json:"terraform"`
 	TerragruntInput     *TerragruntInput     `json:"terragrunt"`
@@ -87,6 +88,16 @@ type TerragruntInput struct {
 	SkipReplan                        *graphql.Boolean `json:"skipReplan"`
 	PrefixResourceNamesWithModuleName *graphql.Boolean `json:"prefixResourceNamesWithModuleName"`
 	Tool                              *graphql.String  `json:"tool"`
+}
+
+// OpenTofuInput represents native OpenTofu-specific configuration.
+type OpenTofuInput struct {
+	Concise                    *graphql.Boolean `json:"concise"`
+	ExternalStateAccessEnabled *graphql.Boolean `json:"externalStateAccessEnabled"`
+	UseSmartSanitization       *graphql.Boolean `json:"useSmartSanitization"`
+	Version                    *graphql.String  `json:"version"`
+	WorkflowTool               *graphql.String  `json:"workflowTool"`
+	Workspace                  *graphql.String  `json:"workspace"`
 }
 
 // TerraformInput represents Terraform-specific configuration.

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -111,7 +111,7 @@ func resourceStack() *schema.Resource {
 			},
 			"ansible": {
 				Type:          schema.TypeList,
-				ConflictsWith: []string{"cloudformation", "kubernetes", "pulumi", "terraform_version", "terraform_workflow_tool", "terraform_workspace", "terragrunt"},
+				ConflictsWith: []string{"cloudformation", "kubernetes", "opentofu", "pulumi", "terraform_version", "terraform_workflow_tool", "terraform_workspace", "terragrunt"},
 				Description:   "Ansible-specific configuration. Presence means this Stack is an Ansible Stack.",
 				Optional:      true,
 				MaxItems:      1,
@@ -346,7 +346,7 @@ func resourceStack() *schema.Resource {
 			},
 			"cloudformation": {
 				Type:          schema.TypeList,
-				ConflictsWith: []string{"ansible", "kubernetes", "pulumi", "terraform_version", "terraform_workflow_tool", "terraform_workspace", "terragrunt"},
+				ConflictsWith: []string{"ansible", "kubernetes", "opentofu", "pulumi", "terraform_version", "terraform_workflow_tool", "terraform_workspace", "terragrunt"},
 				Description:   "CloudFormation-specific configuration. Presence means this Stack is a CloudFormation Stack.",
 				Optional:      true,
 				MaxItems:      1,
@@ -506,7 +506,7 @@ func resourceStack() *schema.Resource {
 			},
 			"kubernetes": {
 				Type:          schema.TypeList,
-				ConflictsWith: []string{"ansible", "cloudformation", "pulumi", "terraform_version", "terraform_workflow_tool", "terraform_workspace", "terragrunt"},
+				ConflictsWith: []string{"ansible", "cloudformation", "opentofu", "pulumi", "terraform_version", "terraform_workflow_tool", "terraform_workspace", "terragrunt"},
 				Description:   "Kubernetes-specific configuration. Presence means this Stack is a Kubernetes Stack.",
 				Optional:      true,
 				MaxItems:      1,
@@ -531,6 +531,52 @@ func resourceStack() *schema.Resource {
 							Optional:         true,
 							Computed:         true,
 							ValidateDiagFunc: validations.DisallowEmptyString,
+						},
+					},
+				},
+			},
+			"opentofu": {
+				Type:          schema.TypeList,
+				ConflictsWith: []string{"ansible", "cloudformation", "kubernetes", "pulumi", "terraform_version", "terraform_workflow_tool", "terraform_workspace", "terraform_smart_sanitization", "terraform_external_state_access", "terragrunt"},
+				Description:   "OpenTofu-specific configuration. Presence means this Stack is a native OpenTofu Stack.",
+				Optional:      true,
+				MaxItems:      1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"concise": {
+							Type:        schema.TypeBool,
+							Description: "Enables the -concise flag for OpenTofu plan/apply/refresh commands. Requires OpenTofu 1.7+. Defaults to `true`.",
+							Optional:    true,
+							Default:     true,
+						},
+						"external_state_access": {
+							Type:        schema.TypeBool,
+							Description: "Indicates whether you can access the Stack state file from other stacks or outside of Spacelift. Defaults to `false`.",
+							Optional:    true,
+							Default:     false,
+						},
+						"use_smart_sanitization": {
+							Type:        schema.TypeBool,
+							Description: "Indicates whether runs on this will use OpenTofu's sensitive value system to sanitize the outputs of state and plans in Spacelift instead of sanitizing all fields. Defaults to `true`.",
+							Optional:    true,
+							Default:     true,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Description: "OpenTofu version to use.",
+							Optional:    true,
+							Computed:    true,
+						},
+						"workflow_tool": {
+							Type:        schema.TypeString,
+							Description: "Defines the tool that will be used to execute the workflow. This can be one of `OPENTOFU` or `CUSTOM`. Defaults to `OPENTOFU`.",
+							Optional:    true,
+							Computed:    true,
+						},
+						"workspace": {
+							Type:        schema.TypeString,
+							Description: "OpenTofu workspace to select.",
+							Optional:    true,
 						},
 					},
 				},
@@ -578,7 +624,7 @@ func resourceStack() *schema.Resource {
 			},
 			"pulumi": {
 				Type:          schema.TypeList,
-				ConflictsWith: []string{"ansible", "cloudformation", "kubernetes", "terraform_version", "terraform_workflow_tool", "terraform_workspace", "terragrunt"},
+				ConflictsWith: []string{"ansible", "cloudformation", "kubernetes", "opentofu", "terraform_version", "terraform_workflow_tool", "terraform_workspace", "terragrunt"},
 				Description:   "Pulumi-specific configuration. Presence means this Stack is a Pulumi Stack.",
 				Optional:      true,
 				MaxItems:      1,
@@ -691,7 +737,7 @@ func resourceStack() *schema.Resource {
 			},
 			"terragrunt": {
 				Type:          schema.TypeList,
-				ConflictsWith: []string{"ansible", "cloudformation", "kubernetes", "pulumi", "terraform_smart_sanitization", "terraform_version", "terraform_workflow_tool", "terraform_workspace"},
+				ConflictsWith: []string{"ansible", "cloudformation", "kubernetes", "opentofu", "pulumi", "terraform_smart_sanitization", "terraform_version", "terraform_workflow_tool", "terraform_workspace"},
 				Description:   "Terragrunt-specific configuration. Presence means this Stack is an Terragrunt Stack.",
 				Optional:      true,
 				MaxItems:      1,
@@ -863,11 +909,7 @@ func resourceStackRead(ctx context.Context, d *schema.ResourceData, meta any) di
 		return nil
 	}
 
-	if err := structs.PopulateStack(d, stack); err != nil {
-		return diag.FromErr(err)
-	}
-
-	return nil
+	return structs.PopulateStack(d, stack)
 }
 
 func resourceStackUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
@@ -1140,6 +1182,39 @@ func getVendorConfig(d *schema.ResourceData) *structs.VendorConfigInput {
 		}
 	}
 
+	if opentofu, ok := d.Get("opentofu").([]any); ok && len(opentofu) > 0 {
+		opentofuConfig := structs.OpenTofuInput{}
+		settings := opentofu[0].(map[string]any)
+
+		if v, ok := settings["concise"]; ok {
+			opentofuConfig.Concise = toOptionalBool(v)
+		}
+
+		if v, ok := settings["external_state_access"]; ok {
+			opentofuConfig.ExternalStateAccessEnabled = toOptionalBool(v)
+		}
+
+		if v, ok := settings["use_smart_sanitization"]; ok {
+			opentofuConfig.UseSmartSanitization = toOptionalBool(v)
+		}
+
+		if version, ok := settings["version"]; ok && version.(string) != "" {
+			opentofuConfig.Version = toOptionalString(version)
+		}
+
+		if workflowTool, ok := settings["workflow_tool"]; ok && workflowTool.(string) != "" {
+			opentofuConfig.WorkflowTool = toOptionalString(workflowTool)
+		}
+
+		if workspace, ok := settings["workspace"]; ok && workspace.(string) != "" {
+			opentofuConfig.Workspace = toOptionalString(workspace)
+		}
+
+		return &structs.VendorConfigInput{
+			OpenTofuInput: &opentofuConfig,
+		}
+	}
+
 	if terragrunt, ok := d.Get("terragrunt").([]any); ok && len(terragrunt) > 0 {
 		terragruntConfig := structs.TerragruntInput{
 			UseRunAll:            toBool(terragrunt[0].(map[string]any)["use_run_all"]),
@@ -1355,8 +1430,8 @@ func resourceStackImport(ctx context.Context, d *schema.ResourceData, meta any) 
 		return nil, fmt.Errorf("stack with ID %q does not exist (or you may not have access to it)", stackID)
 	}
 
-	if err := structs.PopulateStack(d, stack); err != nil {
-		return nil, errors.Wrap(err, "could not import stack into state")
+	if diags := structs.PopulateStack(d, stack); diags.HasError() {
+		return nil, fmt.Errorf("could not import stack into state: %s", diags[0].Summary)
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -543,11 +543,22 @@ func resourceStack() *schema.Resource {
 				MaxItems:      1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"concise": {
-							Type:        schema.TypeBool,
-							Description: "Enables the -concise flag for OpenTofu plan/apply/refresh commands. Requires OpenTofu 1.7+. Defaults to `true`.",
+						"logging": {
+							Type:        schema.TypeList,
+							Description: "Logging configuration for OpenTofu commands.",
 							Optional:    true,
-							Default:     true,
+							Computed:    true,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"concise": {
+										Type:        schema.TypeBool,
+										Description: "Enables the -concise flag for OpenTofu plan/apply/refresh commands. Requires OpenTofu 1.7+. Defaults to `true`.",
+										Optional:    true,
+										Default:     true,
+									},
+								},
+							},
 						},
 						"external_state_access": {
 							Type:        schema.TypeBool,
@@ -1186,8 +1197,11 @@ func getVendorConfig(d *schema.ResourceData) *structs.VendorConfigInput {
 		opentofuConfig := structs.OpenTofuInput{}
 		settings := opentofu[0].(map[string]any)
 
-		if v, ok := settings["concise"]; ok {
-			opentofuConfig.Concise = toOptionalBool(v)
+		if logging, ok := settings["logging"].([]any); ok && len(logging) > 0 {
+			loggingSettings := logging[0].(map[string]any)
+			if v, ok := loggingSettings["concise"]; ok {
+				opentofuConfig.Concise = toOptionalBool(v)
+			}
 		}
 
 		if v, ok := settings["external_state_access"]; ok {

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -1228,6 +1228,61 @@ func TestStackResource(t *testing.T) {
 		})
 	})
 
+	t.Run("with GitHub and OpenTofu (default) configuration", func(t *testing.T) {
+		testSteps(t, []resource.TestStep{
+			{
+				Config: getConfig(`opentofu {}`),
+				Check: Resource(
+					resourceName,
+					Attribute("id", StartsWith("provider-test-stack")),
+
+					Attribute("opentofu.0.concise", Equals("true")),
+					Attribute("opentofu.0.use_smart_sanitization", Equals("true")),
+					Attribute("opentofu.0.external_state_access", Equals("false")),
+					Attribute("opentofu.0.workflow_tool", Equals("OPENTOFU")),
+
+					Attribute("cloudformation.#", Equals("0")),
+					Attribute("kubernetes.#", Equals("0")),
+					Attribute("pulumi.#", Equals("0")),
+					Attribute("ansible.#", Equals("0")),
+					Attribute("terragrunt.#", Equals("0")),
+				),
+			},
+		})
+	})
+
+	t.Run("with GitHub and OpenTofu (explicit settings) configuration", func(t *testing.T) {
+		testSteps(t, []resource.TestStep{
+			{
+				Config: getConfig(`opentofu {
+						version                = "1.8.0"
+						workspace              = "test-workspace"
+						concise                = false
+						use_smart_sanitization = false
+						external_state_access  = true
+						workflow_tool          = "CUSTOM"
+					}`),
+				Check: Resource(
+					resourceName,
+					Attribute("id", StartsWith("provider-test-stack")),
+
+					Attribute("opentofu.0.version", Equals("1.8.0")),
+					Attribute("opentofu.0.workspace", Equals("test-workspace")),
+					Attribute("opentofu.0.concise", Equals("false")),
+					Attribute("opentofu.0.use_smart_sanitization", Equals("false")),
+					Attribute("opentofu.0.external_state_access", Equals("true")),
+					Attribute("opentofu.0.workflow_tool", Equals("CUSTOM")),
+
+					Attribute("cloudformation.#", Equals("0")),
+					Attribute("kubernetes.#", Equals("0")),
+					Attribute("pulumi.#", Equals("0")),
+					Attribute("ansible.#", Equals("0")),
+					Attribute("terragrunt.#", Equals("0")),
+				),
+			},
+		})
+	})
+
 	t.Run("with GitHub and no vendor-specific configuration", func(t *testing.T) {
 		testSteps(t, []resource.TestStep{
 			{
@@ -2368,6 +2423,7 @@ func TestStackResourceSpace(t *testing.T) {
 			},
 		})
 	})
+
 }
 
 // getConfig returns a stack config with injected vendor config

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -1262,13 +1262,46 @@ func TestStackResource(t *testing.T) {
 						}
 						use_smart_sanitization = false
 						external_state_access  = true
-						workflow_tool          = "CUSTOM"
 					}`),
 				Check: Resource(
 					resourceName,
 					Attribute("id", StartsWith("provider-test-stack")),
 
 					Attribute("opentofu.0.version", Equals("1.8.0")),
+					Attribute("opentofu.0.workspace", Equals("test-workspace")),
+					Attribute("opentofu.0.logging.0.concise", Equals("false")),
+					Attribute("opentofu.0.use_smart_sanitization", Equals("false")),
+					Attribute("opentofu.0.external_state_access", Equals("true")),
+					Attribute("opentofu.0.workflow_tool", Equals("OPENTOFU")),
+
+					Attribute("cloudformation.#", Equals("0")),
+					Attribute("kubernetes.#", Equals("0")),
+					Attribute("pulumi.#", Equals("0")),
+					Attribute("ansible.#", Equals("0")),
+					Attribute("terragrunt.#", Equals("0")),
+				),
+			},
+		})
+	})
+
+	t.Run("with GitHub and OpenTofu (custom workflow tool) configuration", func(t *testing.T) {
+		testSteps(t, []resource.TestStep{
+			{
+				// The `version` attribute cannot be set together with a
+				// `CUSTOM` workflow tool, as the API rejects that combination.
+				Config: getConfig(`opentofu {
+						workspace              = "test-workspace"
+						logging {
+							concise = false
+						}
+						use_smart_sanitization = false
+						external_state_access  = true
+						workflow_tool          = "CUSTOM"
+					}`),
+				Check: Resource(
+					resourceName,
+					Attribute("id", StartsWith("provider-test-stack")),
+
 					Attribute("opentofu.0.workspace", Equals("test-workspace")),
 					Attribute("opentofu.0.logging.0.concise", Equals("false")),
 					Attribute("opentofu.0.use_smart_sanitization", Equals("false")),

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -1236,7 +1236,7 @@ func TestStackResource(t *testing.T) {
 					resourceName,
 					Attribute("id", StartsWith("provider-test-stack")),
 
-					Attribute("opentofu.0.concise", Equals("true")),
+					Attribute("opentofu.0.logging.0.concise", Equals("true")),
 					Attribute("opentofu.0.use_smart_sanitization", Equals("true")),
 					Attribute("opentofu.0.external_state_access", Equals("false")),
 					Attribute("opentofu.0.workflow_tool", Equals("OPENTOFU")),
@@ -1257,7 +1257,9 @@ func TestStackResource(t *testing.T) {
 				Config: getConfig(`opentofu {
 						version                = "1.8.0"
 						workspace              = "test-workspace"
-						concise                = false
+						logging {
+							concise = false
+						}
 						use_smart_sanitization = false
 						external_state_access  = true
 						workflow_tool          = "CUSTOM"
@@ -1268,7 +1270,7 @@ func TestStackResource(t *testing.T) {
 
 					Attribute("opentofu.0.version", Equals("1.8.0")),
 					Attribute("opentofu.0.workspace", Equals("test-workspace")),
-					Attribute("opentofu.0.concise", Equals("false")),
+					Attribute("opentofu.0.logging.0.concise", Equals("false")),
 					Attribute("opentofu.0.use_smart_sanitization", Equals("false")),
 					Attribute("opentofu.0.external_state_access", Equals("true")),
 					Attribute("opentofu.0.workflow_tool", Equals("CUSTOM")),


### PR DESCRIPTION
## Description of the change

Add `opentofu` configuration block to `spacelift_stack` resource and data source to support native OpenTofu stacks (vendor=6). This mirrors the GraphQL schema additions from the API layer.

**New `opentofu` block fields:**
- `version` — OpenTofu version constraint
- `workspace` — OpenTofu workspace to select
- `use_smart_sanitization` — sensitive value sanitization (default: `true`)
- `external_state_access` — cross-stack state access (default: `false`)
- `concise` — `-concise` flag for plan/apply/refresh (default: `true`)
- `workflow_tool` — `OPENTOFU` or `CUSTOM` (default: `OPENTOFU`)

**Backward compatibility:** When a stack is migrated server-side from Terraform vendor with `workflowTool=OPEN_TOFU` to native OpenTofu vendor, the provider maps fields back to `terraform_*` attributes to avoid drift. A warning is emitted suggesting the user update their config to use the `opentofu` block. This requires the `opentofu-backend` feature flag to be enabled on the account.

After migration to the native OpenTofu stack, the provider will be backward compatible:
```
$ tofu plan
(...)
No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so
no changes are needed.
╷
│ Warning: Stack uses native OpenTofu vendor but config has no `opentofu` block
│ 
│   with spacelift_stack.opentofu_legacy_test,
│   on main.tf line 37, in resource "spacelift_stack" "opentofu_legacy_test":
│   37: resource "spacelift_stack" "opentofu_legacy_test" {
│ 
│ This stack has been migrated to the native OpenTofu vendor. Consider replacing
│ `terraform_workflow_tool = "OPEN_TOFU"` with an `opentofu` block for full access to
│ OpenTofu-specific features.
╵
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

Fix [CU-869cwv8ar](https://app.clickup.com/t/2384866/869cwv8ar)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [x] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer