### PR TITLE
fix(stack): avoid unnecessary replacement when migrating to terragrunt

### DIFF
--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -45,19 +45,43 @@ func resourceStack() *schema.Resource {
 		},
 
 		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
-			oldUSM, newUSM := diff.GetChange("terragrunt.0.use_state_management")
-			if oldUSM.(bool) != newUSM.(bool) {
-				manageState := diff.Get("manage_state").(bool)
+			// Skip on initial resource creation — there is no old state.
+			if diff.Id() == "" {
+				return nil
+			}
 
-				// When switching between manage_state and terragrunt.use_state_management,
-				// the effective state management may not change (e.g. manage_state=true ->
-				// terragrunt.use_state_management=true). Only force replacement when the
-				// effective value actually changes.
-				oldEffective := oldUSM.(bool) || manageState
-				newEffective := newUSM.(bool) || manageState
-				if oldEffective != newEffective {
-					diff.ForceNew("terragrunt.0.use_state_management")
+			oldUSM, newUSM := diff.GetChange("terragrunt.0.use_state_management")
+			oldTGCount, newTGCount := diff.GetChange("terragrunt.#")
+			isMigration := oldTGCount.(int) != newTGCount.(int)
+
+			if isMigration {
+				// During vendor migration (adding/removing the terragrunt block),
+				// the API does not support changing state management.
+				// Block the plan if the effective value would change.
+				oldMS, newMS := diff.GetChange("manage_state")
+				var wasStateManaged, willBeStateManaged bool
+				if oldTGCount.(int) == 0 {
+					wasStateManaged = oldMS.(bool)
+					willBeStateManaged = newUSM.(bool)
+				} else {
+					wasStateManaged = oldUSM.(bool)
+					willBeStateManaged = newMS.(bool)
 				}
+				if wasStateManaged != willBeStateManaged {
+					return fmt.Errorf(
+						"cannot change state management during vendor migration "+
+							"(effective value would change from %t to %t); "+
+							"destroy the stack first with `terraform destroy`, then recreate it with the new configuration",
+						wasStateManaged, willBeStateManaged,
+					)
+				}
+				return nil
+			}
+
+			// Within an existing terragrunt block, any change to
+			// use_state_management requires replacement.
+			if oldUSM.(bool) != newUSM.(bool) {
+				diff.ForceNew("terragrunt.0.use_state_management")
 			}
 
 			return nil

--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -44,6 +44,25 @@ func resourceStack() *schema.Resource {
 			StateContext: resourceStackImport,
 		},
 
+		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
+			oldUSM, newUSM := diff.GetChange("terragrunt.0.use_state_management")
+			if oldUSM.(bool) != newUSM.(bool) {
+				manageState := diff.Get("manage_state").(bool)
+
+				// When switching between manage_state and terragrunt.use_state_management,
+				// the effective state management may not change (e.g. manage_state=true ->
+				// terragrunt.use_state_management=true). Only force replacement when the
+				// effective value actually changes.
+				oldEffective := oldUSM.(bool) || manageState
+				newEffective := newUSM.(bool) || manageState
+				if oldEffective != newEffective {
+					diff.ForceNew("terragrunt.0.use_state_management")
+				}
+			}
+
+			return nil
+		},
+
 		SchemaVersion: 1,
 
 		StateUpgraders: []schema.StateUpgrader{
@@ -685,7 +704,6 @@ func resourceStack() *schema.Resource {
 							Description: "Determines if Spacelift should manage state for this Terragrunt stack. Takes precedence over `manage_state`. Defaults to `false`.",
 							Optional:    true,
 							Default:     false,
-							ForceNew:    true,
 						},
 						"skip_replan_when_run_all": {
 							Type:        schema.TypeBool,

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -860,72 +860,215 @@ func TestStackResource(t *testing.T) {
 		})
 	})
 
-	t.Run("switching from non-terragrunt to terragrunt with use_state_management should not replace", func(t *testing.T) {
-		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
-		var stackID string
+	t.Run("vendor migration roundtrip preserves state management without replacement", func(t *testing.T) {
+		for _, stateManaged := range []bool{true, false} {
+			t.Run(fmt.Sprintf("state_managed=%t", stateManaged), func(t *testing.T) {
+				randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
-		testSteps(t, []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-				resource "spacelift_stack" "test" {
-					branch       = "master"
-					name         = "Provider test stack tg migration %s"
-					project_root = "root"
-					repository   = "demo"
-					manage_state = true
-					labels       = ["terragrunt"]
-				}
-			`, randomID),
-				Check: resource.ComposeTestCheckFunc(
-					Resource(
-						resourceName,
-						Attribute("manage_state", Equals("true")),
-					),
-					func(s *terraform.State) error {
-						rs, ok := s.RootModule().Resources[resourceName]
-						if !ok {
-							return fmt.Errorf("resource not found: %s", resourceName)
+				testSteps(t, []resource.TestStep{
+					{
+						Config: fmt.Sprintf(`
+						resource "spacelift_stack" "test" {
+							branch       = "master"
+							name         = "Provider test stack tg migr %s"
+							project_root = "root"
+							repository   = "demo"
+							manage_state = %t
+							labels       = ["terragrunt"]
 						}
-						stackID = rs.Primary.ID
-						return nil
+					`, randomID, stateManaged),
+						Check: Resource(
+							resourceName,
+							Attribute("manage_state", Equals(fmt.Sprintf("%t", stateManaged))),
+						),
 					},
-				),
-			},
-			{
-				Config: fmt.Sprintf(`
-				resource "spacelift_stack" "test" {
-					branch       = "master"
-					name         = "Provider test stack tg migration %s"
-					project_root = "root"
-					repository   = "demo"
-					manage_state = true
-					terragrunt {
-						terragrunt_version   = "0.45.0"
-						terraform_version    = "1.4.0"
-						use_run_all          = false
-						use_state_management = true
+					{
+						Config: fmt.Sprintf(`
+						resource "spacelift_stack" "test" {
+							branch       = "master"
+							name         = "Provider test stack tg migr %s"
+							project_root = "root"
+							repository   = "demo"
+							manage_state = %t
+							terragrunt {
+								terragrunt_version   = "0.45.0"
+								terraform_version    = "1.4.0"
+								use_run_all          = false
+								use_state_management = %t
+							}
+						}
+					`, randomID, stateManaged, stateManaged),
+						Check: Resource(
+							resourceName,
+							Attribute("terragrunt.0.use_state_management", Equals(fmt.Sprintf("%t", stateManaged))),
+						),
+					},
+					{
+						Config: fmt.Sprintf(`
+						resource "spacelift_stack" "test" {
+							branch       = "master"
+							name         = "Provider test stack tg migr %s"
+							project_root = "root"
+							repository   = "demo"
+							manage_state = %t
+						}
+					`, randomID, stateManaged),
+						Check: Resource(
+							resourceName,
+							Attribute("manage_state", Equals(fmt.Sprintf("%t", stateManaged))),
+						),
+					},
+				})
+			})
+		}
+	})
+
+	t.Run("vendor migration rejects state management change", func(t *testing.T) {
+		t.Run("forward manage_state=true to use_state_management=false", func(t *testing.T) {
+			randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+			testSteps(t, []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+					resource "spacelift_stack" "test" {
+						branch       = "master"
+						name         = "Provider test stack tg migr err %s"
+						project_root = "root"
+						repository   = "demo"
+						manage_state = true
+						labels       = ["terragrunt"]
 					}
-				}
-			`, randomID),
-				Check: resource.ComposeTestCheckFunc(
-					Resource(
-						resourceName,
-						Attribute("terragrunt.0.use_state_management", Equals("true")),
-						Attribute("manage_state", Equals("true")),
-					),
-					func(s *terraform.State) error {
-						rs, ok := s.RootModule().Resources[resourceName]
-						if !ok {
-							return fmt.Errorf("resource not found: %s", resourceName)
+				`, randomID),
+				},
+				{
+					Config: fmt.Sprintf(`
+					resource "spacelift_stack" "test" {
+						branch       = "master"
+						name         = "Provider test stack tg migr err %s"
+						project_root = "root"
+						repository   = "demo"
+						manage_state = true
+						terragrunt {
+							terragrunt_version   = "0.45.0"
+							terraform_version    = "1.4.0"
+							use_run_all          = false
+							use_state_management = false
 						}
-						if rs.Primary.ID != stackID {
-							return fmt.Errorf("stack was replaced (ID changed from %s to %s), expected in-place update", stackID, rs.Primary.ID)
+					}
+				`, randomID),
+					ExpectError: regexp.MustCompile(`cannot change state management during vendor migration`),
+				},
+			})
+		})
+
+		t.Run("forward manage_state=false to use_state_management=true", func(t *testing.T) {
+			randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+			testSteps(t, []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+					resource "spacelift_stack" "test" {
+						branch       = "master"
+						name         = "Provider test stack tg migr err2 %s"
+						project_root = "root"
+						repository   = "demo"
+						manage_state = false
+						labels       = ["terragrunt"]
+					}
+				`, randomID),
+				},
+				{
+					Config: fmt.Sprintf(`
+					resource "spacelift_stack" "test" {
+						branch       = "master"
+						name         = "Provider test stack tg migr err2 %s"
+						project_root = "root"
+						repository   = "demo"
+						manage_state = false
+						terragrunt {
+							terragrunt_version   = "0.45.0"
+							terraform_version    = "1.4.0"
+							use_run_all          = false
+							use_state_management = true
 						}
-						return nil
-					},
-				),
-			},
+					}
+				`, randomID),
+					ExpectError: regexp.MustCompile(`cannot change state management during vendor migration`),
+				},
+			})
+		})
+
+		t.Run("reverse use_state_management=true to manage_state=false", func(t *testing.T) {
+			randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+			testSteps(t, []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+					resource "spacelift_stack" "test" {
+						branch       = "master"
+						name         = "Provider test stack tg migr err3 %s"
+						project_root = "root"
+						repository   = "demo"
+						manage_state = false
+						terragrunt {
+							terragrunt_version   = "0.45.0"
+							terraform_version    = "1.4.0"
+							use_run_all          = false
+							use_state_management = true
+						}
+					}
+				`, randomID),
+				},
+				{
+					Config: fmt.Sprintf(`
+					resource "spacelift_stack" "test" {
+						branch       = "master"
+						name         = "Provider test stack tg migr err3 %s"
+						project_root = "root"
+						repository   = "demo"
+						manage_state = false
+					}
+				`, randomID),
+					ExpectError: regexp.MustCompile(`cannot change state management during vendor migration`),
+				},
+			})
+		})
+
+		t.Run("reverse use_state_management=false to manage_state=true", func(t *testing.T) {
+			randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+			testSteps(t, []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+					resource "spacelift_stack" "test" {
+						branch       = "master"
+						name         = "Provider test stack tg migr err4 %s"
+						project_root = "root"
+						repository   = "demo"
+						manage_state = false
+						terragrunt {
+							terragrunt_version   = "0.45.0"
+							terraform_version    = "1.4.0"
+							use_run_all          = false
+							use_state_management = false
+						}
+					}
+				`, randomID),
+				},
+				{
+					Config: fmt.Sprintf(`
+					resource "spacelift_stack" "test" {
+						branch       = "master"
+						name         = "Provider test stack tg migr err4 %s"
+						project_root = "root"
+						repository   = "demo"
+						manage_state = true
+					}
+				`, randomID),
+					ExpectError: regexp.MustCompile(`cannot change state management during vendor migration`),
+				},
+			})
 		})
 	})
 

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -860,6 +860,50 @@ func TestStackResource(t *testing.T) {
 		})
 	})
 
+	t.Run("switching from non-terragrunt to terragrunt with use_state_management should not replace", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch       = "master"
+					name         = "Provider test stack tg migration %s"
+					project_root = "root"
+					repository   = "demo"
+					manage_state = true
+				}
+			`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("manage_state", Equals("true")),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch       = "master"
+					name         = "Provider test stack tg migration %s"
+					project_root = "root"
+					repository   = "demo"
+					manage_state = true
+					terragrunt {
+						terragrunt_version   = "0.45.0"
+						terraform_version    = "1.4.0"
+						use_run_all          = false
+						use_state_management = true
+					}
+				}
+			`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("terragrunt.0.use_state_management", Equals("true")),
+					Attribute("manage_state", Equals("true")),
+				),
+			},
+		})
+	})
+
 	t.Run("with Terragrunt skip_replan_when_run_all", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -352,7 +352,7 @@ func TestStackResource(t *testing.T) {
 				terraform_version            = "1.0.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1"
 			}
 		`, randomID),
-			ExpectError: regexp.MustCompile(`could not create stack: stack has 1 error: terraform: invalid Terraform version constraints: improper constraint: 1.0.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1`),
+			ExpectError: regexp.MustCompile(`could not create stack: stack has 1 error: terraform: invalid Terraform version constraints: improper constraint: "?1.0.1.1.1.1.1.1.1.1.1.1.1.1.1.1.1"?`),
 		}})
 	})
 
@@ -859,7 +859,6 @@ func TestStackResource(t *testing.T) {
 			},
 		})
 	})
-
 
 	t.Run("vendor migration roundtrip preserves state management without replacement", func(t *testing.T) {
 		for _, stateManaged := range []bool{true, false} {

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -863,6 +863,8 @@ func TestStackResource(t *testing.T) {
 	t.Run("switching from non-terragrunt to terragrunt with use_state_management should not replace", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
+		var stackID string
+
 		testSteps(t, []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -872,11 +874,22 @@ func TestStackResource(t *testing.T) {
 					project_root = "root"
 					repository   = "demo"
 					manage_state = true
+					labels       = ["terragrunt"]
 				}
 			`, randomID),
-				Check: Resource(
-					resourceName,
-					Attribute("manage_state", Equals("true")),
+				Check: resource.ComposeTestCheckFunc(
+					Resource(
+						resourceName,
+						Attribute("manage_state", Equals("true")),
+					),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("resource not found: %s", resourceName)
+						}
+						stackID = rs.Primary.ID
+						return nil
+					},
 				),
 			},
 			{
@@ -895,10 +908,22 @@ func TestStackResource(t *testing.T) {
 					}
 				}
 			`, randomID),
-				Check: Resource(
-					resourceName,
-					Attribute("terragrunt.0.use_state_management", Equals("true")),
-					Attribute("manage_state", Equals("true")),
+				Check: resource.ComposeTestCheckFunc(
+					Resource(
+						resourceName,
+						Attribute("terragrunt.0.use_state_management", Equals("true")),
+						Attribute("manage_state", Equals("true")),
+					),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[resourceName]
+						if !ok {
+							return fmt.Errorf("resource not found: %s", resourceName)
+						}
+						if rs.Primary.ID != stackID {
+							return fmt.Errorf("stack was replaced (ID changed from %s to %s), expected in-place update", stackID, rs.Primary.ID)
+						}
+						return nil
+					},
 				),
 			},
 		})


### PR DESCRIPTION
## Description of the change

When switching a stack from non-terragrunt (`manage_state=true`) to terragrunt (`use_state_management=true`), the provider was forcing resource replacement even though the effective state management didn't change. This happened because `terragrunt.use_state_management` had `ForceNew: true` set unconditionally in the schema.

The fix removes the static `ForceNew` from `use_state_management` and adds a `CustomizeDiff` that only forces replacement when the effective state management value (`manage_state || use_state_management`) actually changes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer