### PR TITLE
fix(stack): sync manage_state with terragrunt.use_state_management

### DIFF
--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -27,6 +27,101 @@ func resourceStackResourceV0() *schema.Resource {
 	}
 }
 
+func stackCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+	if err := syncManageStateWithTerragrunt(diff); err != nil {
+		return err
+	}
+	if err := forceNewOnUseStateManagementChange(diff); err != nil {
+		return err
+	}
+	return rejectStateChangeOnVendorMigration(diff)
+}
+
+// syncManageStateWithTerragrunt ensures manage_state reflects
+// use_state_management when a terragrunt block is present, and
+// defaults to true when neither terragrunt nor manage_state are set.
+func syncManageStateWithTerragrunt(diff *schema.ResourceDiff) error {
+	_, newTGCount := diff.GetChange("terragrunt.#")
+	rawConfig := diff.GetRawConfig()
+
+	if newTGCount.(int) > 0 {
+		usm := diff.Get("terragrunt.0.use_state_management").(bool)
+
+		msAttr := rawConfig.GetAttr("manage_state")
+		if msAttr.IsNull() {
+			// if manage_state computes to different value than previously,
+			// ForceNew will be triggered and the stack will be recreated
+			// with the new value.
+			return diff.SetNew("manage_state", usm)
+		}
+
+		if msAttr.True() == usm {
+			return nil
+		}
+
+		return fmt.Errorf(
+			"manage_state (%t) conflicts with terragrunt.use_state_management (%t); "+
+				"when using a terragrunt block, remove manage_state from your configuration "+
+				"and use terragrunt.use_state_management instead",
+			msAttr.True(), usm,
+		)
+	}
+
+	// by default, manage_state should be true (just like it was before terragrunt migration was introduced - Default: true)
+	if rawConfig.GetAttr("manage_state").IsNull() {
+		return diff.SetNew("manage_state", true)
+	}
+
+	return nil
+}
+
+// forceNewOnUseStateManagementChange marks use_state_management as ForceNew
+// when its value changes within an existing terragrunt block (i.e. not during
+// a vendor migration where the block is being added or removed).
+func forceNewOnUseStateManagementChange(diff *schema.ResourceDiff) error {
+	if diff.Id() == "" {
+		return nil // it means we are creating a new stack, so no need to check for use_state_management changes
+	}
+
+	oldTGCount, newTGCount := diff.GetChange("terragrunt.#")
+	if oldTGCount.(int) == 0 || newTGCount.(int) == 0 {
+		return nil // it means we are adding or removing the terragrunt block, which is handled by rejectStateChangeOnVendorMigration
+	}
+
+	oldUSM, newUSM := diff.GetChange("terragrunt.0.use_state_management")
+	if oldUSM.(bool) != newUSM.(bool) {
+		diff.ForceNew("terragrunt.0.use_state_management")
+	}
+
+	return nil
+}
+
+// rejectStateChangeOnVendorMigration blocks adding or removing the terragrunt
+// block when the effective state-management value would change, because the
+// API does not support that in a single operation.
+func rejectStateChangeOnVendorMigration(diff *schema.ResourceDiff) error {
+	if diff.Id() == "" {
+		return nil // it means we are creating a new stack, so no need to check for vendor migration
+	}
+
+	oldTGCount, newTGCount := diff.GetChange("terragrunt.#")
+	if oldTGCount.(int) == newTGCount.(int) {
+		return nil // it means we are not adding or removing the terragrunt block, so no need to check for vendor migration
+	}
+
+	oldMS, newMS := diff.GetChange("manage_state")
+	if oldMS.(bool) != newMS.(bool) {
+		return fmt.Errorf(
+			"cannot change state management during vendor migration "+
+				"(effective value would change from %t to %t); "+
+				"destroy the stack first with `terraform destroy`, then recreate it with the new configuration",
+			oldMS.(bool), newMS.(bool),
+		)
+	}
+
+	return nil
+}
+
 func resourceStack() *schema.Resource {
 	return &schema.Resource{
 		Description: "" +
@@ -44,48 +139,7 @@ func resourceStack() *schema.Resource {
 			StateContext: resourceStackImport,
 		},
 
-		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
-			// Skip on initial resource creation — there is no old state.
-			if diff.Id() == "" {
-				return nil
-			}
-
-			oldUSM, newUSM := diff.GetChange("terragrunt.0.use_state_management")
-			oldTGCount, newTGCount := diff.GetChange("terragrunt.#")
-			isMigration := oldTGCount.(int) != newTGCount.(int)
-
-			if isMigration {
-				// During vendor migration (adding/removing the terragrunt block),
-				// the API does not support changing state management.
-				// Block the plan if the effective value would change.
-				oldMS, newMS := diff.GetChange("manage_state")
-				var wasStateManaged, willBeStateManaged bool
-				if oldTGCount.(int) == 0 {
-					wasStateManaged = oldMS.(bool)
-					willBeStateManaged = newUSM.(bool)
-				} else {
-					wasStateManaged = oldUSM.(bool)
-					willBeStateManaged = newMS.(bool)
-				}
-				if wasStateManaged != willBeStateManaged {
-					return fmt.Errorf(
-						"cannot change state management during vendor migration "+
-							"(effective value would change from %t to %t); "+
-							"destroy the stack first with `terraform destroy`, then recreate it with the new configuration",
-						wasStateManaged, willBeStateManaged,
-					)
-				}
-				return nil
-			}
-
-			// Within an existing terragrunt block, any change to
-			// use_state_management requires replacement.
-			if oldUSM.(bool) != newUSM.(bool) {
-				diff.ForceNew("terragrunt.0.use_state_management")
-			}
-
-			return nil
-		},
+		CustomizeDiff: schema.CustomizeDiffFunc(stackCustomizeDiff),
 
 		SchemaVersion: 1,
 
@@ -542,9 +596,9 @@ func resourceStack() *schema.Resource {
 			},
 			"manage_state": {
 				Type:        schema.TypeBool,
-				Description: "Determines if Spacelift should manage state for this stack. Defaults to `true`.",
+				Description: "Determines if Spacelift should manage state for this stack. Defaults to `true`. When a `terragrunt` block is present, this is automatically set to match `use_state_management`.",
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				ForceNew:    true,
 			},
 			"name": {

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -787,7 +787,7 @@ func TestStackResource(t *testing.T) {
 		})
 	})
 
-	t.Run("with Terragrunt use_state_management", func(t *testing.T) {
+	t.Run("with Terragrunt use_state_management=false syncs manage_state", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
 		testSteps(t, []resource.TestStep{
@@ -795,14 +795,13 @@ func TestStackResource(t *testing.T) {
 				Config: fmt.Sprintf(`
 				resource "spacelift_stack" "test" {
 					branch       = "master"
-					name         = "Provider test stack terragrunt state %s"
+					name         = "Provider test stack tg usm false %s"
 					project_root = "root"
 					repository   = "demo"
-					manage_state = false
 					terragrunt {
-						terragrunt_version = "0.45.0"
-						terraform_version  = "1.4.0"
-						use_run_all        = false
+						terragrunt_version   = "0.45.0"
+						terraform_version    = "1.4.0"
+						use_run_all          = false
 						use_state_management = false
 					}
 				}
@@ -813,40 +812,24 @@ func TestStackResource(t *testing.T) {
 					Attribute("manage_state", Equals("false")),
 				),
 			},
+		})
+	})
+
+	t.Run("with Terragrunt use_state_management=true syncs manage_state", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
 				resource "spacelift_stack" "test" {
 					branch       = "master"
-					name         = "Provider test stack terragrunt state %s"
+					name         = "Provider test stack tg usm true %s"
 					project_root = "root"
 					repository   = "demo"
-					manage_state = false
 					terragrunt {
-						terragrunt_version = "0.45.0"
-						terraform_version  = "1.4.0"
-						use_run_all        = false
-						use_state_management = true
-					}
-				}
-			`, randomID),
-				Check: Resource(
-					resourceName,
-					Attribute("terragrunt.0.use_state_management", Equals("true")),
-					Attribute("manage_state", Equals("false")),
-				),
-			},
-			{
-				Config: fmt.Sprintf(`
-				resource "spacelift_stack" "test" {
-					branch       = "master"
-					name         = "Provider test stack terragrunt state %s"
-					project_root = "root"
-					repository   = "demo"
-					manage_state = true
-					terragrunt {
-						terragrunt_version = "0.45.0"
-						terraform_version  = "1.4.0"
-						use_run_all        = false
+						terragrunt_version   = "0.45.0"
+						terraform_version    = "1.4.0"
+						use_run_all          = false
 						use_state_management = true
 					}
 				}
@@ -889,7 +872,6 @@ func TestStackResource(t *testing.T) {
 							name         = "Provider test stack tg migr %s"
 							project_root = "root"
 							repository   = "demo"
-							manage_state = %t
 							terragrunt {
 								terragrunt_version   = "0.45.0"
 								terraform_version    = "1.4.0"
@@ -897,10 +879,11 @@ func TestStackResource(t *testing.T) {
 								use_state_management = %t
 							}
 						}
-					`, randomID, stateManaged, stateManaged),
+					`, randomID, stateManaged),
 						Check: Resource(
 							resourceName,
 							Attribute("terragrunt.0.use_state_management", Equals(fmt.Sprintf("%t", stateManaged))),
+							Attribute("manage_state", Equals(fmt.Sprintf("%t", stateManaged))),
 						),
 					},
 					{
@@ -921,6 +904,150 @@ func TestStackResource(t *testing.T) {
 				})
 			})
 		}
+	})
+
+	t.Run("migration with manage_state omitted inherits from use_state_management", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch       = "master"
+					name         = "Provider test stack tg ms omit %s"
+					project_root = "root"
+					repository   = "demo"
+					manage_state = false
+					labels       = ["terragrunt"]
+				}
+			`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("manage_state", Equals("false")),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch       = "master"
+					name         = "Provider test stack tg ms omit %s"
+					project_root = "root"
+					repository   = "demo"
+					terragrunt {
+						terragrunt_version   = "0.45.0"
+						terraform_version    = "1.4.0"
+						use_run_all          = false
+						use_state_management = false
+					}
+				}
+			`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("manage_state", Equals("false")),
+					Attribute("terragrunt.0.use_state_management", Equals("false")),
+				),
+			},
+		})
+	})
+
+	t.Run("manage_state conflicts with use_state_management on create", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch       = "master"
+					name         = "Provider test stack tg conflict %s"
+					project_root = "root"
+					repository   = "demo"
+					manage_state = true
+					terragrunt {
+						terragrunt_version   = "0.45.0"
+						terraform_version    = "1.4.0"
+						use_run_all          = false
+						use_state_management = false
+					}
+				}
+			`, randomID),
+				ExpectError: regexp.MustCompile(`manage_state \(true\) conflicts with terragrunt.use_state_management \(false\)`),
+			},
+		})
+	})
+
+	t.Run("manage_state conflicts with use_state_management on update", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch       = "master"
+					name         = "Provider test stack tg conflict upd %s"
+					project_root = "root"
+					repository   = "demo"
+					terragrunt {
+						terragrunt_version   = "0.45.0"
+						terraform_version    = "1.4.0"
+						use_run_all          = false
+						use_state_management = true
+					}
+				}
+			`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("manage_state", Equals("true")),
+					Attribute("terragrunt.0.use_state_management", Equals("true")),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch       = "master"
+					name         = "Provider test stack tg conflict upd %s"
+					project_root = "root"
+					repository   = "demo"
+					manage_state = false
+					terragrunt {
+						terragrunt_version   = "0.45.0"
+						terraform_version    = "1.4.0"
+						use_run_all          = false
+						use_state_management = true
+					}
+				}
+			`, randomID),
+				ExpectError: regexp.MustCompile(`manage_state \(false\) conflicts with terragrunt.use_state_management \(true\)`),
+			},
+		})
+	})
+
+	t.Run("manage_state consistent with use_state_management is allowed", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "spacelift_stack" "test" {
+					branch       = "master"
+					name         = "Provider test stack tg consistent %s"
+					project_root = "root"
+					repository   = "demo"
+					manage_state = false
+					terragrunt {
+						terragrunt_version   = "0.45.0"
+						terraform_version    = "1.4.0"
+						use_run_all          = false
+						use_state_management = false
+					}
+				}
+			`, randomID),
+				Check: Resource(
+					resourceName,
+					Attribute("manage_state", Equals("false")),
+					Attribute("terragrunt.0.use_state_management", Equals("false")),
+				),
+			},
+		})
 	})
 
 	t.Run("vendor migration rejects state management change", func(t *testing.T) {
@@ -947,7 +1074,6 @@ func TestStackResource(t *testing.T) {
 						name         = "Provider test stack tg migr err %s"
 						project_root = "root"
 						repository   = "demo"
-						manage_state = true
 						terragrunt {
 							terragrunt_version   = "0.45.0"
 							terraform_version    = "1.4.0"
@@ -984,7 +1110,6 @@ func TestStackResource(t *testing.T) {
 						name         = "Provider test stack tg migr err2 %s"
 						project_root = "root"
 						repository   = "demo"
-						manage_state = false
 						terragrunt {
 							terragrunt_version   = "0.45.0"
 							terraform_version    = "1.4.0"
@@ -1009,7 +1134,6 @@ func TestStackResource(t *testing.T) {
 						name         = "Provider test stack tg migr err3 %s"
 						project_root = "root"
 						repository   = "demo"
-						manage_state = false
 						terragrunt {
 							terragrunt_version   = "0.45.0"
 							terraform_version    = "1.4.0"
@@ -1045,7 +1169,6 @@ func TestStackResource(t *testing.T) {
 						name         = "Provider test stack tg migr err4 %s"
 						project_root = "root"
 						repository   = "demo"
-						manage_state = false
 						terragrunt {
 							terragrunt_version   = "0.45.0"
 							terraform_version    = "1.4.0"
@@ -1383,7 +1506,6 @@ func TestStackResource(t *testing.T) {
 					name                           = "Provider test external access %s"
 					project_root                   = "root"
 					repository                     = "demo"
-					manage_state                   = false
 					terraform_external_state_access = true
 					terragrunt {
 						terragrunt_version      = "0.45.0"
@@ -1396,7 +1518,7 @@ func TestStackResource(t *testing.T) {
 				Check: Resource(
 					resourceName,
 					Attribute("terraform_external_state_access", Equals("true")),
-					Attribute("manage_state", Equals("false")),
+					Attribute("manage_state", Equals("true")),
 					Attribute("terragrunt.0.use_state_management", Equals("true")),
 				),
 			},


### PR DESCRIPTION
## Description of the change

Reduces inconsistency between `manage_state` and `terragrunt.use_state_management` by making `manage_state` automatically reflect `use_state_management` when a terragrunt block is present.

Key changes:
- **Conflict validation**: When `manage_state` is explicitly set in config alongside a `terragrunt` block and differs from `use_state_management`, an error is returned with a clear message telling the user to remove `manage_state` and use `use_state_management` instead. This prevents silent override of user-defined configuration and applies on both create and update.
- **Auto-sync**: When `manage_state` is not set in config, it is automatically computed from `use_state_management`.
- **Explicit ForceNew**: Restored `diff.ForceNew("terragrunt.0.use_state_management")` as a safety net alongside the implicit ForceNew from `manage_state` schema.
- **Refactored CustomizeDiff**: Extracted into three named functions (`syncManageStateWithTerragrunt`, `forceNewOnUseStateManagementChange`, `rejectStateChangeOnVendorMigration`) for readability.
- **Schema change**: `manage_state` changed from `Default: true` to `Computed: true` to support provider-driven values.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Reduces drift between `manage_state` and `terragrunt.use_state_management`

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer