### PR TITLE
fix: template deploy without input

### DIFF
--- a/spacelift/internal/structs/template_deployment.go
+++ b/spacelift/internal/structs/template_deployment.go
@@ -53,7 +53,7 @@ type TemplateDeploymentCreateInput struct {
 	Space       graphql.ID                          `json:"space"`
 	Name        graphql.String                      `json:"name"`
 	Description *graphql.String                     `json:"description,omitempty"`
-	Inputs      []TemplateDeploymentCreateInputPair `json:"inputs,omitempty"`
+	Inputs      []TemplateDeploymentCreateInputPair `json:"inputs"`
 }
 
 // TemplateDeploymentUpdateInput represents the input for updating a deployment.
@@ -61,5 +61,5 @@ type TemplateDeploymentUpdateInput struct {
 	VersionID   *graphql.ID                         `json:"versionId,omitempty"`
 	Name        *graphql.String                     `json:"name,omitempty"`
 	Description *graphql.String                     `json:"description,omitempty"`
-	Inputs      []TemplateDeploymentCreateInputPair `json:"inputs,omitempty"`
+	Inputs      []TemplateDeploymentCreateInputPair `json:"inputs"`
 }

--- a/spacelift/resource_template_deployment_test.go
+++ b/spacelift/resource_template_deployment_test.go
@@ -199,4 +199,60 @@ EOT
 			},
 		})
 	})
+
+	t.Run("Creates a template deployment without inputs", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+		initialVersion := "1.0.0"
+
+		config := func(name, description, version, envName, secret string) string {
+			return fmt.Sprintf(`
+				resource "spacelift_template" "test" {
+					name  = "test-template-%[1]s"
+					space = "root"
+				}
+
+				resource "spacelift_template_version" "version" {
+					template_id    = spacelift_template.test.id
+					version_number = "%[2]s"
+					state          = "PUBLISHED"
+					template       = <<-EOT
+stacks:
+- name: test-stack-noinput-%[1]s
+  key: test
+  autodeploy: true
+  vcs:
+    reference:
+      value: master
+      type: branch
+    repository: terraform-bacon-tasty
+    provider: GITHUB
+  vendor:
+    terraform:
+      manage_state: true
+      version: "1.5.0"
+EOT
+				}
+
+				resource "spacelift_template_deployment" "test" {
+					template_version_id = spacelift_template_version.%[3]s.id
+					space               = "root"
+					name                = "%[4]s"
+					description         = "%[5]s"
+				}
+
+				data "spacelift_stack" "test" {
+				  stack_id = spacelift_template_deployment.test.stacks[0].id
+				}
+			`, randomID, initialVersion, version, name, description, envName, secret)
+		}
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: config("deployment-"+randomID, "test description", "version", "production", "foobar"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(deploymentResource, "id", fmt.Sprintf("test-template-%[1]s/deployment-%[1]s", randomID)),
+				),
+			},
+		})
+	})
 }


### PR DESCRIPTION
## Description of the change

This make sure we can deploy a template version without any inputs. Follow up of
https://github.com/spacelift-io/terraform-provider-spacelift/pull/744

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
