### PR TITLE
docs: reference GraphQL Action enum in spacelift_role description

### DIFF
--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -4,12 +4,15 @@ page_title: "spacelift_role Resource - terraform-provider-spacelift"
 subcategory: ""
 description: |-
   spacelift_role represents a Spacelift role - a collection of permissions that can be assigned to IdP groups or API keys to control access to Spacelift resources and operations.
+  The available actions that can be performed are defined in Spacelift's GraphQL API Action enum (e.g. http://graphdoc.io/preview/enum/Action?endpoint=https://demo.app.spacelift.io/graphql).
   Note: you must have admin access to the root Space in order to create or mutate roles.
 ---
 
 # spacelift_role (Resource)
 
 `spacelift_role` represents a Spacelift **role** - a collection of permissions that can be assigned to IdP groups or API keys to control access to Spacelift resources and operations.
+
+The available actions that can be performed are defined in Spacelift's GraphQL API `Action` enum (e.g. http://graphdoc.io/preview/enum/Action?endpoint=https://demo.app.spacelift.io/graphql).
 
 **Note:** you must have admin access to the `root` Space in order to create or mutate roles.
 

--- a/spacelift/resource_role.go
+++ b/spacelift/resource_role.go
@@ -24,6 +24,8 @@ func resourceRole() *schema.Resource {
 			"`spacelift_role` represents a Spacelift **role** - " +
 			"a collection of permissions that can be assigned to IdP groups or API keys " +
 			"to control access to Spacelift resources and operations.\n\n" +
+			"The available actions that can be performed are defined in Spacelift's GraphQL API `Action` enum " +
+			"(e.g. http://graphdoc.io/preview/enum/Action?endpoint=https://demo.app.spacelift.io/graphql).\n\n" +
 			"**Note:** you must have admin access to the `root` Space in order to create or mutate roles.",
 
 		CreateContext: resourceRoleCreate,


### PR DESCRIPTION
Adds a sentence to the `spacelift_role` resource description pointing users to Spacelift's GraphQL API `Action` enum, which defines the available actions a role can perform.