### PR TITLE
fix(stack): wait for async deletion to complete

### DIFF
--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -911,10 +911,21 @@ func resourceStackDelete(ctx context.Context, d *schema.ResourceData, meta any) 
 		DeleteStack *structs.Stack `graphql:"stackDelete(id: $id)"`
 	}
 
-	variables := map[string]any{"id": toID(d.Id())}
+	id := d.Id()
+	variables := map[string]any{"id": toID(id)}
 
 	if err := meta.(*internal.Client).Mutate(ctx, "StackDelete", &mutation, variables); err != nil {
 		return diag.Errorf("could not delete stack: %v", internal.FromSpaceliftError(err))
+	}
+
+	// stackDelete removes the stack asynchronously, so the stack (and its
+	// references to e.g. its space) can still exist when this returns. Wait
+	// until the backend has actually dropped it before reporting success,
+	// otherwise dependent resources like the parent space fail to delete.
+	if mutation.DeleteStack != nil && mutation.DeleteStack.Deleting {
+		if diagnostics := waitForDestroy(ctx, meta.(*internal.Client), id); diagnostics.HasError() {
+			return diagnostics
+		}
 	}
 
 	d.SetId("")

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -2397,3 +2397,37 @@ func getConfig(vendorConfig string) string {
 				}
 			`, randomID, vendorConfig)
 }
+
+func TestStackResourceInSpaceDestroy(t *testing.T) {
+	const resourceName = "spacelift_stack.test"
+
+	t.Run("stack in a managed space destroys in order", func(t *testing.T) {
+		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+
+		config := fmt.Sprintf(`
+			resource "spacelift_space" "test" {
+				name             = "Stack space %s"
+				parent_space_id  = "root"
+				inherit_entities = true
+			}
+
+			resource "spacelift_stack" "test" {
+				branch     = "master"
+				repository = "demo"
+				name       = "Stack in space %s"
+				space_id   = spacelift_space.test.id
+			}
+		`, randomID, randomID)
+
+		testSteps(t, []resource.TestStep{
+			{
+				Config: config,
+				Check: Resource(
+					resourceName,
+					Attribute("id", StartsWith("stack-in-space-")),
+					Attribute("space_id", StartsWith("stack-space-")),
+				),
+			},
+		})
+	})
+}


### PR DESCRIPTION
Fix an intermittent error when destroying a stack together with its parent space in one run, caused by the delete handler returning before the backend had dropped the stack.

Poll until the backend reports the stack gone before returning, instead of returning as soon as the stack deletion mutation is accepted.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Pull Request is no longer marked as "draft"
- [x] Reviewers have been assigned
- [x] Changes have been reviewed by at least one other engineer
