### PR TITLE
fix(stack): add terraform_smart_sanitization to terragrunt ConflictsWith

### DIFF
--- a/spacelift/resource_stack.go
+++ b/spacelift/resource_stack.go
@@ -691,7 +691,7 @@ func resourceStack() *schema.Resource {
 			},
 			"terragrunt": {
 				Type:          schema.TypeList,
-				ConflictsWith: []string{"ansible", "cloudformation", "kubernetes", "pulumi", "terraform_version", "terraform_workflow_tool", "terraform_workspace"},
+				ConflictsWith: []string{"ansible", "cloudformation", "kubernetes", "pulumi", "terraform_smart_sanitization", "terraform_version", "terraform_workflow_tool", "terraform_workspace"},
 				Description:   "Terragrunt-specific configuration. Presence means this Stack is an Terragrunt Stack.",
 				Optional:      true,
 				MaxItems:      1,


### PR DESCRIPTION
## Description of the change

Add `terraform_smart_sanitization` to the `terragrunt` block's `ConflictsWith` list in the stack resource schema. This prevents users from setting both `terraform_smart_sanitization` (top-level, for Terraform stacks) and `terragrunt.use_smart_sanitization` (nested, for Terragrunt stacks) at the same time.

Follows the same pattern as `terraform_version`, `terraform_workflow_tool`, and `terraform_workspace` which already conflict with the `terragrunt` block.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

https://spacelift-io.slack.com/archives/C0B2M8PP38U/p1783350974838729?thread_ts=1781282628.130399&cid=C0B2M8PP38U

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [x] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [x] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer