### PR TITLE
test: make acceptance tests genuinely parallel

### DIFF
--- a/spacelift/data_aws_integration_attachment_external_id_test.go
+++ b/spacelift/data_aws_integration_attachment_external_id_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAWSIntegrationAttachmentExternalIDData(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "data.spacelift_aws_integration_attachment_external_id.test"
 
 	t.Run("with a stack", func(t *testing.T) {

--- a/spacelift/data_aws_integration_attachment_test.go
+++ b/spacelift/data_aws_integration_attachment_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAWSIntegrationAttachmentData(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "data.spacelift_aws_integration_attachment.test"
 
 	t.Run("with a stack", func(t *testing.T) {

--- a/spacelift/data_aws_integration_test.go
+++ b/spacelift/data_aws_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAWSIntegrationData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("without generating AWS creds in the worker", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		testSteps(t, []resource.TestStep{{
@@ -135,6 +137,8 @@ func TestAWSIntegrationData(t *testing.T) {
 }
 
 func TestAWSIntegrationDataSpace(t *testing.T) {
+	t.Parallel()
+
 	t.Run("without generating AWS creds in the worker", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		testSteps(t, []resource.TestStep{{
@@ -199,6 +203,8 @@ func TestAWSIntegrationDataSpace(t *testing.T) {
 }
 
 func TestAWSIntegrationDataRegion(t *testing.T) {
+	t.Parallel()
+
 	t.Run("without region specified", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		testSteps(t, []resource.TestStep{{
@@ -278,6 +284,8 @@ func TestAWSIntegrationDataRegion(t *testing.T) {
 }
 
 func TestAWSIntegrationDataTagAssumeRole(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with tag_assume_role disabled", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		testSteps(t, []resource.TestStep{{

--- a/spacelift/data_aws_role_test.go
+++ b/spacelift/data_aws_role_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAWSRoleData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with a stack", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_azure_devops_integration_test.go
+++ b/spacelift/data_azure_devops_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAzureDevOpsIntegrationData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("without the id specified", func(t *testing.T) {
 		cfg := testConfig.SourceCode.AzureDevOps.Default
 

--- a/spacelift/data_azure_integration_attachment_test.go
+++ b/spacelift/data_azure_integration_attachment_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAzureIntegrationAttachmentData(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "data.spacelift_azure_integration_attachment.test"
 
 	t.Run("with a stack", func(t *testing.T) {

--- a/spacelift/data_azure_integration_test.go
+++ b/spacelift/data_azure_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAzureIntegrationData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("when looking up integration by ID", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_azure_integrations_test.go
+++ b/spacelift/data_azure_integrations_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestAzureIntegrationsData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("when looking up integrations", func(t *testing.T) {
 		subId1 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 		subId2 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)

--- a/spacelift/data_bitbucket_cloud_integration_test.go
+++ b/spacelift/data_bitbucket_cloud_integration_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestBitbucketCloudIntegrationData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("without the id specified", func(t *testing.T) {
 		cfg := testConfig.SourceCode.BitbucketCloud.Default
 		testSteps(t, []resource.TestStep{

--- a/spacelift/data_bitbucket_datacenter_integration_test.go
+++ b/spacelift/data_bitbucket_datacenter_integration_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestBitbucketDataCenterIntegrationData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("without the id specified", func(t *testing.T) {
 		cfg := testConfig.SourceCode.BitbucketDatacenter.Default
 		testSteps(t, []resource.TestStep{{

--- a/spacelift/data_context_attachment_test.go
+++ b/spacelift/data_context_attachment_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestContextAttachmentData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with a stack", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_context_test.go
+++ b/spacelift/data_context_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestContextData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("retrieves context data without an error", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
@@ -70,6 +72,8 @@ func TestContextData(t *testing.T) {
 }
 
 func TestContextDataSpace(t *testing.T) {
+	t.Parallel()
+
 	t.Run("retrieves context data without an error", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_drift_detection_test.go
+++ b/spacelift/data_drift_detection_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestDriftDetectionData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with a stack", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_environment_variable_test.go
+++ b/spacelift/data_environment_variable_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestEnvironmentVariableData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with a context", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_gcp_service_account_test.go
+++ b/spacelift/data_gcp_service_account_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestGCPServiceAccountData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with a stack", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_github_enterprise_integration_test.go
+++ b/spacelift/data_github_enterprise_integration_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestGithubEnterpriseIntegrationData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("without the ID specified", func(t *testing.T) {
 		cfg := testConfig.SourceCode.GithubEnterprise.Default
 		testSteps(t, []resource.TestStep{{

--- a/spacelift/data_gitlab_integration_test.go
+++ b/spacelift/data_gitlab_integration_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestGitlabIntegrationData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("without the id specified", func(t *testing.T) {
 		cfg := testConfig.SourceCode.Gitlab.Default
 		testSteps(t, []resource.TestStep{{

--- a/spacelift/data_idp_group_mapping_test.go
+++ b/spacelift/data_idp_group_mapping_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestIdpGroupMappingData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("reads an existing IdP group mapping by name", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		name := "test-group-" + randomID

--- a/spacelift/data_module_test.go
+++ b/spacelift/data_module_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestModuleData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("basic test", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_modules_test.go
+++ b/spacelift/data_modules_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestModulesData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("reads the modules collection", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_mounted_file_test.go
+++ b/spacelift/data_mounted_file_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestMountedFileData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with a context", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_plugin_template_test.go
+++ b/spacelift/data_plugin_template_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestPluginTemplateData(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "data.spacelift_plugin_template.test"
 
 	t.Run("reads plugin template data without error", func(t *testing.T) {

--- a/spacelift/data_plugin_test.go
+++ b/spacelift/data_plugin_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestPluginData(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "data.spacelift_plugin.test"
 
 	t.Run("reads plugin data without error", func(t *testing.T) {

--- a/spacelift/data_policies_test.go
+++ b/spacelift/data_policies_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestPoliciesData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("load all policies", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_policy_test.go
+++ b/spacelift/data_policy_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestPolicyData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("creates and updates a policy", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
@@ -45,6 +47,8 @@ func TestPolicyData(t *testing.T) {
 }
 
 func TestPolicyDataSpace(t *testing.T) {
+	t.Parallel()
+
 	t.Run("creates and updates a policy", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_role_actions_test.go
+++ b/spacelift/data_role_actions_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestRoleActionsData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("retrieves role actions without an error", func(t *testing.T) {
 		testSteps(t, []resource.TestStep{{
 			Config: `

--- a/spacelift/data_role_test.go
+++ b/spacelift/data_role_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestRoleData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("reads a system role (filter by name)", func(t *testing.T) {
 		testSteps(t, []resource.TestStep{{
 			Config: `

--- a/spacelift/data_saved_filter_test.go
+++ b/spacelift/data_saved_filter_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestSavedFilterData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("creates and updates a filter", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_saved_filters_test.go
+++ b/spacelift/data_saved_filters_test.go
@@ -14,6 +14,8 @@ import (
 // But if we use the same type, tests could fail (for example listing saved filters - ).
 
 func TestSavedFiltersData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("load all saved filters", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		datasourceName := "data.spacelift_saved_filters.all"

--- a/spacelift/data_scheduled_delete_stack_test.go
+++ b/spacelift/data_scheduled_delete_stack_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestScheduledDeleteStack(t *testing.T) {
+	t.Parallel()
+
 	t.Run("scheduled delete_stack", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		at := "123"

--- a/spacelift/data_scheduled_task_test.go
+++ b/spacelift/data_scheduled_task_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestScheduledTaskData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("task scheduling config", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_space_by_path_test.go
+++ b/spacelift/data_space_by_path_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestSpaceByPathData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("creates and reads a space", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		spaceName := fmt.Sprintf("My first space %s", randomID)

--- a/spacelift/data_space_test.go
+++ b/spacelift/data_space_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestSpaceData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("creates and reads a space", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_spaces_test.go
+++ b/spacelift/data_spaces_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestSpacesData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("load all spaces", func(t *testing.T) {
 		datasourceName := "data.spacelift_spaces.test"
 

--- a/spacelift/data_stack_outputs_test.go
+++ b/spacelift/data_stack_outputs_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestStackOutputsData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("retrieves stack outputs metadata", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_stack_test.go
+++ b/spacelift/data_stack_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestStackData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with Terraform stack", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
@@ -550,6 +552,8 @@ func TestStackData(t *testing.T) {
 }
 
 func TestStackDataSpace(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with Terraform stack", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_stacks_test.go
+++ b/spacelift/data_stacks_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestStacksData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("reads the stacks collection", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_template_deployment_test.go
+++ b/spacelift/data_template_deployment_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestTemplateDeploymentData(t *testing.T) {
+	t.Parallel()
+
 	const datasourceName = "data.spacelift_template_deployment.test"
 
 	t.Run("creates and reads a template deployment", func(t *testing.T) {

--- a/spacelift/data_template_test.go
+++ b/spacelift/data_template_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestTemplateData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("creates and reads a template", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_template_version_test.go
+++ b/spacelift/data_template_version_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestTemplateVersionData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("reads a template version by version_id in DRAFT state", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_user_test.go
+++ b/spacelift/data_user_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestUserData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("basic test", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		testEmail := fmt.Sprintf("test-user-%s@example.com", randomID)

--- a/spacelift/data_vcs_agent_pool_test.go
+++ b/spacelift/data_vcs_agent_pool_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestVCSAgentPoolData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("retrieves VCS agent pool data without an error", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_vcs_agent_pools_test.go
+++ b/spacelift/data_vcs_agent_pools_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestVCSAgentPoolsData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("retrieves VCS agent pools data without an error", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/data_webhook_test.go
+++ b/spacelift/data_webhook_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestWebhookData(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with a stack", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/resource_api_key_test.go
+++ b/spacelift/resource_api_key_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAPIKeyResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_api_key.test"
 
 	t.Run("creates and updates a SECRET API key", func(t *testing.T) {
@@ -59,6 +61,8 @@ func TestAPIKeyResource(t *testing.T) {
 }
 
 func TestAPIKeyResourceOIDC(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_api_key.test"
 
 	t.Run("creates an OIDC API key and updates name", func(t *testing.T) {
@@ -224,6 +228,8 @@ func TestAPIKeyResourceOIDC(t *testing.T) {
 }
 
 func TestAPIKeyResourceErrors(t *testing.T) {
+	t.Parallel()
+
 	t.Run("fails with empty name", func(t *testing.T) {
 		config := `
 			resource "spacelift_api_key" "test" {

--- a/spacelift/resource_aws_integration_attachment_test.go
+++ b/spacelift/resource_aws_integration_attachment_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAWSIntegrationAttachmentResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_aws_integration_attachment.test"
 
 	t.Run("with a stack", func(t *testing.T) {

--- a/spacelift/resource_aws_role_test.go
+++ b/spacelift/resource_aws_role_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAWSRoleResource(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with a stack", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/resource_azure_devops_integration_test.go
+++ b/spacelift/resource_azure_devops_integration_test.go
@@ -61,6 +61,8 @@ func terraformVersionAtLeast(major, minor int) (bool, string, error) {
 }
 
 func TestAzureDevOpsIntegrationResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_azure_devops_integration.test"
 
 	t.Run("creates and updates an Azure DevOps integration without an error", func(t *testing.T) {

--- a/spacelift/resource_azure_integration_attachment_test.go
+++ b/spacelift/resource_azure_integration_attachment_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAzureIntegrationAttachmentResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_azure_integration_attachment.test"
 
 	t.Run("with a stack", func(t *testing.T) {

--- a/spacelift/resource_azure_integration_test.go
+++ b/spacelift/resource_azure_integration_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAzureIntegrationResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_azure_integration.test"
 
 	t.Run("Creates and updates an integration", func(t *testing.T) {
@@ -95,6 +97,8 @@ func TestAzureIntegrationResource(t *testing.T) {
 }
 
 func TestAzureIntegrationResourceSpace(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_azure_integration.test"
 
 	t.Run("Creates and updates an integration", func(t *testing.T) {

--- a/spacelift/resource_bitbucket_datacenter_integration_test.go
+++ b/spacelift/resource_bitbucket_datacenter_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestBitbucketDatacenterIntegrationResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_bitbucket_datacenter_integration.test"
 
 	t.Run("creates and updates a bitbucket datacenter integration without an error", func(t *testing.T) {

--- a/spacelift/resource_blueprint_test.go
+++ b/spacelift/resource_blueprint_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestBlueprintResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_blueprint.test"
 
 	t.Run("Creates and updates a blueprint in DRAFT state", func(t *testing.T) {

--- a/spacelift/resource_context_attachment_test.go
+++ b/spacelift/resource_context_attachment_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestContextAttachmentResource(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with a stack", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/resource_context_test.go
+++ b/spacelift/resource_context_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestContextResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_context.test"
 
 	t.Run("creates and updates contexts without an error", func(t *testing.T) {
@@ -116,6 +118,8 @@ func TestContextResource(t *testing.T) {
 }
 
 func TestContextResourceSpace(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_context.test"
 
 	t.Run("creates and updates contexts without an error", func(t *testing.T) {

--- a/spacelift/resource_default_runner_image_test.go
+++ b/spacelift/resource_default_runner_image_test.go
@@ -29,6 +29,10 @@ resource "spacelift_default_runner_image" "test" {
 }
 `
 
+// The default runner image is account-wide, and the images below don't exist
+// anywhere. Any stack that doesn't override runner_image inherits whatever this
+// test sets, so running it alongside others leaves their workers trying to pull a
+// bogus image. It has to stay sequential.
 func Test_resourceDefaultAccountRunnerImage(t *testing.T) {
 	const resourceName = "spacelift_default_runner_image.test"
 
@@ -38,7 +42,7 @@ func Test_resourceDefaultAccountRunnerImage(t *testing.T) {
 	privateImage2 := fmt.Sprintf("private-runner:%s-updated", randomID)
 	publicImage2 := fmt.Sprintf("public-runner:%s-updated", randomID)
 
-	testSteps(t, []resource.TestStep{
+	testStepsSequential(t, []resource.TestStep{
 		{
 			Config: fmt.Sprintf(defaultAccountRunnerImageBothFields, privateImage, publicImage),
 			Check: Resource(

--- a/spacelift/resource_drift_detection_test.go
+++ b/spacelift/resource_drift_detection_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestDriftDetectionResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_drift_detection.test"
 
 	t.Run("with a stack", func(t *testing.T) {

--- a/spacelift/resource_environment_variable_test.go
+++ b/spacelift/resource_environment_variable_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestEnvironmentVariableResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_environment_variable.test"
 
 	t.Run("with a context", func(t *testing.T) {

--- a/spacelift/resource_gcp_service_account_test.go
+++ b/spacelift/resource_gcp_service_account_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestGCPServiceAccountResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_gcp_service_account.test"
 
 	t.Run("with a stack", func(t *testing.T) {

--- a/spacelift/resource_gitlab_integration_test.go
+++ b/spacelift/resource_gitlab_integration_test.go
@@ -14,6 +14,8 @@ import (
 const useGitCheckout = true
 
 func TestGitLabIntegrationResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_gitlab_integration.test"
 
 	t.Run("creates and updates a GitLab integration without an error", func(t *testing.T) {
@@ -235,6 +237,8 @@ func TestGitLabIntegrationResource(t *testing.T) {
 }
 
 func TestGitLabIntegrationClearLabels(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_gitlab_integration.test"
 
 	t.Run("creates and updates a GitLab integration without an error", func(t *testing.T) {

--- a/spacelift/resource_idp_group_mapping_test.go
+++ b/spacelift/resource_idp_group_mapping_test.go
@@ -36,6 +36,8 @@ resource "spacelift_idp_group_mapping" "test" {
 `
 
 func TestIdpGroupMappingResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_idp_group_mapping.test"
 
 	t.Run("creates and updates a user group mapping without an error", func(t *testing.T) {

--- a/spacelift/resource_module_test.go
+++ b/spacelift/resource_module_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestModuleResource(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with GitHub", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
@@ -363,6 +365,8 @@ func TestModuleResource(t *testing.T) {
 }
 
 func TestModuleResourceSpace(t *testing.T) {
+	t.Parallel()
+
 	t.Run("with GitHub", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/resource_mounted_file_test.go
+++ b/spacelift/resource_mounted_file_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestMountedFileResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_mounted_file.test"
 
 	t.Run("with a context", func(t *testing.T) {

--- a/spacelift/resource_named_webhook_secret_header_test.go
+++ b/spacelift/resource_named_webhook_secret_header_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestNamedWebhookSecretHeaderResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_named_webhook_secret_header.test-secret"
 
 	t.Run("attach a webhook to root space with all fields filled", func(t *testing.T) {

--- a/spacelift/resource_named_webhook_test.go
+++ b/spacelift/resource_named_webhook_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestNamedWebhookResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_named_webhook.test"
 
 	t.Run("attach a webhook to root space with all fields filled", func(t *testing.T) {

--- a/spacelift/resource_plugin_template_test.go
+++ b/spacelift/resource_plugin_template_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestPluginTemplateResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_plugin_template.test"
 
 	t.Run("creates plugin template without an error", func(t *testing.T) {
@@ -121,6 +123,8 @@ hooks:
 }
 
 func TestPluginTemplateResourceMinimal(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_plugin_template.test"
 
 	t.Run("creates minimal plugin template", func(t *testing.T) {
@@ -161,6 +165,8 @@ hooks:
 }
 
 func TestPluginTemplateResourceMissingAttributes(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_plugin_template.test"
 
 	t.Run("creates minimal plugin template", func(t *testing.T) {

--- a/spacelift/resource_plugin_test.go
+++ b/spacelift/resource_plugin_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestPluginResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_plugin.test"
 
 	t.Run("creates and updates plugin without an error", func(t *testing.T) {
@@ -88,6 +90,8 @@ func TestPluginResource(t *testing.T) {
 }
 
 func TestPluginResourceInSpace(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_plugin.test"
 
 	t.Run("creates plugin in a space", func(t *testing.T) {
@@ -126,6 +130,8 @@ func TestPluginResourceInSpace(t *testing.T) {
 }
 
 func TestPluginResourceMissingParameters(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_plugin.test"
 
 	t.Run("missing parameter causes errors", func(t *testing.T) {
@@ -151,6 +157,8 @@ func TestPluginResourceMissingParameters(t *testing.T) {
 }
 
 func TestPluginResourceInvalidParameters(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_plugin.test"
 
 	t.Run("unknown parameter causes error", func(t *testing.T) {

--- a/spacelift/resource_policy_attachment_test.go
+++ b/spacelift/resource_policy_attachment_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestPolicyAttachmentResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_policy_attachment.test"
 
 	t.Run("with a stack", func(t *testing.T) {

--- a/spacelift/resource_policy_test.go
+++ b/spacelift/resource_policy_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestPolicyResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_policy.test"
 
 	t.Run("creates and updates a policy", func(t *testing.T) {
@@ -158,6 +160,8 @@ func TestPolicyResource(t *testing.T) {
 }
 
 func TestPolicyResourceSpace(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_policy.test"
 
 	t.Run("creates and updates a policy", func(t *testing.T) {

--- a/spacelift/resource_repo_test.go
+++ b/spacelift/resource_repo_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestRepoResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_repo.test"
 
 	t.Run("creates, updates and imports a repo", func(t *testing.T) {

--- a/spacelift/resource_role_attachment_test.go
+++ b/spacelift/resource_role_attachment_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestRoleAttachmentResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_role_attachment.test"
 
 	t.Run("exactly one of API key, IDP group mapping, stack, or user must be set", func(t *testing.T) {

--- a/spacelift/resource_role_test.go
+++ b/spacelift/resource_role_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestRoleResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_role.test"
 
 	t.Run("creates and updates roles without an error", func(t *testing.T) {
@@ -133,6 +135,8 @@ func TestRoleResource(t *testing.T) {
 }
 
 func TestRoleResourceValidation(t *testing.T) {
+	t.Parallel()
+
 	t.Run("fails with invalid action", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/resource_run_test.go
+++ b/spacelift/resource_run_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestRunResource(t *testing.T) {
+	t.Parallel()
 
 	t.Run("on a new stack", func(t *testing.T) {
 		const resourceName = "spacelift_run.test"
@@ -50,6 +51,7 @@ func TestRunResource(t *testing.T) {
 }
 
 func TestRunResourceWait(t *testing.T) {
+	t.Parallel()
 
 	t.Run("on a new stack", func(t *testing.T) {
 		const resourceName = "spacelift_run.test"

--- a/spacelift/resource_saved_filter_test.go
+++ b/spacelift/resource_saved_filter_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestSavedFilterResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_saved_filter.test"
 
 	t.Run("creates and updates a filter", func(t *testing.T) {

--- a/spacelift/resource_scheduled_delete_stack_test.go
+++ b/spacelift/resource_scheduled_delete_stack_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestScheduledDeleteStackResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_scheduled_delete_stack.test"
 
 	t.Run("for scheduled delete_stack", func(t *testing.T) {

--- a/spacelift/resource_scheduled_task_test.go
+++ b/spacelift/resource_scheduled_task_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestScheduledTaskResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_scheduled_task.test"
 
 	t.Run("for scheduled task", func(t *testing.T) {

--- a/spacelift/resource_security_email_test.go
+++ b/spacelift/resource_security_email_test.go
@@ -16,6 +16,9 @@ resource "spacelift_security_email" "test" {
 }
 `
 
+// The security email is account-wide, so two concurrent writers fight over one
+// value. Nothing else reads it today, but two CI jobs against the same account
+// would collide, so keep it sequential alongside the other account-level settings.
 func Test_resourceSecurityEmail(t *testing.T) {
 	const resourceName = "spacelift_security_email.test"
 
@@ -24,7 +27,7 @@ func Test_resourceSecurityEmail(t *testing.T) {
 		emailAddress := fmt.Sprintf("%s@example.com", randomID)
 		emailAddress2 := fmt.Sprintf("%s@example2.com", randomID)
 
-		testSteps(t, []resource.TestStep{
+		testStepsSequential(t, []resource.TestStep{
 			{
 				Config: fmt.Sprintf(securityEmailSimple, emailAddress),
 				Check: Resource(

--- a/spacelift/resource_space_test.go
+++ b/spacelift/resource_space_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestSpaceResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_space.test"
 
 	t.Run("creates and updates a space", func(t *testing.T) {

--- a/spacelift/resource_stack_activator_test.go
+++ b/spacelift/resource_stack_activator_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestStackActivatorResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_stack_activator.test"
 
 	t.Run("test activator", func(t *testing.T) {

--- a/spacelift/resource_stack_azure_devops_test.go
+++ b/spacelift/resource_stack_azure_devops_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestVCSIntegrationAzureDevOps(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_stack.test"
 
 	t.Run("with_default_integration", func(t *testing.T) {

--- a/spacelift/resource_stack_bitbucket_cloud_test.go
+++ b/spacelift/resource_stack_bitbucket_cloud_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestVCSIntegrationBitbucketCloud(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_stack.test"
 
 	t.Run("with_default_integration", func(t *testing.T) {

--- a/spacelift/resource_stack_bitbucket_datacenter_test.go
+++ b/spacelift/resource_stack_bitbucket_datacenter_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestVCSIntegrationBitbucketDatacenter(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_stack.test"
 
 	t.Run("with_default_integration", func(t *testing.T) {

--- a/spacelift/resource_stack_dependency_reference_test.go
+++ b/spacelift/resource_stack_dependency_reference_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestStackDependencyReferenceResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_stack_dependency_reference.test"
 
 	t.Run("creates, updates and deletes stack dependency reference", func(t *testing.T) {

--- a/spacelift/resource_stack_dependency_test.go
+++ b/spacelift/resource_stack_dependency_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestStackDependencyResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_stack_dependency.test"
 
 	t.Run("creates and updates stack dependency", func(t *testing.T) {

--- a/spacelift/resource_stack_destructor_test.go
+++ b/spacelift/resource_stack_destructor_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestStackDestructorResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_stack_destructor.test"
 
 	t.Run("test destructor", func(t *testing.T) {
@@ -64,6 +66,8 @@ func TestStackDestructorResource(t *testing.T) {
 }
 
 func TestDestroyStackDestructor(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_stack_destructor.test"
 
 	t.Run("test destroy with runs", func(t *testing.T) {

--- a/spacelift/resource_stack_github_enterprise_test.go
+++ b/spacelift/resource_stack_github_enterprise_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestVCSIntegrationGithubEnterprise(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_stack.test"
 
 	t.Run("with_default_integration", func(t *testing.T) {

--- a/spacelift/resource_stack_gitlab_test.go
+++ b/spacelift/resource_stack_gitlab_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestVCSIntegrationGitlab(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_stack.test"
 
 	t.Run("with_default_integration", func(t *testing.T) {

--- a/spacelift/resource_stack_test.go
+++ b/spacelift/resource_stack_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestStackResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_stack.test"
 
 	t.Run("with GitHub and no state import", func(t *testing.T) {
@@ -1425,6 +1427,8 @@ func TestStackResource(t *testing.T) {
 }
 
 func TestStackResourceSpace(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_stack.test"
 
 	t.Run("with GitHub and no state import", func(t *testing.T) {
@@ -2399,6 +2403,8 @@ func getConfig(vendorConfig string) string {
 }
 
 func TestStackResourceInSpaceDestroy(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_stack.test"
 
 	t.Run("stack in a managed space destroys in order", func(t *testing.T) {

--- a/spacelift/resource_task_test.go
+++ b/spacelift/resource_task_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestTaskResource(t *testing.T) {
+	t.Parallel()
 
 	t.Run("on a new stack", func(t *testing.T) {
 		const resourceName = "spacelift_task.test"
@@ -50,6 +51,7 @@ func TestTaskResource(t *testing.T) {
 }
 
 func TestTaskResourceWait(t *testing.T) {
+	t.Parallel()
 
 	t.Run("on a new stack", func(t *testing.T) {
 		const resourceName = "spacelift_task.test"

--- a/spacelift/resource_template_deployment_test.go
+++ b/spacelift/resource_template_deployment_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestTemplateDeploymentResource(t *testing.T) {
+	t.Parallel()
+
 	const deploymentResource = "spacelift_template_deployment.test"
 	const stackDatasource = "data.spacelift_stack.test"
 

--- a/spacelift/resource_template_test.go
+++ b/spacelift/resource_template_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestTemplateResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_template.test"
 
 	t.Run("Creates and updates a template", func(t *testing.T) {

--- a/spacelift/resource_template_version_test.go
+++ b/spacelift/resource_template_version_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestTemplateVersionResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_template_version.test"
 
 	t.Run("Creates and updates a template version in DRAFT state", func(t *testing.T) {

--- a/spacelift/resource_user_test.go
+++ b/spacelift/resource_user_test.go
@@ -53,6 +53,8 @@ resource "spacelift_user" "test" {
 `
 
 func TestUserResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_user.test"
 
 	t.Run("creates a user without an error", func(t *testing.T) {

--- a/spacelift/resource_vcs_agent_pool_test.go
+++ b/spacelift/resource_vcs_agent_pool_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestVCSAgentPoolResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_vcs_agent_pool.test"
 
 	t.Run("creates and updates a VCS agent pool without an error", func(t *testing.T) {

--- a/spacelift/resource_version_test.go
+++ b/spacelift/resource_version_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestVersionResource(t *testing.T) {
+	t.Parallel()
+
 	t.Run("on a new module", func(t *testing.T) {
 		const resourceName = "spacelift_version.test"
 

--- a/spacelift/resource_webhook_test.go
+++ b/spacelift/resource_webhook_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestWebhookResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_webhook.test"
 
 	t.Run("with a stack", func(t *testing.T) {

--- a/spacelift/resource_worker_pool_recycle_test.go
+++ b/spacelift/resource_worker_pool_recycle_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestWorkerPoolRecycleResource(t *testing.T) {
+	t.Parallel()
+
 	t.Run("recycles a worker pool", func(t *testing.T) {
 		const resourceName = "spacelift_worker_pool_recycle.test"
 

--- a/spacelift/resource_worker_pool_test.go
+++ b/spacelift/resource_worker_pool_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestWorkerPoolResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_worker_pool.test"
 
 	t.Run("without a CSR", func(t *testing.T) {
@@ -248,6 +250,8 @@ func TestWorkerPoolResource(t *testing.T) {
 }
 
 func TestWorkerPoolResourceSpace(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_worker_pool.test"
 
 	t.Run("without a CSR", func(t *testing.T) {

--- a/spacelift/test_provider.go
+++ b/spacelift/test_provider.go
@@ -2,26 +2,22 @@
 package spacelift
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var (
-	provider     *schema.Provider
-	providerLock sync.Mutex
-)
-
-func testProvider() *schema.Provider {
-	providerLock.Lock()
-	defer providerLock.Unlock()
-	if provider == nil {
-		provider = Provider("commit", "version")()
+// testAccProviderFactories returns the SDKv2 provider factory for use in the
+// ProviderFactories test field. Each test gets its own provider instance:
+// schema.Provider is mutated when Terraform configures it, so sharing one
+// across parallel tests races on its internal state.
+func testAccProviderFactories() map[string]func() (*schema.Provider, error) {
+	return map[string]func() (*schema.Provider, error){
+		"spacelift": func() (*schema.Provider, error) {
+			return Provider("commit", "version")(), nil
+		},
 	}
-
-	return provider
 }
 
 func testSteps(t *testing.T, steps []resource.TestStep) {
@@ -29,11 +25,9 @@ func testSteps(t *testing.T, steps []resource.TestStep) {
 	t.Helper()
 
 	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		Providers: map[string]*schema.Provider{
-			"spacelift": testProvider(),
-		},
-		Steps: steps,
+		IsUnitTest:        true,
+		ProviderFactories: testAccProviderFactories(),
+		Steps:             steps,
 	})
 }
 
@@ -41,10 +35,8 @@ func testStepsSequential(t *testing.T, steps []resource.TestStep) {
 	t.Helper()
 
 	resource.Test(t, resource.TestCase{
-		IsUnitTest: true,
-		Providers: map[string]*schema.Provider{
-			"spacelift": testProvider(),
-		},
-		Steps: steps,
+		IsUnitTest:        true,
+		ProviderFactories: testAccProviderFactories(),
+		Steps:             steps,
 	})
 }


### PR DESCRIPTION
## Description of the change

The test job took ~23 minutes and spent nearly all of it waiting rather than working. `-parallel 40` was barely being used.

`t.Parallel()` was only ever called inside the `testSteps` helper, on whatever `*testing.T` it was handed, so parallelism depended on *where* the helper was called from:

| Shape | Count | Before |
|---|---|---|
| `testSteps(t, …)` directly on the top-level `t` | 29 | already parallel |
| `testSteps` only inside `t.Run` closures | 122 | **sequential** — a parallel subtest resumes only after its parent returns |

That left ~122 sequential groups plus a concurrent tail of 29, i.e. effective concurrency of ~2.8 against a budget of 40. This adds `t.Parallel()` to the 122-function group only; adding it to the other 29 panics with `t.Parallel called multiple times`.

Two things had to change alongside it.

**The shared provider instance.** `testProvider()` memoised one `*schema.Provider` for the whole suite. `Providers` is deprecated in favour of `ProviderFactories` for exactly this reason: Terraform mutates the provider when it configures it, and the SDK serves it in-process, so every concurrent test hit the same object. `go test -race` reports 2 data races on `grpc_provider.go:735` with the singleton and 0 with a factory. `test_provider_framework.go` already did this correctly with `ProtoV6ProviderFactories`; the SDKv2 helper never caught up.

**Account-wide settings.** `Test_resourceDefaultAccountRunnerImage` points the account's default runner image at tags that exist nowhere, and any stack that doesn't set its own `runner_image` inherits it — so once everything ran at once, unrelated tests' workers started dying with `pull access denied for public-runner`. All 13 run failures in one window carried that byte-identical note. It's now sequential, as is `Test_resourceSecurityEmail`, which writes account-level state the same way; `Test_resourceAuditTrailWebhook` already was. Note that test was *already* parallel before this PR — it just used to overlap 28 others rather than 150, so collisions looked like background noise.

### Result

| | Before | After |
|---|---|---|
| `./spacelift` package | 1375.7s | ~210s |
| Whole job | 23m25s | ~4m |


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
