### PR TITLE
chore(lint): lint test files and add tparallel

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 version: "2"
 
 run:
-  tests: false
+  tests: true
 
 output:
   formats:
@@ -22,6 +22,7 @@ linters:
     - ineffassign
     - nolintlint
     - staticcheck
+    - tparallel
     - unused
   settings:
     depguard:
@@ -71,6 +72,13 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      # Test config structs name fields after the credentials they hold, and the
+      # values come from the environment rather than being embedded.
+      - path: _test\.go
+        linters:
+          - gosec
+        text: G117
     paths:
       - third_party$
       - builtin$

--- a/spacelift/data_azure_integrations_test.go
+++ b/spacelift/data_azure_integrations_test.go
@@ -16,10 +16,10 @@ func TestAzureIntegrationsData(t *testing.T) {
 	t.Parallel()
 
 	t.Run("when looking up integrations", func(t *testing.T) {
-		subId1 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
-		subId2 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+		subID1 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
+		subID2 := acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)
 		first := &structs.AzureIntegration{
-			DefaultSubscriptionID: &subId1,
+			DefaultSubscriptionID: &subID1,
 			Labels:                []string{"one", "two"},
 			Name:                  acctest.RandStringFromCharSet(5, acctest.CharSetAlpha),
 			TenantID:              acctest.RandStringFromCharSet(10, acctest.CharSetAlpha),
@@ -27,7 +27,7 @@ func TestAzureIntegrationsData(t *testing.T) {
 			AutoattachEnabled:     true,
 		}
 		second := &structs.AzureIntegration{
-			DefaultSubscriptionID: &subId2,
+			DefaultSubscriptionID: &subID2,
 			Labels:                []string{"three", "four"},
 			Name:                  acctest.RandStringFromCharSet(5, acctest.CharSetAlpha),
 			TenantID:              acctest.RandStringFromCharSet(10, acctest.CharSetAlpha),

--- a/spacelift/data_policies_test.go
+++ b/spacelift/data_policies_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	. "github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/testhelpers"
 )
 

--- a/spacelift/data_repo_test.go
+++ b/spacelift/data_repo_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestRepoData(t *testing.T) {
+	t.Parallel()
+
 	const datasourceName = "data.spacelift_repo.test"
 
 	t.Run("reads an existing repo", func(t *testing.T) {

--- a/spacelift/data_repos_test.go
+++ b/spacelift/data_repos_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestReposData(t *testing.T) {
+	t.Parallel()
+
 	const datasourceName = "data.spacelift_repos.test"
 
 	t.Run("finds a repo by label in its space", func(t *testing.T) {

--- a/spacelift/data_tool_versions_test.go
+++ b/spacelift/data_tool_versions_test.go
@@ -66,10 +66,6 @@ func TestToolVersionsData(t *testing.T) {
 	})
 
 	t.Run("only allows specific tools", func(t *testing.T) {
-		re, err := regexp.Compile(`tool must be one of \[.*]`)
-		if err != nil {
-			t.Fatalf("could not compile regexp: %v", err)
-		}
 		testSteps(t, []resource.TestStep{
 			{
 				Config: `
@@ -77,7 +73,7 @@ func TestToolVersionsData(t *testing.T) {
 					tool = "this-tool-should-error"
 				}
 				`,
-				ExpectError: re,
+				ExpectError: regexp.MustCompile(`tool must be one of \[.*]`),
 			},
 		})
 	})

--- a/spacelift/resource_plugin_template_test.go
+++ b/spacelift/resource_plugin_template_test.go
@@ -167,8 +167,6 @@ hooks:
 func TestPluginTemplateResourceMissingAttributes(t *testing.T) {
 	t.Parallel()
 
-	const resourceName = "spacelift_plugin_template.test"
-
 	t.Run("creates minimal plugin template", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/resource_plugin_test.go
+++ b/spacelift/resource_plugin_test.go
@@ -132,8 +132,6 @@ func TestPluginResourceInSpace(t *testing.T) {
 func TestPluginResourceMissingParameters(t *testing.T) {
 	t.Parallel()
 
-	const resourceName = "spacelift_plugin.test"
-
 	t.Run("missing parameter causes errors", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
@@ -158,8 +156,6 @@ func TestPluginResourceMissingParameters(t *testing.T) {
 
 func TestPluginResourceInvalidParameters(t *testing.T) {
 	t.Parallel()
-
-	const resourceName = "spacelift_plugin.test"
 
 	t.Run("unknown parameter causes error", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)

--- a/spacelift/resource_repo_file_test.go
+++ b/spacelift/resource_repo_file_test.go
@@ -41,6 +41,8 @@ func TestRepoFileModeUnchanged(t *testing.T) {
 }
 
 func TestRepoFileResource(t *testing.T) {
+	t.Parallel()
+
 	const resourceName = "spacelift_repo_file.test"
 
 	t.Run("creates, updates and imports a file", func(t *testing.T) {

--- a/spacelift/resource_role_test.go
+++ b/spacelift/resource_role_test.go
@@ -26,7 +26,7 @@ func TestRoleResource(t *testing.T) {
 				if i > 0 {
 					actionsList.WriteString(", ")
 				}
-				actionsList.WriteString(fmt.Sprintf(`"%s"`, action))
+				fmt.Fprintf(&actionsList, `"%s"`, action)
 			}
 
 			return fmt.Sprintf(`

--- a/spacelift/resource_run_test.go
+++ b/spacelift/resource_run_test.go
@@ -97,8 +97,6 @@ func TestRunResourceWait(t *testing.T) {
 	})
 
 	t.Run("timed out run", func(t *testing.T) {
-		const resourceName = "spacelift_run.test"
-
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		randomIDwp := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/resource_scheduled_delete_stack_test.go
+++ b/spacelift/resource_scheduled_delete_stack_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	. "github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/testhelpers"
 )
 

--- a/spacelift/resource_scheduled_run_test.go
+++ b/spacelift/resource_scheduled_run_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	. "github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/testhelpers"
 )
 

--- a/spacelift/resource_scheduled_task_test.go
+++ b/spacelift/resource_scheduled_task_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	. "github.com/spacelift-io/terraform-provider-spacelift/spacelift/internal/testhelpers"
 )
 

--- a/spacelift/resource_task_test.go
+++ b/spacelift/resource_task_test.go
@@ -97,8 +97,6 @@ func TestTaskResourceWait(t *testing.T) {
 	})
 
 	t.Run("timed out run", func(t *testing.T) {
-		const resourceName = "spacelift_task.test"
-
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 		randomIDwp := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 

--- a/spacelift/resource_template_deployment_test.go
+++ b/spacelift/resource_template_deployment_test.go
@@ -108,7 +108,7 @@ EOT
 			`, randomID, initialVersion, newVersion, version, name, description, envName, secret)
 		}
 
-		var firstTemplateVersionId string
+		var firstTemplateVersionID string
 		testSteps(t, []resource.TestStep{
 			{
 				Config: config("deployment-"+randomID, "test description", "first_version", "production", "foobar"),
@@ -121,7 +121,7 @@ EOT
 					resource.TestCheckResourceAttr(deploymentResource, "template_id", "test-template-"+randomID),
 					resource.TestCheckResourceAttr(deploymentResource, "deployment_id", "deployment-"+randomID),
 					resource.TestCheckResourceAttrWith(deploymentResource, "template_version_id", func(value string) error {
-						firstTemplateVersionId = value
+						firstTemplateVersionID = value
 						if !strings.HasPrefix(value, "test-template-"+randomID) {
 							return fmt.Errorf("expected template version ID to start with %s, got %s", "test-template-"+randomID, value)
 						}
@@ -159,7 +159,7 @@ EOT
 					resource.TestCheckResourceAttr(deploymentResource, "description", "updated description"),
 					resource.TestCheckResourceAttr(deploymentResource, "state", "FINISHED"),
 					resource.TestCheckResourceAttrWith(deploymentResource, "template_version_id", func(value string) error {
-						if value == firstTemplateVersionId {
+						if value == firstTemplateVersionID {
 							return fmt.Errorf("expected template version ID to change, got %s", value)
 						}
 						return nil

--- a/spacelift/resource_worker_pool_test.go
+++ b/spacelift/resource_worker_pool_test.go
@@ -376,7 +376,7 @@ func TestWorkerPoolResourceSpace(t *testing.T) {
 	t.Run("CSR changes reset worker pool", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
-		var originalId string
+		var originalID string
 		var originalConfig string
 		csr := "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJRWtqQ0NBbm9DQVFBd1RURUxNQWtHQTFVRUJoTUNVRXd4RGpBTUJnTlZCQW9NQldKaFkyOXVNUTR3REFZRApWUVFEREFWaVlXTnZiakVlTUJ3R0NTcUdTSWIzRFFFSkFSWVBZbUZqYjI1QVltRmpiMjR1YjNKbk1JSUNJakFOCkJna3Foa2lHOXcwQkFRRUZBQU9DQWc4QU1JSUNDZ0tDQWdFQXdhand1UmlreTFkODF0TVpJZytJSXBHUHQxclUKV2t4UGhDOENKNzNUWmx3ZTdVcC9McFFiNnpYU0I2eStCWkludnptd1ZBNzNuM0dnVEdFeS9VbDF2VUthaXZmaQpna3lnd05vV0ExYzRTaUNnbjdYTnl1T2c2MktSWGxNb05TeCsrZmVINXZzVGRRVVd2TjZIZkJEQ2dGZ1VQa1JuClp1MDUwOWxBQ2ZrZ00ycnl0b3N3enplbUVUbWRrNlhsYXBnWE9Ebll5bGgvbnRrVFJqZU91VThOUUF1eGRmSUEKY2JFQ0lJZ1Vuak44WWJhWTlGL1RyRjBHUGlQRVZuTEh3Yi95REM2d0NiOXFITUFHRXJhZ0d0cHVzbis0eTBsRwo5S0IvTzZ1R2haRk5HK3FDYUM3MFFKZWI3TzRSdlI3VlA4aWxPOU8rQnE2OU4vY1B4cUFXRTY3WUplUzVxa1hNClFRVVBxVGVXMGs2NC9KZ2c0Nm5ZTmhueGJ5Rkp1MzZ5ME1xbndDN1FYVjZicjFDNldsM3gzTzlNZng4UGVaWGIKdjFqejhod2RWSGFIc0ZLTkgwemdrTk5ISkJ1ZTAyZWwxRkNnbCtMSGNTdWJKdHJnaXpLWkVFSGlFeWhUVURUOQpqeTlSWGpPSUUrNTQ3TkFNMHZvVlY1aTg1eDN0LzdFeFI5R0lraFpwejNQSlV3WUplbHE1M3JPakRvRXZhWTF1CmFUSm9VclYwUUUwK0hTN3ZyaWxXb0VXWlFjOUFiNFFmNnZicmpncCsvVzFEVU5WcGFtVjhQU2dTS3M4RUkwNW4Kek5hc3Q3cnA3b1A2WXBiR2VrbGVQRllWVUVqNTZOKzBxNnh3MFdtS1loNmtYOGRxTTVoNWlkVTFsdUlSU01xMgpkUmJZWStwRFQyeHAwaWtDQXdFQUFhQUFNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUNBUUNjZUM2VXRSbnZ3MkRmCkpsQ285NFdIZDRUTTdQYVBtYmdkeVlMSGpacTZKNGdMcGxrcFlnSno2TnA4OThhTExtRDluTlNEV1c0QkpieDkKdXNaaTA3eFl1cjZybjY0cFRUeUhOK1U4WHZsYVdCQjVoMmV3NytZeXVDNWh4RkU1Mjg0OEJ2WG9LNFdmSzRIegpsZ25vWW9qWERNWEpSRTBqR0drVk8rckt4ZW41ak9ZQW4rbkxQT25HNzRSR25kZ2xTYVFhbFFidjFZb095L1dSCll3QzNqM2JodzUrTG9BNVUvaXhZSytma09rZmZOR0VpaU91K0tZV1J6cTVUd2hOKzFHV1l1M3B4WGJ3ZHM3emgKcjlrdVRvdUhpbDg0OTdaZTJGY2t1VTF3OWVaSmY4WlBHWlNLamhmSUhMYWtwNE9UQUlDb1hDS0hhNEhtUVVzRApVdFBjS0E4ZUdkNmh3U0gyS0FndWU2VVdsMDhFZ2xnRlhkOC90Qy9wYzhNR3QxU2RtTzgzUlVEenJLREt3TCszClhNc0xYOWlic1VTZzk3ZzF5R1RxWE1JeUhXK0tiT3lOZS9JYVBYblJJKy9zdkJaTEY0OGQ4UTdKY2xQcHZ6SysKSnlhMXVLWkI4MFRlZnlpaW5oa21GcmcvWmNzdEI2MEI5VFVHaHNib3JmNW5hdnNCcWIxUkN6c2J5VUFvOVphUgpTUXQyNDlMOUc1bmlIcUNTUENxWXVqRktuMWxIVjVicGxwaDFzWHozOVU5RXVTanNxRlNlMlorM0duUVNSSHlNCkx1YTNPT2pmRXh6UUl3Zm5DUy8wMjVIZENjMDZXY3hNK3JUUlA1UW13eGRJNFBtTTNEU2dCRXE0L2RjeEZwTUYKWnp4VkNreU5PWUJPRklTTXRUWDNiQXI3K3JST2VBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUgUkVRVUVTVC0tLS0tCg=="
 		testSteps(t, []resource.TestStep{
@@ -395,7 +395,7 @@ func TestWorkerPoolResourceSpace(t *testing.T) {
 					// This function saves the id of the resource to a higher scoped variable
 					// so we can use it later
 					func(attributes map[string]string) error {
-						originalId = attributes["id"]
+						originalID = attributes["id"]
 						originalConfig = attributes["config"]
 						return nil
 					},
@@ -411,7 +411,7 @@ func TestWorkerPoolResourceSpace(t *testing.T) {
 				Check: Resource(
 					resourceName,
 					// We validate the id has not changed, which tells us the resource was not recreated
-					Attribute("id", func(v string) error { return Equals(originalId)(v) }),
+					Attribute("id", func(v string) error { return Equals(originalID)(v) }),
 					// We validate the config has not changed
 					Attribute("config", func(v string) error { return NotEquals(originalConfig)(v) }),
 					// We also validate the CSR is the new one
@@ -424,7 +424,7 @@ func TestWorkerPoolResourceSpace(t *testing.T) {
 	t.Run("Name and description change does not impact csr or config", func(t *testing.T) {
 		randomID := acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
 
-		var originalId string
+		var originalID string
 		var originalConfig string
 		csr := "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJRWtqQ0NBbm9DQVFBd1RURUxNQWtHQTFVRUJoTUNVRXd4RGpBTUJnTlZCQW9NQldKaFkyOXVNUTR3REFZRApWUVFEREFWaVlXTnZiakVlTUJ3R0NTcUdTSWIzRFFFSkFSWVBZbUZqYjI1QVltRmpiMjR1YjNKbk1JSUNJakFOCkJna3Foa2lHOXcwQkFRRUZBQU9DQWc4QU1JSUNDZ0tDQWdFQXdhand1UmlreTFkODF0TVpJZytJSXBHUHQxclUKV2t4UGhDOENKNzNUWmx3ZTdVcC9McFFiNnpYU0I2eStCWkludnptd1ZBNzNuM0dnVEdFeS9VbDF2VUthaXZmaQpna3lnd05vV0ExYzRTaUNnbjdYTnl1T2c2MktSWGxNb05TeCsrZmVINXZzVGRRVVd2TjZIZkJEQ2dGZ1VQa1JuClp1MDUwOWxBQ2ZrZ00ycnl0b3N3enplbUVUbWRrNlhsYXBnWE9Ebll5bGgvbnRrVFJqZU91VThOUUF1eGRmSUEKY2JFQ0lJZ1Vuak44WWJhWTlGL1RyRjBHUGlQRVZuTEh3Yi95REM2d0NiOXFITUFHRXJhZ0d0cHVzbis0eTBsRwo5S0IvTzZ1R2haRk5HK3FDYUM3MFFKZWI3TzRSdlI3VlA4aWxPOU8rQnE2OU4vY1B4cUFXRTY3WUplUzVxa1hNClFRVVBxVGVXMGs2NC9KZ2c0Nm5ZTmhueGJ5Rkp1MzZ5ME1xbndDN1FYVjZicjFDNldsM3gzTzlNZng4UGVaWGIKdjFqejhod2RWSGFIc0ZLTkgwemdrTk5ISkJ1ZTAyZWwxRkNnbCtMSGNTdWJKdHJnaXpLWkVFSGlFeWhUVURUOQpqeTlSWGpPSUUrNTQ3TkFNMHZvVlY1aTg1eDN0LzdFeFI5R0lraFpwejNQSlV3WUplbHE1M3JPakRvRXZhWTF1CmFUSm9VclYwUUUwK0hTN3ZyaWxXb0VXWlFjOUFiNFFmNnZicmpncCsvVzFEVU5WcGFtVjhQU2dTS3M4RUkwNW4Kek5hc3Q3cnA3b1A2WXBiR2VrbGVQRllWVUVqNTZOKzBxNnh3MFdtS1loNmtYOGRxTTVoNWlkVTFsdUlSU01xMgpkUmJZWStwRFQyeHAwaWtDQXdFQUFhQUFNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUNBUUNjZUM2VXRSbnZ3MkRmCkpsQ285NFdIZDRUTTdQYVBtYmdkeVlMSGpacTZKNGdMcGxrcFlnSno2TnA4OThhTExtRDluTlNEV1c0QkpieDkKdXNaaTA3eFl1cjZybjY0cFRUeUhOK1U4WHZsYVdCQjVoMmV3NytZeXVDNWh4RkU1Mjg0OEJ2WG9LNFdmSzRIegpsZ25vWW9qWERNWEpSRTBqR0drVk8rckt4ZW41ak9ZQW4rbkxQT25HNzRSR25kZ2xTYVFhbFFidjFZb095L1dSCll3QzNqM2JodzUrTG9BNVUvaXhZSytma09rZmZOR0VpaU91K0tZV1J6cTVUd2hOKzFHV1l1M3B4WGJ3ZHM3emgKcjlrdVRvdUhpbDg0OTdaZTJGY2t1VTF3OWVaSmY4WlBHWlNLamhmSUhMYWtwNE9UQUlDb1hDS0hhNEhtUVVzRApVdFBjS0E4ZUdkNmh3U0gyS0FndWU2VVdsMDhFZ2xnRlhkOC90Qy9wYzhNR3QxU2RtTzgzUlVEenJLREt3TCszClhNc0xYOWlic1VTZzk3ZzF5R1RxWE1JeUhXK0tiT3lOZS9JYVBYblJJKy9zdkJaTEY0OGQ4UTdKY2xQcHZ6SysKSnlhMXVLWkI4MFRlZnlpaW5oa21GcmcvWmNzdEI2MEI5VFVHaHNib3JmNW5hdnNCcWIxUkN6c2J5VUFvOVphUgpTUXQyNDlMOUc1bmlIcUNTUENxWXVqRktuMWxIVjVicGxwaDFzWHozOVU5RXVTanNxRlNlMlorM0duUVNSSHlNCkx1YTNPT2pmRXh6UUl3Zm5DUy8wMjVIZENjMDZXY3hNK3JUUlA1UW13eGRJNFBtTTNEU2dCRXE0L2RjeEZwTUYKWnp4VkNreU5PWUJPRklTTXRUWDNiQXI3K3JST2VBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUgUkVRVUVTVC0tLS0tCg=="
 		testSteps(t, []resource.TestStep{
@@ -441,7 +441,7 @@ func TestWorkerPoolResourceSpace(t *testing.T) {
 					Attribute("csr", Equals(csr)),
 					Attribute("name", Equals(fmt.Sprintf("My workerpool to update %s", randomID))),
 					func(attributes map[string]string) error {
-						originalId = attributes["id"]
+						originalID = attributes["id"]
 						originalConfig = attributes["config"]
 						return nil
 					},
@@ -457,7 +457,7 @@ func TestWorkerPoolResourceSpace(t *testing.T) {
 				`, randomID, randomID, csr),
 				Check: Resource(
 					resourceName,
-					Attribute("id", func(v string) error { return Equals(originalId)(v) }),
+					Attribute("id", func(v string) error { return Equals(originalID)(v) }),
 					Attribute("config", func(v string) error { return Equals(originalConfig)(v) }),
 					Attribute("csr", Equals(csr)),
 					Attribute("name", Equals(fmt.Sprintf("My workerpool to update %s - updated", randomID))),

--- a/spacelift/test_provider.go
+++ b/spacelift/test_provider.go
@@ -1,4 +1,3 @@
-//nolint:unused
 package spacelift
 
 import (


### PR DESCRIPTION
## Description of the change

`run.tests: false` meant `_test.go` was never linted, which is how the parallelism bug in #830 stayed hidden: 122 tests took `t.Parallel()` from a helper and nothing checked it reached the right `*testing.T`. `tparallel` checks. Drop a `t.Parallel()` and lint now fails:

```
data_policies_test.go:13:6: TestPoliciesData should call t.Parallel on the top level as well as its subtests (tparallel)
```

Start at `.golangci.yml:4`. Flipping `run.tests` on aims every enabled linter at test files for the first time, and that, not `tparallel`, is what the other 14 files answer: import grouping, `Id`→`ID`, five dead `resourceName` consts, a `WriteString(Sprintf)`, a pointless `regexp.Compile` error branch. Lint ends where it started, on the 5 `gosec` findings already present on `main`.

`paralleltest`, also suggested, is not here: 345 findings, effectively all false positives, since it wants a literal `t.Parallel()` in the body and cannot see through `testSteps`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
