### PR TITLE
ci: run the no-drift migration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,40 @@ name: 🧪 Test
 on: [push]
 
 jobs:
+  # The no-drift tests in spacelift/migrationtest verify that a resource moved to the
+  # Plugin Framework produces state identical to the last SDKv2 release. They stand up
+  # state with a published provider release, so unlike the rest of the suite they cannot
+  # set IsUnitTest and genuinely need TF_ACC. The "Test the code" job below runs ./...
+  # without TF_ACC, which means these tests skip there — hence a job of their own.
+  migration-drift:
+    name: Verify migrated resources produce no state drift
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Go
+        uses: actions/setup-go@v7
+        with: { go-version-file: go.mod }
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "~1"
+          terraform_wrapper: false
+
+      - name: Run the no-drift verification tests
+        run: go test -parallel 10 -timeout 30m -v ./spacelift/migrationtest/
+        if: github.actor != 'dependabot[bot]'
+        env:
+          # These tests download a published provider release from the Spacelift registry,
+          # so they are acceptance tests in the strict sense and TF_ACC must be set.
+          TF_ACC: "1"
+          SPACELIFT_API_KEY_ENDPOINT: ${{ vars.preprod_SPACELIFT_API_KEY_ENDPOINT }}
+          SPACELIFT_API_KEY_ID: ${{ secrets.PREPROD_SPACELIFT_API_KEY_ID }}
+          SPACELIFT_API_KEY_SECRET: ${{ secrets.PREPROD_SPACELIFT_API_KEY_SECRET }}
+
   deployment:
     name: Test the code
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description of the change

The `spacelift/migrationtest` package proves a resource moved to the Plugin Framework
lands the same state as the last SDKv2 release. CI was never running it: the existing job
runs `go test ./...` without `TF_ACC`, and these tests cannot set `IsUnitTest` because
they stand up state with a published provider release. The package passed with zero tests
executed.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Chore (maintenance work, dependency bumps, refactors, not supposed to break existing functionalities)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (non-breaking change that adds documentation)

## Related issues

Part of #765

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] Examples for new resources and data sources have been added
- [ ] Default values have been documented in the description (e.g., "Dummy: (Boolean) Blah blah. Defaults to `false`.)
- [ ] If the action fails that checks the documentation: Run `go generate` to make sure the docs are up to date

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Pull Request is no longer marked as "draft"
- [ ] Reviewers have been assigned
- [ ] Changes have been reviewed by at least one other engineer
